### PR TITLE
build(widget): implement multi-stage Docker build for widget bundle

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       DISABLE_DATABASE: ${DISABLE_DATABASE}
 
       # Security
-      CREDENTIAL_MASTER_KEY: ${CREDENTIAL_MASTER_KEY}
+      MASTER_API_KEY: ${MASTER_API_KEY}
 
       # Basic Settings
       LOG_LEVEL: ${LOG_LEVEL:-DEBUG}


### PR DESCRIPTION
The Dockerfile now uses a multi-stage build process where:
1. First stage builds the widget.iife.js bundle from source using Node
2. Second stage copies the built artifacts into the nginx image
3. Maintains compatibility with existing paths while improving build process