### PR TITLE
feat: add test connection button to credentials page

### DIFF
--- a/backend/app/api/credentials.py
+++ b/backend/app/api/credentials.py
@@ -310,6 +310,11 @@ class CredentialTestResponse(BaseModel):
     message: str
 
 
+class CredentialTestRawRequest(BaseModel):
+    service_type: str
+    data: Dict[str, Any]
+
+
 async def _test_openai(secret: Dict[str, Any]) -> CredentialTestResponse:
     try:
         from openai import AsyncOpenAI
@@ -320,7 +325,13 @@ async def _test_openai(secret: Dict[str, Any]) -> CredentialTestResponse:
     except asyncio.TimeoutError:
         return CredentialTestResponse(success=False, message="Connection timed out.")
     except Exception as e:
-        return CredentialTestResponse(success=False, message=str(e))
+        msg = str(e)
+        if "invalid" in msg.lower() or "auth" in msg.lower():
+            msg += (
+                " Note: If this key is for an OpenAI-compatible provider "
+                "(OpenRouter, vLLM, etc.), it may still be valid for that provider."
+            )
+        return CredentialTestResponse(success=False, message=msg)
 
 
 async def _test_cohere(secret: Dict[str, Any]) -> CredentialTestResponse:
@@ -419,6 +430,39 @@ def _test_webhook_auth(secret: Dict[str, Any], service_type: str) -> CredentialT
     return CredentialTestResponse(success=False, message="Unknown credential type.")
 
 
