### PR TITLE
fix: prevent infinite loading spinner on sign-in and stop auth refresh loops

### DIFF
--- a/client/app/App.tsx
+++ b/client/app/App.tsx
@@ -38,6 +38,20 @@ function AuthSynchronizer() {
 
   useEffect(() => {
     if (isAuthenticated && user?.access_token) {
+      // Check if token is expired — don't write expired tokens to localStorage
+      try {
+        const payload = JSON.parse(atob(user.access_token.split('.')[1]));
+        const isExpired = payload.exp * 1000 < Date.now();
+        if (isExpired) {
+          console.warn('OIDC token expired, skipping localStorage sync');
+          return;
+        }
+      } catch (e) {
+        // If token cannot be parsed, skip writing
+        console.warn('Could not parse OIDC token, skipping sync:', e);
+        return;
+      }
+
       localStorage.setItem("auth_access_token", user.access_token);
       if (user.refresh_token) {
         localStorage.setItem("auth_refresh_token", user.refresh_token);

--- a/client/app/components/AuthGuard.tsx
+++ b/client/app/components/AuthGuard.tsx
@@ -27,20 +27,28 @@ export default function AuthGuard({ children }: { children: React.ReactNode }) {
         }
       }
 
-      // 1. Token yoksa signin'e yönlendir
+      // 1. No token — redirect to signin
       if (!apiClient.isAuthenticated()) {
         setShouldRedirect(true);
         return;
       }
 
-      // 2. Kullanıcı yoksa backend'den çek
+      // 2. No user in store — fetch from backend
       if (!user) {
         try {
-          const me = await apiClient.get("/auth/me");
-          setUser(me);
+          const me = await Promise.race([
+            apiClient.get("/auth/me"),
+            new Promise((_, reject) =>
+              setTimeout(() => reject(new Error("Auth check timeout")), 5000)
+            ),
+          ]);
+          setUser(me as any);
           setIsAuthenticated(true);
         } catch (err) {
-          // Token bozuksa interceptor zaten yönlendirir
+          // Token invalid or timeout — clear tokens and redirect to signin
+          console.warn("AuthGuard: auth check failed:", err);
+          localStorage.removeItem("auth_access_token");
+          localStorage.removeItem("auth_refresh_token");
           setUser(null);
           setIsAuthenticated(false);
           setChecking(false);
@@ -63,14 +71,14 @@ export default function AuthGuard({ children }: { children: React.ReactNode }) {
     }
   }, [shouldRedirect, navigate, location]);
 
-  // Auth durumu değişirse ve geçerli değilse yönlendir
+  // If auth state changes and becomes invalid, redirect
   useEffect(() => {
     if (!checking && (!isAuthenticated || !user)) {
       setShouldRedirect(true);
     }
   }, [checking, isAuthenticated, user]);
 
-  // Auth kontrolü sırasında veya kullanıcı yoksa loading göster
+  // Show loading during auth check or when user is not loaded
   if (checking || !isAuthenticated || !user) {
     return (
       <div className="flex items-center justify-center min-h-screen">

--- a/client/app/components/PublicOnlyGuard.tsx
+++ b/client/app/components/PublicOnlyGuard.tsx
@@ -14,15 +14,26 @@ export default function PublicOnlyGuard({
 
   useEffect(() => {
     const init = async () => {
-      // localStorage'da token var mı kontrol et
+      // Check if token exists in localStorage
       const accessToken = localStorage.getItem("auth_access_token");
 
       if (accessToken) {
-        // Token varsa initialize et
-        await initialize();
+        try {
+          // Initialize with timeout — proceed if not completed within 5 seconds
+          await Promise.race([
+            initialize(),
+            new Promise((_, reject) =>
+              setTimeout(() => reject(new Error("Auth init timeout")), 5000)
+            ),
+          ]);
+        } catch (error) {
+          console.warn("Auth initialization failed, clearing tokens:", error);
+          localStorage.removeItem("auth_access_token");
+          localStorage.removeItem("auth_refresh_token");
+        }
         setReady(true);
       } else {
-        // Token yoksa direkt ready yap
+        // No token found, set ready immediately
         setReady(true);
       }
     };
@@ -31,12 +42,12 @@ export default function PublicOnlyGuard({
 
   useEffect(() => {
     if (ready && isAuthenticated) {
-      // Giriş yapmışsa → anasayfa /
+      // Already authenticated → redirect to home
       navigate("/", { replace: true });
     }
   }, [ready, isAuthenticated, navigate]);
 
-  // Token yoksa ve ready ise direkt children'ı göster
+  // Show loading spinner until ready
   if (!ready) {
     return (
       <div className="flex items-center justify-center min-h-screen">
@@ -45,6 +56,6 @@ export default function PublicOnlyGuard({
     );
   }
 
-  // Giriş yapmamışsa, children'ı (örneğin signin formu) göster
+  // Not authenticated — render children (e.g. signin form)
   return <>{children}</>;
 }

--- a/client/app/lib/api-client.ts
+++ b/client/app/lib/api-client.ts
@@ -93,6 +93,11 @@ class ApiClient {
             async (error: AxiosError) => {
                 const originalRequest = error.config as any;
 
+                // Skip interceptor logic for auth endpoints
+                if (originalRequest.url?.includes('/auth/signin') || originalRequest.url?.includes('/auth/signup')) {
+                    return Promise.reject(this.handleError(error));
+                }
+
                 if (error.response?.status === 401 && !originalRequest._retry) {
                     if (this.isRefreshing) {
                         // If refresh is already in progress, queue the request
@@ -129,21 +134,20 @@ class ApiClient {
                         } else {
                             this.processQueue(new Error('No refresh token'), null);
                             TokenManager.clearTokens();
-                            // Hard redirect to login - forces full page reload to clear stale React state
-                            if (typeof window !== 'undefined') {
+                            // Redirect to login only if not already on signin page
+                            if (typeof window !== 'undefined' && !window.location.pathname.endsWith('/signin')) {
                                 const basePath = window.VITE_BASE_PATH || '';
-                                window.location.href = `${basePath}/signin`;
-                                return new Promise(() => {}); // Prevent further execution during redirect
+                                window.location.replace(`${basePath}/signin`);
                             }
+                            return Promise.reject(new Error('Authentication failed - no refresh token'));
                         }
                     } catch (refreshError) {
                         this.processQueue(refreshError, null);
                         TokenManager.clearTokens();
-                        // Hard redirect to login - forces full page reload to clear stale React state
-                        if (typeof window !== 'undefined') {
+                        // Redirect to login only if not already on signin page
+                        if (typeof window !== 'undefined' && !window.location.pathname.endsWith('/signin')) {
                             const basePath = window.VITE_BASE_PATH || '';
-                            window.location.href = `${basePath}/signin`;
-                            return new Promise(() => {}); // Prevent further execution during redirect
+                            window.location.replace(`${basePath}/signin`);
                         }
                         return Promise.reject(refreshError);
                     } finally {


### PR DESCRIPTION
- reject unresolved promises in API interceptor to handle timeout errors correctly
- skip auth endpoints in interceptor to avoid recursive token refresh calls
- add Promise.race timeouts and error boundaries in AuthGuard and PublicOnlyGuard to prevent infinite mount state
- validate JWT expiration in AuthSynchronizer to stop syncing expired Keycloak tokens to localStorage