### PR TITLE
refactor : enforce consistent export naming and remove sensitive data from bundle template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,9 +63,6 @@ supabase/.temp/
 supabase/.env
 supabase/.branches/
 
-# Docker
-.docker/
-
 # Logs
 *.log
 logs/

--- a/backend/app/api/export.py
+++ b/backend/app/api/export.py
@@ -108,8 +108,8 @@ async def export_workflows(
     if not request.export_name or not request.export_name.strip():
         raise HTTPException(status_code=400, detail="Export name is required")
     
-    # Sanitize export name
-    export_name = "".join(c if c.isalnum() or c in "_-" else "_" for c in request.export_name.strip().lower())
+    # Sanitize export name: remove spaces entirely
+    export_name = "".join(c for c in request.export_name.strip().lower() if c.isalnum() or c in "_-")
     
     config = {
         "version": "1.0",
@@ -214,7 +214,7 @@ async def export_workflows(
         
         # Create flow file
         safe_name = "".join(c if c.isalnum() or c in "_-" else "_" for c in workflow.name.lower())[:50]
-        flow_filename = f"{export_name}_flows/{safe_name}.json"
+        flow_filename = f"flows/{safe_name}.json"
         flow_files[flow_filename] = json.dumps(flow_data, indent=2, default=str, ensure_ascii=False)
         
         config["workflows"].append({

--- a/backend/scripts/export_workflows.py
+++ b/backend/scripts/export_workflows.py
@@ -74,9 +74,9 @@ async def export_workflows(
     Credentials are exported with empty secrets (user fills them).
     """
     output_path = Path(output_dir)
-    # Sanitize export name
-    safe_export_name = "".join(c if c.isalnum() or c in "_-" else "_" for c in export_name.strip().lower())
-    flows_dir = output_path / f"{safe_export_name}_flows"
+    # Sanitize export name: remove spaces entirely
+    safe_export_name = "".join(c for c in export_name.strip().lower() if c.isalnum() or c in "_-")
+    flows_dir = output_path / "flows"
     flows_dir.mkdir(parents=True, exist_ok=True)
     
     config = {
@@ -178,7 +178,7 @@ async def export_workflows(
             
             # Save flow file (unchanged - keeps credential_id as-is)
             safe_name = "".join(c if c.isalnum() or c in "_-" else "_" for c in workflow.name.lower())[:50]
-            flow_file = f"{safe_export_name}_flows/{safe_name}.json"
+            flow_file = f"flows/{safe_name}.json"
             (output_path / flow_file).write_text(
                 json.dumps(flow_data, indent=2, default=str, ensure_ascii=False)
             )

--- a/client/app/components/modals/WorkflowExportModal.tsx
+++ b/client/app/components/modals/WorkflowExportModal.tsx
@@ -70,8 +70,8 @@ export default function WorkflowExportModal({
         setError(null);
 
         try {
-            // Sanitize export name: replace spaces with underscores, lowercase
-            const sanitizedName = exportName.trim().replace(/\s+/g, '_').toLowerCase();
+            // Sanitize export name: remove spaces, lowercase
+            const sanitizedName = exportName.trim().replace(/\s+/g, '').toLowerCase();
             await exportWorkflows(Array.from(selectedIds), sanitizedName);
             onClose();
         } catch (err: any) {
@@ -148,7 +148,7 @@ export default function WorkflowExportModal({
                                 </div>
                             )}
                             <p className="mt-1.5 text-xs text-gray-400">
-                                ZIP will contain: <code className="bg-gray-100 px-1 py-0.5 rounded">{exportName.trim().replace(/\s+/g, '_').toLowerCase() || '...'}_flows/</code> and <code className="bg-gray-100 px-1 py-0.5 rounded">{exportName.trim().replace(/\s+/g, '_').toLowerCase() || '...'}_workflows_config.yaml</code>
+                                ZIP will contain: <code className="bg-gray-100 px-1 py-0.5 rounded">flows/</code> and <code className="bg-gray-100 px-1 py-0.5 rounded">{exportName.trim().replace(/\s+/g, '').toLowerCase() || '...'}_workflows_config.yaml</code>
                             </p>
                         </div>
 

--- a/export-docker/import_bundle/README.md
+++ b/export-docker/import_bundle/README.md
@@ -24,7 +24,7 @@ cd backend
 python -m scripts.import_workflows --config /path/to/<your_export_name>_workflows_config.yaml
 ```
 
-*Note: The script safely creates new UUID bounds, updates existing schemas if names match, and automatically links workflow internal dependencies avoiding any data-corruption or primary-key collisions across environments.*
+*Note: The script safely maps new UUID bounds, updates existing schemas if names match, and automatically links workflow internal dependencies avoiding any data-corruption or primary-key collisions across environments.*
 
 ## Workflows
 


### PR DESCRIPTION
- remove spaces instead of replacing with underscores in export name sanitization
- use fixed `flows/` directory instead of dynamic folder naming inside export bundle
- replace export-docker README with generic template to avoid committing credentials and workflow IDs