+async def _run_test(service_type: str, secret: Dict[str, Any]) -> CredentialTestResponse:
+    """Route a test request to the appropriate handler based on service type."""
+    if service_type == "openai":
+        return await _test_openai(secret)
+    elif service_type == "cohere":
+        return await _test_cohere(secret)
+    elif service_type == "tavily_search":
+        return await _test_tavily(secret)
+    elif service_type == "postgresql_vectorstore":
+        return await _test_postgresql(secret)
+    elif service_type == "kafka":
+        return await _test_kafka(secret)
+    elif service_type in ("basic_auth", "header_auth"):
+        return _test_webhook_auth(secret, service_type)
+    else:
+        return CredentialTestResponse(
+            success=False, message=f"Test not supported for service type: {service_type}"
+        )
+
+
+@router.post("/test-raw", response_model=CredentialTestResponse)
+async def test_credential_raw(
+    request: CredentialTestRawRequest,
+    current_user=Depends(get_current_user),
+):
+    """Test credentials before saving, using raw data from the form."""
+    try:
+        return await _run_test(request.service_type, request.data)
+    except Exception as e:
+        logger.error(f"Unexpected error testing raw credential: {e}")
+        return CredentialTestResponse(success=False, message=f"Unexpected error: {e}")
+
+
 @router.post("/{credential_id}/test", response_model=CredentialTestResponse)
 async def test_credential(
     credential_id: uuid.UUID,
@@ -437,22 +481,7 @@ async def test_credential(
     secret: Dict[str, Any] = decrypted.get("secret", {})
 
     try:
-        if service_type == "openai":
-            return await _test_openai(secret)
-        elif service_type == "cohere":
-            return await _test_cohere(secret)
-        elif service_type == "tavily_search":
-            return await _test_tavily(secret)
-        elif service_type == "postgresql_vectorstore":
-            return await _test_postgresql(secret)
-        elif service_type == "kafka":
-            return await _test_kafka(secret)
-        elif service_type in ("basic_auth", "header_auth"):
-            return _test_webhook_auth(secret, service_type)
-        else:
-            return CredentialTestResponse(
-                success=False, message=f"Test not supported for service type: {service_type}"
-            )
+        return await _run_test(service_type, secret)
     except Exception as e:
         logger.error(f"Unexpected error testing credential {credential_id}: {e}")
         return CredentialTestResponse(success=False, message=f"Unexpected error: {e}")

--- a/client/app/components/credentials/CredentialCard.tsx
+++ b/client/app/components/credentials/CredentialCard.tsx
@@ -37,7 +37,10 @@ const CredentialCard: React.FC<CredentialCardProps> = ({
       setTestState("error");
       setTestMessage("Unexpected error. Please try again.");
     }
-    setTimeout(() => setTestState("idle"), 4000);
+    setTimeout(() => {
+      setTestState("idle");
+      setTestMessage("");
+    }, 4000);
   };
   return (
     <div className="bg-white border border-gray-200 rounded-lg p-4 hover:shadow-sm transition-all duration-200">

--- a/client/app/components/credentials/DynamicCredentialForm.tsx
+++ b/client/app/components/credentials/DynamicCredentialForm.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from "react";
 import { Formik, Form, Field, ErrorMessage } from "formik";
+import { Check, Loader2, X as XIcon, Zap } from "lucide-react";
 import { resolveIconPath } from "~/lib/iconUtils";
 import type { ServiceDefinition, ServiceField } from "~/types/credentials";
 
@@ -7,18 +8,24 @@ interface DynamicCredentialFormProps {
   service: ServiceDefinition;
   onSubmit: (values: any) => void;
   onCancel: () => void;
+  onTest?: (data: Record<string, any>) => Promise<{ success: boolean; message: string }>;
   initialValues?: Record<string, any>;
   isSubmitting?: boolean;
 }
+
+type TestState = "idle" | "loading" | "success" | "error";
 
 const DynamicCredentialForm: React.FC<DynamicCredentialFormProps> = ({
   service,
   onSubmit,
   onCancel,
+  onTest,
   initialValues = {},
   isSubmitting = false,
 }) => {
   const [iconFailed, setIconFailed] = useState(false);
+  const [testState, setTestState] = useState<TestState>("idle");
+  const [testMessage, setTestMessage] = useState("");
   const validateField = (
     field: ServiceField,
     value: any
@@ -232,6 +239,13 @@ const DynamicCredentialForm: React.FC<DynamicCredentialFormProps> = ({
               );
             })}
 
+            {/* Test result message */}
+            {testMessage && testState !== "loading" && (
+              <p className={`text-sm ${testState === "success" ? "text-green-600" : "text-red-500"}`}>
+                {testMessage}
+              </p>
+            )}
+
             {/* Form Actions */}
             <div className="flex items-center justify-end gap-3 pt-6 border-t border-gray-200">
               <button
@@ -241,6 +255,41 @@ const DynamicCredentialForm: React.FC<DynamicCredentialFormProps> = ({
               >
                 Cancel
               </button>
+              {onTest && (
+                <button
+                  type="button"
+                  disabled={testState === "loading"}
+                  onClick={async () => {
+                    setTestState("loading");
+                    setTestMessage("");
+                    try {
+                      const result = await onTest(values);
+                      setTestState(result.success ? "success" : "error");
+                      setTestMessage(result.message);
+                    } catch {
+                      setTestState("error");
+                      setTestMessage("Unexpected error. Please try again.");
+                    }
+                    setTimeout(() => {
+                      setTestState("idle");
+                      setTestMessage("");
+                    }, 4000);
+                  }}
+                  className={`flex items-center gap-1.5 px-5 py-2.5 rounded-lg border transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed
+                    ${testState === "success"
+                      ? "text-green-600 border-green-300 bg-green-50"
+                      : testState === "error"
+                      ? "text-red-500 border-red-300 bg-red-50"
+                      : "text-gray-700 border-gray-300 bg-white hover:bg-gray-50"
+                    }`}
+                >
+                  {testState === "loading" && <Loader2 className="w-4 h-4 animate-spin" />}
+                  {testState === "success" && <Check className="w-4 h-4" />}
+                  {testState === "error" && <XIcon className="w-4 h-4" />}
+                  {testState === "idle" && <Zap className="w-4 h-4" />}
+                  Test Connection
+                </button>
+              )}
               <button
                 type="submit"
                 disabled={isSubmitting}

--- a/client/app/lib/config.ts
+++ b/client/app/lib/config.ts
@@ -75,6 +75,7 @@ export const API_ENDPOINTS = {
     UPDATE: (id: string) => `/credentials/${id}`,
     DELETE: (id: string) => `/credentials/${id}`,
     TEST: (id: string) => `/credentials/${id}/test`,
+    TEST_RAW: '/credentials/test-raw',
   },
   API_KEYS: {
     LIST: '/api-keys',

--- a/client/app/routes/credentials.tsx
+++ b/client/app/routes/credentials.tsx
@@ -11,7 +11,7 @@ import {
   Cloud,
   Settings,
 } from "lucide-react";
-import { testUserCredential } from "~/services/userCredentialService";
+import { testUserCredential, testCredentialRaw } from "~/services/userCredentialService";
 import React, { useState, useEffect } from "react";
 import DashboardSidebar from "~/components/dashboard/DashboardSidebar";
 import { useUserCredentialStore } from "../stores/userCredential";
@@ -420,6 +420,10 @@ function CredentialsLayout() {
                   setSelectedService(null);
                   setEditingCredential(null);
                   setEditingInitialValues({});
+                }}
+                onTest={async (values) => {
+                  const { name, ...data } = values;
+                  return await testCredentialRaw(selectedService.id, data);
                 }}
                 initialValues={
                   editingCredential

--- a/client/app/services/userCredentialService.ts
+++ b/client/app/services/userCredentialService.ts
@@ -26,3 +26,13 @@ export const deleteUserCredential = async (id: string): Promise<{ message: strin
 export const testUserCredential = async (id: string): Promise<{ success: boolean; message: string }> => {
   return await apiClient.post<{ success: boolean; message: string }>(API_ENDPOINTS.CREDENTIALS.TEST(id), {});
 };
+
+export const testCredentialRaw = async (
+  serviceType: string,
+  data: Record<string, any>
+): Promise<{ success: boolean; message: string }> => {
+  return await apiClient.post<{ success: boolean; message: string }>(
+    API_ENDPOINTS.CREDENTIALS.TEST_RAW,
+    { service_type: serviceType, data }
+  );
+};


### PR DESCRIPTION
## Summary

Adds a **Test Connection** button to each credential card so users can verify their credentials work before using them in workflows.

- New `POST /api/v1/credentials/{id}/test` endpoint — decrypts the credential and runs a real connection test
- Test button on each `CredentialCard` with loading/success/error states
- Error message shown inline below the card actions

### Supported credential types

| Type | How it's tested |
|------|----------------|
| OpenAI | `openai.models.list()` |
| Cohere | minimal embed call |
| Tavily Search | short search query |
| PostgreSQL | `psycopg2.connect()` + `SELECT 1` |
| Kafka | `AdminClient.list_topics()` |
| Basic Auth / Header Auth | format validation (no target URL available) |

All network tests have a 10-second timeout.

Closes #360

## Test plan
- [ ] OpenAI credential: test with valid key → success; invalid key → error message from API
- [ ] PostgreSQL: test with running local DB → success; wrong host → connection error
- [ ] Kafka: test with broker running → success; wrong broker → timeout/error
- [ ] Loading spinner shows during test, button disabled
- [ ] Success state turns green for ~4 seconds then resets
- [ ] Error state shows message in red below actions