### PR TITLE
fix: prevent chat session from dropping during workflow execution

### DIFF
--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -116,8 +116,8 @@ async def delete_chatflow(
 @router.get("/active-session/id", response_model=Dict[str, Optional[str]])
 async def get_active_session_id(
     chatflow_id: Optional[str] = None,
-    current_user: User = Depends(get_current_user)
+    current_user: User = Depends(get_current_user),
+    db=Depends(get_db),
 ):
-    db = next(get_db())
     session_id = memory_service.get_active_session_id(db, str(current_user.id), chatflow_id=chatflow_id)
     return {"session_id": session_id}

--- a/backend/app/core/graph_builder/node_executor.py
+++ b/backend/app/core/graph_builder/node_executor.py
@@ -99,25 +99,21 @@ class NodeExecutor:
                 except Exception as e:
                     logger.warning(f"Failed to inject credentials for node {node_id}: {e}")
 
+            # Resolve session_id once and write back to state for consistency
+            session_id = state.session_id
+            if not session_id or session_id == 'None' or len(str(session_id).strip()) == 0:
+                session_id = f"session_{node_id}_{uuid.uuid4().hex[:8]}"
+                state.session_id = session_id
+                logger.warning(f"Generated fallback session_id: {session_id}")
+
             # Setup session for ReAct Agents and Tool Agents
             if gnode.type in PROCESSOR_NODE_TYPES and hasattr(gnode.node_instance, 'session_id'):
-                session_id = state.session_id or f"session_{node_id}"
-                
-                # Ensure session_id is valid
-                if not session_id or session_id == 'None' or len(session_id.strip()) == 0:
-                    session_id = f"session_{node_id}_{uuid.uuid4().hex[:8]}"
-                
                 gnode.node_instance.session_id = session_id
                 logger.debug(f"Set session_id on agent {node_id}: {session_id}")
-            
-            # Setup session for memory nodes (priority over user_id)
+
+            # Setup session for memory nodes
             if any(memory_type in gnode.type for memory_type in MEMORY_NODE_TYPES):
                 if hasattr(gnode.node_instance, 'session_id'):
-                    # Use state.session_id as primary source
-                    session_id = state.session_id
-                    if not session_id or session_id == 'None' or len(session_id.strip()) == 0:
-                        session_id = f"session_{node_id}_{uuid.uuid4().hex[:8]}"
-                    
                     gnode.node_instance.session_id = session_id
                     logger.debug(f"Set session_id on memory node {node_id}: {session_id}")
                 

--- a/backend/app/core/memory_manager.py
+++ b/backend/app/core/memory_manager.py
@@ -37,7 +37,7 @@ class MemoryMetrics:
 class MemoryCleanupPolicy:
     """Memory cleanup policy configuration."""
     max_session_age_hours: int = 24      # 24 hours
-    max_inactive_hours: int = 2          # 2 hours
+    max_inactive_hours: int = 6          # 6 hours
     max_messages_per_session: int = 1000 # 1000 messages
     max_memory_mb_per_session: int = 50  # 50MB per session
     cleanup_interval_minutes: int = 15   # 15 minutes

--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -287,7 +287,7 @@ class ChatService:
         self._workflow_built = False
         self._last_workflow_id = None
     
-    async def _execute_workflow(self, user_input: str, chatflow_id: UUID, workflow_id: UUID = None) -> str:
+    async def _execute_workflow(self, user_input: str, chatflow_id: UUID, workflow_id: UUID = None, user_id: UUID = None) -> str:
         """
         Execute the actual workflow with user input and return LLM response.
         
@@ -654,7 +654,7 @@ class ChatService:
             db_chat_message.content = self._encrypt_content(new_content)
 
         # 3. Regenerate a new response from the LLM using actual workflow
-        llm_response_content = await self._execute_workflow(new_content, chatflow_id)
+        llm_response_content = await self._execute_workflow(new_content, chatflow_id, user_id=user_id)
         encrypted_llm_content = self._encrypt_content(llm_response_content)
         llm_message = ChatMessage(
             role="assistant",
@@ -732,7 +732,7 @@ class ChatService:
         await self.create_chat_message(user_message)
 
         # 3. Execute the actual workflow with the specified workflow_id
-        llm_response_content = await self._execute_workflow(user_input, chatflow_id, workflow_id)
+        llm_response_content = await self._execute_workflow(user_input, chatflow_id, workflow_id, user_id=user_id)
 
         # 4. Save LLM's response (create_chat_message will handle encryption)
         llm_message = ChatMessageCreate(
@@ -759,7 +759,7 @@ class ChatService:
         await self.create_chat_message(user_message)
 
         # 2. Execute the actual workflow with the specified workflow_id
-        llm_response_content = await self._execute_workflow(user_input, chatflow_id, workflow_id)
+        llm_response_content = await self._execute_workflow(user_input, chatflow_id, workflow_id, user_id=user_id)
 
         # 3. Save LLM's response (create_chat_message will handle encryption)
         llm_message = ChatMessageCreate(

--- a/client/app/components/canvas/FlowCanvas.tsx
+++ b/client/app/components/canvas/FlowCanvas.tsx
@@ -322,15 +322,17 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
     }
   }, [currentWorkflow?.name]);
 
-  // Clear chats and execution data when workflow changes to prevent accumulation
+  // Clear chats and execution data only when switching to a DIFFERENT workflow
+  const prevWorkflowIdRef = useRef<string | null>(null);
   useEffect(() => {
-    if (currentWorkflow?.id) {
-      // Reset active chat when switching to a different workflow
-      setActiveChatflowId(null);
-      // Clear chats when switching to a different workflow
-      clearAllChats();
-      // Clear execution data for the previous workflow
+    if (currentWorkflow?.id && currentWorkflow.id !== prevWorkflowIdRef.current) {
+      if (prevWorkflowIdRef.current !== null) {
+        // Actually switching workflows — clear previous session
+        setActiveChatflowId(null);
+        clearAllChats();
+      }
       setCurrentExecutionForWorkflow(currentWorkflow.id, null);
+      prevWorkflowIdRef.current = currentWorkflow.id;
     }
   }, [currentWorkflow?.id, clearAllChats, setCurrentExecutionForWorkflow, setActiveChatflowId]);
 

--- a/client/app/stores/chat.ts
+++ b/client/app/stores/chat.ts
@@ -236,7 +236,7 @@ const executeWorkflowWithStreaming = async (
 
 export const useChatStore = create<ChatStore>((set, get) => ({
   chats: {},
-  activeChatflowId: null,
+  activeChatflowId: typeof window !== 'undefined' ? sessionStorage.getItem('activeChatflowId') : null,
   loading: false,
   thinking: false, // Initialize thinking state
   error: null,
@@ -330,7 +330,16 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     }
   },
 
-  setActiveChatflowId: (chatflow_id) => set({ activeChatflowId: chatflow_id }),
+  setActiveChatflowId: (chatflow_id) => {
+    if (typeof window !== 'undefined') {
+      if (chatflow_id) {
+        sessionStorage.setItem('activeChatflowId', chatflow_id);
+      } else {
+        sessionStorage.removeItem('activeChatflowId');
+      }
+    }
+    set({ activeChatflowId: chatflow_id });
+  },
   setLoading: (loading) => set({ loading }),
   setThinking: (thinking) => set({ thinking }), // Add setThinking
   setError: (error) => set({ error }),


### PR DESCRIPTION
## Summary

Fixes multiple root causes behind the session drop bug in workflow chat.

### Backend fixes

- **`chat_service.py`** — `_execute_workflow()` was referencing `user_id` without receiving it as a parameter, causing a `NameError` that broke user context creation. Added `user_id` param and passed it through from all call sites.

- **`chat.py`** — `get_active_session_id` endpoint was using `next(get_db())` (raw sync generator) inside an async handler. Switched to `Depends(get_db)` which lets FastAPI handle the lifecycle properly.

- **`node_executor.py`** — When `state.session_id` was empty, each node generated its own random fallback ID independently, causing memory fragmentation across nodes in the same workflow. Now the fallback ID is written back to `state.session_id` so all subsequent nodes share it.

- **`memory_manager.py`** — Inactivity cleanup threshold was 2 hours which is too aggressive for typical chat usage. Increased to 6 hours.

### Frontend fixes

- **`chat.ts`** — `activeChatflowId` was only in Zustand memory state, lost on page refresh. Now persisted to `sessionStorage` and restored on init.

- **`FlowCanvas.tsx`** — `useEffect` was clearing the chat session every time the component re-rendered with the same workflow ID. Added a ref to track the previous workflow ID and only clear when actually switching to a different workflow.

Closes #362

## Test plan
- [ ] Send messages in chat panel — session_id stays consistent in backend logs
- [ ] Refresh the page — chat session is preserved
- [ ] Leave chat idle for a few hours — session still works
- [ ] Switch between workflows — previous chat clears, new one starts clean
- [ ] Navigate back to the same workflow — no unnecessary session reset