### PR TITLE
feat: add credential testing functionality to user credentials management

### DIFF
--- a/backend/app/api/credentials.py
+++ b/backend/app/api/credentials.py
@@ -1,9 +1,11 @@
 """User Credentials API endpoints"""
 
+import asyncio
 import logging
 import uuid
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, Depends, HTTPException, status, Query
+from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.user import User
@@ -303,6 +305,234 @@ async def delete_credential(
             detail="Failed to delete credential"
         )
 
+class CredentialTestResponse(BaseModel):
+    success: bool
+    message: str
+
+
+class CredentialTestRawRequest(BaseModel):
+    service_type: str
+    data: Dict[str, Any]
+
+
+async def _test_openai(secret: Dict[str, Any]) -> CredentialTestResponse:
+    try:
+        from openai import AsyncOpenAI
+
+        client = AsyncOpenAI(api_key=secret.get("api_key", ""))
+        await asyncio.wait_for(client.models.list(), timeout=10)
+        return CredentialTestResponse(success=True, message="Connected to OpenAI successfully.")
+    except asyncio.TimeoutError:
+        return CredentialTestResponse(success=False, message="Connection timed out.")
+    except Exception as e:
+        msg = str(e)
+        if "invalid" in msg.lower() or "auth" in msg.lower():
+            msg += (
+                " Note: If this key is for an OpenAI-compatible provider "
+                "(OpenRouter, vLLM, etc.), it may still be valid for that provider."
+            )
+        return CredentialTestResponse(success=False, message=msg)
+
+
+async def _test_openai_compatible(secret: Dict[str, Any]) -> CredentialTestResponse:
+    try:
+        from openai import AsyncOpenAI
+
+        # Use dummy key for local servers that don't need auth, so client doesn't complain about empty key
+        api_key = secret.get("api_key", "")
+        if not api_key:
+            api_key = "dummy_for_local"
+
+        client = AsyncOpenAI(
+            api_key=api_key,
+            base_url=secret.get("base_url", "")
+        )
+        
+        # 1. Ensure the endpoint exists and responds to OpenAI format
+        await asyncio.wait_for(client.models.list(), timeout=10)
+        
+        # 2. Force an authentication check
+        # Some providers (like OpenRouter) have a completely public /models endpoint.
+        # Sending a dummy chat request with empty messages usually fails fast on Auth (401)
+        # BEFORE it fails on missing messages (400), letting us verify the API key!
+        try:
+            await asyncio.wait_for(
+                client.chat.completions.create(
+                    model="test-auth",
+                    messages=[],
+                    max_tokens=1
+                ),
+                timeout=10
+            )
+        except Exception as auth_test_e:
+            err_msg = str(auth_test_e).lower()
+            if "401" in err_msg or "unauthorized" in err_msg or "invalid" in err_msg:
+                return CredentialTestResponse(success=False, message="Invalid API Key or Unauthorized.")
+            # If it's a 400 Bad Request or 404 Model Not Found, it means authentication passed!
+            pass
+
+        return CredentialTestResponse(success=True, message="Connected to OpenAI Compatible provider successfully.")
+    except asyncio.TimeoutError:
+        return CredentialTestResponse(success=False, message="Connection timed out.")
+    except Exception as e:
+        return CredentialTestResponse(success=False, message=str(e))
+
+
+async def _test_cohere(secret: Dict[str, Any]) -> CredentialTestResponse:
+    try:
+        import cohere
+
+        client = cohere.AsyncClientV2(api_key=secret.get("api_key", ""))
+        await asyncio.wait_for(
+            client.embed(texts=["test"], model="embed-english-v3.0", input_type="search_query"),
+            timeout=10,
+        )
+        return CredentialTestResponse(success=True, message="Connected to Cohere successfully.")
+    except asyncio.TimeoutError:
+        return CredentialTestResponse(success=False, message="Connection timed out.")
+    except Exception as e:
+        return CredentialTestResponse(success=False, message=str(e))
+
+
+async def _test_tavily(secret: Dict[str, Any]) -> CredentialTestResponse:
+    try:
+        from tavily import AsyncTavilyClient
+
+        client = AsyncTavilyClient(api_key=secret.get("api_key", ""))
+        await asyncio.wait_for(client.search("test"), timeout=10)
+        return CredentialTestResponse(success=True, message="Connected to Tavily successfully.")
+    except asyncio.TimeoutError:
+        return CredentialTestResponse(success=False, message="Connection timed out.")
+    except Exception as e:
+        return CredentialTestResponse(success=False, message=str(e))
+
+
+async def _test_postgresql(secret: Dict[str, Any]) -> CredentialTestResponse:
+    try:
+        import psycopg2
+
+        def _connect():
+            conn = psycopg2.connect(
+                host=secret.get("host", "localhost"),
+                port=int(secret.get("port", 5432)),
+                dbname=secret.get("database", ""),
+                user=secret.get("username", ""),
+                password=secret.get("password", ""),
+                connect_timeout=10,
+            )
+            cur = conn.cursor()
+            cur.execute("SELECT 1")
+            cur.close()
+            conn.close()
+
+        await asyncio.wait_for(asyncio.get_event_loop().run_in_executor(None, _connect), timeout=15)
+        return CredentialTestResponse(success=True, message="Connected to PostgreSQL successfully.")
+    except asyncio.TimeoutError:
+        return CredentialTestResponse(success=False, message="Connection timed out.")
+    except Exception as e:
+        return CredentialTestResponse(success=False, message=str(e))
+
+
+async def _test_kafka(secret: Dict[str, Any]) -> CredentialTestResponse:
+    try:
+        from confluent_kafka.admin import AdminClient
+
+        conf: Dict[str, Any] = {
+            "bootstrap.servers": secret.get("brokers", ""),
+            "socket.timeout.ms": 10000,
+        }
+        security_protocol = secret.get("security_protocol", "PLAINTEXT")
+        if security_protocol:
+            conf["security.protocol"] = security_protocol
+        if security_protocol in ("SASL_PLAINTEXT", "SASL_SSL"):
+            conf["sasl.mechanism"] = secret.get("sasl_mechanism", "PLAIN")
+            conf["sasl.username"] = secret.get("sasl_username", "")
+            conf["sasl.password"] = secret.get("sasl_password", "")
+
+        def _connect():
+            admin = AdminClient(conf)
+            metadata = admin.list_topics(timeout=10)
+            return metadata
+
+        await asyncio.wait_for(asyncio.get_event_loop().run_in_executor(None, _connect), timeout=15)
+        return CredentialTestResponse(success=True, message="Connected to Kafka successfully.")
+    except asyncio.TimeoutError:
+        return CredentialTestResponse(success=False, message="Connection timed out.")
+    except Exception as e:
+        return CredentialTestResponse(success=False, message=str(e))
+
+
+def _test_webhook_auth(secret: Dict[str, Any], service_type: str) -> CredentialTestResponse:
+    if service_type == "basic_auth":
+        if secret.get("username") and secret.get("password"):
+            return CredentialTestResponse(success=True, message="Credentials format is valid.")
+        return CredentialTestResponse(success=False, message="Username and password are required.")
+    if service_type == "header_auth":
+        if secret.get("header_name") and secret.get("header_value"):
+            return CredentialTestResponse(success=True, message="Credentials format is valid.")
+        return CredentialTestResponse(success=False, message="Header name and value are required.")
+    return CredentialTestResponse(success=False, message="Unknown credential type.")
+
+
+async def _run_test(service_type: str, secret: Dict[str, Any]) -> CredentialTestResponse:
+    """Route a test request to the appropriate handler based on service type."""
+    if service_type == "openai":
+        return await _test_openai(secret)
+    elif service_type == "openai_compatible":
+        return await _test_openai_compatible(secret)
+    elif service_type == "cohere":
+        return await _test_cohere(secret)
+    elif service_type == "tavily_search":
+        return await _test_tavily(secret)
+    elif service_type == "postgresql_vectorstore":
+        return await _test_postgresql(secret)
+    elif service_type == "kafka":
+        return await _test_kafka(secret)
+    elif service_type in ("basic_auth", "header_auth"):
+        return _test_webhook_auth(secret, service_type)
+    else:
+        return CredentialTestResponse(
+            success=False, message=f"Test not supported for service type: {service_type}"
+        )
+
+
+@router.post("/test-raw", response_model=CredentialTestResponse)
+async def test_credential_raw(
+    request: CredentialTestRawRequest,
+    current_user=Depends(get_current_user),
+):
+    """Test credentials before saving, using raw data from the form."""
+    try:
+        return await _run_test(request.service_type, request.data)
+    except Exception as e:
+        logger.error(f"Unexpected error testing raw credential: {e}")
+        return CredentialTestResponse(success=False, message=f"Unexpected error: {e}")
+
+
+@router.post("/{credential_id}/test", response_model=CredentialTestResponse)
+async def test_credential(
+    credential_id: uuid.UUID,
+    current_user=Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session),
+    credential_service: CredentialService = Depends(get_credential_service_dep),
+):
+    """Test whether a saved credential can successfully connect to its service."""
+    user_id = current_user.id
+
+    decrypted = await credential_service.get_decrypted_credential(db, user_id, credential_id)
+    if not decrypted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Credential not found")
+
+    service_type: str = decrypted.get("service_type", "")
+    secret: Dict[str, Any] = decrypted.get("secret", {})
+
+    try:
+        return await _run_test(service_type, secret)
+    except Exception as e:
+        logger.error(f"Unexpected error testing credential {credential_id}: {e}")
+        return CredentialTestResponse(success=False, message=f"Unexpected error: {e}")
+
+
 def _detect_service_type(data: dict) -> str:
     """
     Detect service type from credential data structure.
@@ -324,6 +554,8 @@ def _detect_service_type(data: dict) -> str:
         # Cohere API
         if data.get("provider") == "cohere" or data.get("cohere") is True:
             return "cohere"
+        if "base_url" in data:
+            return "openai_compatible"
         if "organization" in data or "project_id" in data:
             return "openai"
         elif "engine" in data or "model" in data:

--- a/backend/app/nodes/llms/openai_compatible_node.py
+++ b/backend/app/nodes/llms/openai_compatible_node.py
@@ -160,7 +160,7 @@ class OpenAICompatibleNode(BaseNode):
                     placeholder="Select API Key",
                     required=True,
                     hint="Required for commercial providers, optional for some local servers",
-                    serviceType="openai",
+                    serviceType="openai_compatible",
                 ),
                 NodeProperty(
                     name="base_url",

--- a/client/app/components/credentials/CredentialCard.tsx
+++ b/client/app/components/credentials/CredentialCard.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Pencil, Trash } from "lucide-react";
+import { Check, Loader2, Pencil, Trash, Zap, X as XIcon } from "lucide-react";
 import { timeAgo } from "~/lib/dateFormatter";
 import { resolveIconPath } from "~/lib/iconUtils";
 import { getServiceDefinition } from "~/types/credentials";
@@ -9,16 +9,39 @@ interface CredentialCardProps {
   credential: UserCredential;
   onEdit: (credential: UserCredential) => void;
   onDelete: (id: string) => void;
+  onTest: (id: string) => Promise<{ success: boolean; message: string }>;
 }
+
+type TestState = "idle" | "loading" | "success" | "error";
 
 const CredentialCard: React.FC<CredentialCardProps> = ({
   credential,
   onEdit,
   onDelete,
+  onTest,
 }) => {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const serviceDefinition = getServiceDefinition(credential.service_type);
   const [iconFailed, setIconFailed] = useState(false);
+  const [testState, setTestState] = useState<TestState>("idle");
+  const [testMessage, setTestMessage] = useState<string>("");
+
+  const handleTest = async () => {
+    setTestState("loading");
+    setTestMessage("");
+    try {
+      const result = await onTest(credential.id);
+      setTestState(result.success ? "success" : "error");
+      setTestMessage(result.message);
+    } catch {
+      setTestState("error");
+      setTestMessage("Unexpected error. Please try again.");
+    }
+    setTimeout(() => {
+      setTestState("idle");
+      setTestMessage("");
+    }, 4000);
+  };
   return (
     <div className="bg-white border border-gray-200 rounded-lg p-4 hover:shadow-sm transition-all duration-200">
       {/* Header */}
@@ -71,8 +94,32 @@ const CredentialCard: React.FC<CredentialCardProps> = ({
         <span>Updated: {timeAgo(credential.updated_at)}</span>
       </div>
 
+      {/* Test result message */}
+      {testMessage && testState !== "loading" && (
+        <p className={`text-xs mt-1 mb-1 ${testState === "success" ? "text-green-600" : "text-red-500"}`}>
+          {testMessage}
+        </p>
+      )}
+
       {/* Actions */}
       <div className="flex items-center justify-end gap-1.5">
+        <button
+          onClick={handleTest}
+          disabled={testState === "loading"}
+          className={`flex items-center gap-1 px-2 py-1 text-xs rounded-md transition-all duration-200
+            ${testState === "success" ? "text-green-600 bg-green-50" :
+              testState === "error" ? "text-red-500 bg-red-50" :
+                "text-gray-400 hover:text-purple-600 hover:bg-purple-50"}
+            disabled:opacity-50 disabled:cursor-not-allowed`}
+          title="Test connection"
+        >
+          {testState === "loading" && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
+          {testState === "success" && <Check className="w-3.5 h-3.5" />}
+          {testState === "error" && <XIcon className="w-3.5 h-3.5" />}
+          {testState === "idle" && <Zap className="w-3.5 h-3.5" />}
+          Test
+        </button>
+
         <button
           onClick={() => onEdit(credential)}
           className="p-1.5 text-gray-400 hover:text-blue-600 hover:bg-blue-50 rounded-md transition-all duration-200"

--- a/client/app/components/credentials/DynamicCredentialForm.tsx
+++ b/client/app/components/credentials/DynamicCredentialForm.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from "react";
 import { Formik, Form, Field, ErrorMessage } from "formik";
+import { Check, Loader2, X as XIcon, Zap } from "lucide-react";
 import { resolveIconPath } from "~/lib/iconUtils";
 import type { ServiceDefinition, ServiceField } from "~/types/credentials";
 
@@ -7,18 +8,24 @@ interface DynamicCredentialFormProps {
   service: ServiceDefinition;
   onSubmit: (values: any) => void;
   onCancel: () => void;
+  onTest?: (data: Record<string, any>) => Promise<{ success: boolean; message: string }>;
   initialValues?: Record<string, any>;
   isSubmitting?: boolean;
 }
+
+type TestState = "idle" | "loading" | "success" | "error";
 
 const DynamicCredentialForm: React.FC<DynamicCredentialFormProps> = ({
   service,
   onSubmit,
   onCancel,
+  onTest,
   initialValues = {},
   isSubmitting = false,
 }) => {
   const [iconFailed, setIconFailed] = useState(false);
+  const [testState, setTestState] = useState<TestState>("idle");
+  const [testMessage, setTestMessage] = useState("");
   const validateField = (
     field: ServiceField,
     value: any
@@ -232,6 +239,13 @@ const DynamicCredentialForm: React.FC<DynamicCredentialFormProps> = ({
               );
             })}
 
+            {/* Test result message */}
+            {testMessage && testState !== "loading" && (
+              <p className={`text-sm ${testState === "success" ? "text-green-600" : "text-red-500"}`}>
+                {testMessage}
+              </p>
+            )}
+
             {/* Form Actions */}
             <div className="flex items-center justify-end gap-3 pt-6 border-t border-gray-200">
               <button
@@ -241,6 +255,41 @@ const DynamicCredentialForm: React.FC<DynamicCredentialFormProps> = ({
               >
                 Cancel
               </button>
+              {onTest && (
+                <button
+                  type="button"
+                  disabled={testState === "loading"}
+                  onClick={async () => {
+                    setTestState("loading");
+                    setTestMessage("");
+                    try {
+                      const result = await onTest(values);
+                      setTestState(result.success ? "success" : "error");
+                      setTestMessage(result.message);
+                    } catch {
+                      setTestState("error");
+                      setTestMessage("Unexpected error. Please try again.");
+                    }
+                    setTimeout(() => {
+                      setTestState("idle");
+                      setTestMessage("");
+                    }, 4000);
+                  }}
+                  className={`flex items-center gap-1.5 px-5 py-2.5 rounded-lg border transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed
+                    ${testState === "success"
+                      ? "text-green-600 border-green-300 bg-green-50"
+                      : testState === "error"
+                        ? "text-red-500 border-red-300 bg-red-50"
+                        : "text-gray-700 border-gray-300 bg-white hover:bg-gray-50"
+                    }`}
+                >
+                  {testState === "loading" && <Loader2 className="w-4 h-4 animate-spin" />}
+                  {testState === "success" && <Check className="w-4 h-4" />}
+                  {testState === "error" && <XIcon className="w-4 h-4" />}
+                  {testState === "idle" && <Zap className="w-4 h-4" />}
+                  Test Connection
+                </button>
+              )}
               <button
                 type="submit"
                 disabled={isSubmitting}

--- a/client/app/lib/config.ts
+++ b/client/app/lib/config.ts
@@ -74,6 +74,8 @@ export const API_ENDPOINTS = {
     GET: (id: string) => `/credentials/${id}`,
     UPDATE: (id: string) => `/credentials/${id}`,
     DELETE: (id: string) => `/credentials/${id}`,
+    TEST: (id: string) => `/credentials/${id}/test`,
+    TEST_RAW: '/credentials/test-raw',
   },
   API_KEYS: {
     LIST: '/api-keys',

--- a/client/app/routes/credentials.tsx
+++ b/client/app/routes/credentials.tsx
@@ -11,6 +11,7 @@ import {
   Cloud,
   Settings,
 } from "lucide-react";
+import { testUserCredential, testCredentialRaw } from "~/services/userCredentialService";
 import React, { useState, useEffect } from "react";
 import DashboardSidebar from "~/components/dashboard/DashboardSidebar";
 import { useUserCredentialStore } from "../stores/userCredential";
@@ -178,6 +179,10 @@ function CredentialsLayout() {
     }
   };
 
+  const handleTestCredential = async (id: string) => {
+    return await testUserCredential(id);
+  };
+
   const getCategoryIcon = (category: string) => {
     const icons: Record<string, React.ReactNode> = {
       ai: <Zap className="w-4 h-4" />,
@@ -307,6 +312,7 @@ function CredentialsLayout() {
                     credential={credential}
                     onEdit={handleEditCredential}
                     onDelete={handleDeleteCredential}
+                    onTest={handleTestCredential}
                   />
                 ))}
               </div>
@@ -414,6 +420,10 @@ function CredentialsLayout() {
                   setSelectedService(null);
                   setEditingCredential(null);
                   setEditingInitialValues({});
+                }}
+                onTest={async (values) => {
+                  const { name, ...data } = values;
+                  return await testCredentialRaw(selectedService.id, data);
                 }}
                 initialValues={
                   editingCredential

--- a/client/app/services/userCredentialService.ts
+++ b/client/app/services/userCredentialService.ts
@@ -22,3 +22,17 @@ export const updateUserCredential = async (id: string, data: Partial<CredentialC
 export const deleteUserCredential = async (id: string): Promise<{ message: string; deleted_id: string }> => {
   return await apiClient.delete<{ message: string; deleted_id: string }>(API_ENDPOINTS.CREDENTIALS.DELETE(id));
 };
+
+export const testUserCredential = async (id: string): Promise<{ success: boolean; message: string }> => {
+  return await apiClient.post<{ success: boolean; message: string }>(API_ENDPOINTS.CREDENTIALS.TEST(id), {});
+};
+
+export const testCredentialRaw = async (
+  serviceType: string,
+  data: Record<string, any>
+): Promise<{ success: boolean; message: string }> => {
+  return await apiClient.post<{ success: boolean; message: string }>(
+    API_ENDPOINTS.CREDENTIALS.TEST_RAW,
+    { service_type: serviceType, data }
+  );
+};

--- a/client/app/types/credentials.ts
+++ b/client/app/types/credentials.ts
@@ -58,6 +58,32 @@ export const SERVICE_DEFINITIONS: ServiceDefinition[] = [
     ]
   },
   {
+    id: 'openai_compatible',
+    name: 'OpenAI Compatible',
+    description: 'Connect to any OpenAI-API compatible service like OpenRouter, vLLM, DeepSeek, or LM Studio.',
+    icon: 'openai.svg',
+    category: 'ai',
+    color: 'from-gray-500 to-slate-600',
+    fields: [
+      {
+        name: 'base_url',
+        label: 'Base URL',
+        type: 'text',
+        required: true,
+        placeholder: 'https://openrouter.ai/api/v1',
+        description: 'The endpoint URL for the compatible service'
+      },
+      {
+        name: 'api_key',
+        label: 'API Key',
+        type: 'password',
+        required: true,
+        placeholder: '...',
+        description: 'The authentication key for the compatible service'
+      }
+    ]
+  },
+  {
     id: 'cohere',
     name: 'Cohere',
     description: 'Cohere AI API credentials for embeddings and reranking',


### PR DESCRIPTION
- Implemented API endpoints for testing user credentials, including support for various services like OpenAI, Cohere, Tavily, PostgreSQL, and Kafka.
- Enhanced frontend components to allow users to test credentials directly from the UI, displaying success or error messages based on the test results.
- Updated service definitions to include a new "OpenAI Compatible" service type with necessary fields for configuration.
- Improved user experience with loading indicators and feedback messages during credential testing.