### PR TITLE
fix: fix infinite loading spinner on sign in page

### DIFF
--- a/client/app/components/AuthGuard.tsx
+++ b/client/app/components/AuthGuard.tsx
@@ -10,10 +10,10 @@ export default function AuthGuard({ children }: { children: React.ReactNode }) {
   const location = useLocation();
   const { user, isAuthenticated, setUser, setIsAuthenticated } = useAuth();
   const [checking, setChecking] = useState(true);
-  const [shouldRedirect, setShouldRedirect] = useState(false);
 
   useEffect(() => {
     const checkAuth = async () => {
+      // Keycloak redirect parametrelerini bekle
       const searchParams = new URLSearchParams(window.location.search);
       if (searchParams.has("code") && searchParams.has("state")) {
         let retries = 0;
@@ -29,7 +29,8 @@ export default function AuthGuard({ children }: { children: React.ReactNode }) {
 
       // 1. Token yoksa signin'e yönlendir
       if (!apiClient.isAuthenticated()) {
-        setShouldRedirect(true);
+        setChecking(false);
+        navigate("/signin", { replace: true, state: { from: location } });
         return;
       }
 
@@ -39,44 +40,38 @@ export default function AuthGuard({ children }: { children: React.ReactNode }) {
           const me = await apiClient.get("/auth/me");
           setUser(me);
           setIsAuthenticated(true);
+          setChecking(false);
         } catch (err) {
-          // Token bozuksa interceptor zaten yönlendirir
+          console.error('Auth check failed:', err);
+          // Token bozuksa temizle ve yönlendir
+          localStorage.removeItem('auth_access_token');
+          localStorage.removeItem('auth_refresh_token');
           setUser(null);
           setIsAuthenticated(false);
           setChecking(false);
-          setShouldRedirect(true);
-          return;
+          navigate("/signin", { replace: true, state: { from: location } });
         }
+      } else {
+        setChecking(false);
       }
-
-      setChecking(false);
     };
 
     checkAuth();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Redirect effect
-  useEffect(() => {
-    if (shouldRedirect) {
-      navigate("/signin", { replace: true, state: { from: location } });
-    }
-  }, [shouldRedirect, navigate, location]);
-
-  // Auth durumu değişirse ve geçerli değilse yönlendir
-  useEffect(() => {
-    if (!checking && (!isAuthenticated || !user)) {
-      setShouldRedirect(true);
-    }
-  }, [checking, isAuthenticated, user]);
-
-  // Auth kontrolü sırasında veya kullanıcı yoksa loading göster
-  if (checking || !isAuthenticated || !user) {
+  // Auth kontrolü sırasında loading göster
+  if (checking) {
     return (
       <div className="flex items-center justify-center min-h-screen">
         <Loader2 className="w-4 h-4 animate-spin" />
       </div>
     );
+  }
+
+  // Auth geçerli değilse null döndür (redirect zaten yapıldı)
+  if (!isAuthenticated || !user) {
+    return null;
   }
 
   return <>{children}</>;

--- a/client/app/components/AuthGuard.tsx
+++ b/client/app/components/AuthGuard.tsx
@@ -13,7 +13,7 @@ export default function AuthGuard({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     const checkAuth = async () => {
-      // Keycloak redirect parametrelerini bekle
+      // Wait for Keycloak redirect parameters
       const searchParams = new URLSearchParams(window.location.search);
       if (searchParams.has("code") && searchParams.has("state")) {
         let retries = 0;
@@ -27,14 +27,14 @@ export default function AuthGuard({ children }: { children: React.ReactNode }) {
         }
       }
 
-      // 1. Token yoksa signin'e yönlendir
+      // 1. If no token, redirect to signin
       if (!apiClient.isAuthenticated()) {
         setChecking(false);
         navigate("/signin", { replace: true, state: { from: location } });
         return;
       }
 
-      // 2. Kullanıcı yoksa backend'den çek
+      // 2. If no user, fetch from backend
       if (!user) {
         try {
           const me = await apiClient.get("/auth/me");
@@ -43,7 +43,7 @@ export default function AuthGuard({ children }: { children: React.ReactNode }) {
           setChecking(false);
         } catch (err) {
           console.error('Auth check failed:', err);
-          // Token bozuksa temizle ve yönlendir
+          // If token is invalid, clear and redirect
           localStorage.removeItem('auth_access_token');
           localStorage.removeItem('auth_refresh_token');
           setUser(null);
@@ -60,7 +60,7 @@ export default function AuthGuard({ children }: { children: React.ReactNode }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Auth kontrolü sırasında loading göster
+  // Show loading during auth check
   if (checking) {
     return (
       <div className="flex items-center justify-center min-h-screen">
@@ -69,7 +69,7 @@ export default function AuthGuard({ children }: { children: React.ReactNode }) {
     );
   }
 
-  // Auth geçerli değilse null döndür (redirect zaten yapıldı)
+  // Return null if auth is invalid (redirect already done)
   if (!isAuthenticated || !user) {
     return null;
   }

--- a/client/app/components/PublicOnlyGuard.tsx
+++ b/client/app/components/PublicOnlyGuard.tsx
@@ -27,12 +27,12 @@ export default function PublicOnlyGuard({
 
   useEffect(() => {
     if (!initializing && !isLoading && isAuthenticated) {
-      // Giriş yapmışsa → anasayfa /
+      // If logged in, redirect to home page
       navigate("/", { replace: true });
     }
   }, [initializing, isLoading, isAuthenticated, navigate]);
 
-  // Initialize veya loading sırasında spinner göster
+  // Show spinner during initialize or loading
   if (initializing || isLoading) {
     return (
       <div className="flex items-center justify-center min-h-screen">
@@ -41,6 +41,6 @@ export default function PublicOnlyGuard({
     );
   }
 
-  // Giriş yapmamışsa, children'ı (örneğin signin formu) göster
+  // If not logged in, show children (e.g., signin form)
   return <>{children}</>;
 }

--- a/client/app/components/PublicOnlyGuard.tsx
+++ b/client/app/components/PublicOnlyGuard.tsx
@@ -10,34 +10,30 @@ export default function PublicOnlyGuard({
 }) {
   const navigate = useNavigate();
   const { isAuthenticated, initialize, isLoading } = useAuth();
-  const [ready, setReady] = useState(false);
+  const [initializing, setInitializing] = useState(true);
 
   useEffect(() => {
     const init = async () => {
-      // localStorage'da token var mı kontrol et
-      const accessToken = localStorage.getItem("auth_access_token");
-
-      if (accessToken) {
-        // Token varsa initialize et
+      try {
         await initialize();
-        setReady(true);
-      } else {
-        // Token yoksa direkt ready yap
-        setReady(true);
+      } catch (error) {
+        console.error('Initialize failed:', error);
+      } finally {
+        setInitializing(false);
       }
     };
     init();
   }, [initialize]);
 
   useEffect(() => {
-    if (ready && isAuthenticated) {
+    if (!initializing && !isLoading && isAuthenticated) {
       // Giriş yapmışsa → anasayfa /
       navigate("/", { replace: true });
     }
-  }, [ready, isAuthenticated, navigate]);
+  }, [initializing, isLoading, isAuthenticated, navigate]);
 
-  // Token yoksa ve ready ise direkt children'ı göster
-  if (!ready) {
+  // Initialize veya loading sırasında spinner göster
+  if (initializing || isLoading) {
     return (
       <div className="flex items-center justify-center min-h-screen">
         <Loader2 className="w-4 h-4 animate-spin" />

--- a/client/app/stores/auth.ts
+++ b/client/app/stores/auth.ts
@@ -42,30 +42,35 @@ export const useAuthStore = create<AuthState>()(
 
     // Initialize auth state from localStorage
     initialize: async () => {
+      set({ isLoading: true });
+      
       const accessToken = localStorage.getItem('auth_access_token');
-      if (accessToken) {
-        set({ isAuthenticated: true, isLoading: true });
-        try {
-          const user = await AuthService.getProfile();
-          set({ 
-            user,
-            isAuthenticated: true,
-            isLoading: false,
-            error: null
-          });
-        } catch (error: any) {
-          // Token expired or invalid, clear it
-          localStorage.removeItem('auth_access_token');
-          localStorage.removeItem('auth_refresh_token');
-          set({ 
-            user: null,
-            isAuthenticated: false,
-            isLoading: false,
-            error: null
-          });
-        }
-      } else {
+      
+      if (!accessToken) {
         // Token yoksa direkt false state'e set et
+        set({ 
+          user: null,
+          isAuthenticated: false,
+          isLoading: false,
+          error: null
+        });
+        return;
+      }
+
+      // Token varsa validate et
+      try {
+        const user = await AuthService.getProfile();
+        set({ 
+          user,
+          isAuthenticated: true,
+          isLoading: false,
+          error: null
+        });
+      } catch (error: any) {
+        // Token expired or invalid, clear it
+        console.error('Token validation failed:', error);
+        localStorage.removeItem('auth_access_token');
+        localStorage.removeItem('auth_refresh_token');
         set({ 
           user: null,
           isAuthenticated: false,

--- a/client/app/stores/auth.ts
+++ b/client/app/stores/auth.ts
@@ -47,7 +47,7 @@ export const useAuthStore = create<AuthState>()(
       const accessToken = localStorage.getItem('auth_access_token');
       
       if (!accessToken) {
-        // Token yoksa direkt false state'e set et
+        // If no token, set state to false directly
         set({ 
           user: null,
           isAuthenticated: false,
@@ -57,7 +57,7 @@ export const useAuthStore = create<AuthState>()(
         return;
       }
 
-      // Token varsa validate et
+      // If token exists, validate it
       try {
         const user = await AuthService.getProfile();
         set({ 
@@ -132,7 +132,7 @@ export const useAuthStore = create<AuthState>()(
     },
 
     signOut: async () => {
-      // Önce state'i temizle
+      // Clear state first
       set({ 
         user: null,
         isAuthenticated: false,
@@ -144,7 +144,7 @@ export const useAuthStore = create<AuthState>()(
       localStorage.removeItem('auth_access_token');
       localStorage.removeItem('auth_refresh_token');
       
-      // API call'u background'da yap
+      // Make API call in background
       try {
         await AuthService.signOut();
       } catch (error) {


### PR DESCRIPTION
- Fix initialize() to always set isLoading to false
- Add proper error handling in auth guards
- Remove race condition in PublicOnlyGuard
- Improve token validation and cleanup
- Fix infinite loading spinner on sign in page
- Clear invalid tokens properly from localStorage