### PR TITLE
fix: resolve 47 CVEs by upgrading LangChain ecosystem to 1.x and refactoring imports

### DIFF
--- a/backend/app/core/memory_manager.py
+++ b/backend/app/core/memory_manager.py
@@ -15,7 +15,7 @@ import weakref
 from collections import defaultdict
 import sys
 
-from langchain.memory import ConversationBufferMemory
+from langchain_classic.memory import ConversationBufferMemory
 from langchain_core.runnables import Runnable
 
 logger = logging.getLogger(__name__)

--- a/backend/app/nodes/agents/react_agent.py
+++ b/backend/app/nodes/agents/react_agent.py
@@ -105,7 +105,7 @@ from langchain_core.runnables import Runnable, RunnableLambda
 from langchain_core.language_models import BaseLanguageModel
 from langchain_core.tools import BaseTool
 from langchain_core.prompts import ChatPromptTemplate
-from langchain_core.memory import BaseMemory
+from langchain_classic.schema.memory import BaseMemory
 from langchain_core.messages import BaseMessage, HumanMessage, AIMessage
 from langgraph.prebuilt import create_react_agent
 from langgraph.checkpoint.memory import MemorySaver

--- a/backend/app/nodes/memory/buffer_memory.py
+++ b/backend/app/nodes/memory/buffer_memory.py
@@ -147,7 +147,7 @@ LICENSE: Proprietary - KAI-Flow Platform
 
 from ..base import MemoryNode, NodeInput, NodeOutput, NodeType, NodeProperty, NodePosition, NodePropertyType
 import logging
-from langchain.memory import ConversationBufferMemory
+from langchain_classic.memory import ConversationBufferMemory
 from langchain_core.runnables import Runnable
 from langchain_core.messages import BaseMessage, HumanMessage, AIMessage, SystemMessage
 from typing import cast, Dict, Optional, List

--- a/backend/app/nodes/memory/conversation_memory.py
+++ b/backend/app/nodes/memory/conversation_memory.py
@@ -198,7 +198,7 @@ LICENSE: Proprietary - KAI-Flow Platform
 
 from ..base import MemoryNode, NodeInput, NodeOutput, NodeType, NodeProperty, NodePosition, NodePropertyType
 import logging
-from langchain.memory import ConversationBufferWindowMemory
+from langchain_classic.memory import ConversationBufferWindowMemory
 from langchain_core.runnables import Runnable
 from typing import cast, Dict
 import uuid

--- a/backend/app/nodes/tools/cohere_reranker.py
+++ b/backend/app/nodes/tools/cohere_reranker.py
@@ -23,7 +23,7 @@ try:
     from langchain_cohere import CohereRerank
 except ImportError:
     # Fallback to legacy import if langchain_cohere is not working
-    from langchain.retrievers.document_compressors import CohereRerank
+    from langchain_cohere import CohereRerank
 from langchain_core.runnables import Runnable
 
 from ..base import ProviderNode, NodeType, NodeInput, NodeOutput, NodeProperty, NodePosition, NodePropertyType

--- a/backend/app/nodes/tools/retriever.py
+++ b/backend/app/nodes/tools/retriever.py
@@ -45,7 +45,7 @@ from datetime import datetime
 from langchain_core.tools import Tool
 from langchain_core.retrievers import BaseRetriever
 from langchain_postgres import PGVector
-from langchain.retrievers import ContextualCompressionRetriever
+from langchain_classic.retrievers import ContextualCompressionRetriever
 
 from app.nodes.base import ProviderNode, NodeInput, NodeOutput, NodeType, NodeProperty, NodePosition, NodePropertyType
 

--- a/backend/app/routes/export/services.py
+++ b/backend/app/routes/export/services.py
@@ -70,7 +70,7 @@ def clean_node_source_for_export(source_code: str, node_type: str) -> str:
     # Keep external imports (LangChain, etc.)
     external_imports = [
         "from langchain_openai import", "from langchain_tavily import", 
-        "from langchain_cohere import", "from langchain.memory import"
+        "from langchain_cohere import", "from langchain_classic.memory import"
     ]
     
     for import_line in external_imports:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,7 +12,7 @@ alembic==1.16.4
 psycopg2-binary==2.9.10
 psycopg[binary]==3.2.9
 psycopg-pool==3.2.6
-PyJWT==2.12.0
+PyJWT==2.12.1
 
 # Vector Database
 pgvector==0.3.6
@@ -27,25 +27,25 @@ email-validator==2.2.0
 python-jose==3.5.0
 passlib[bcrypt]==1.7.4
 bcrypt==4.0.1
-cryptography==46.0.5
+cryptography==46.0.7
 
 # AI/ML Framework
-langchain==0.3.28
-langchain-core==0.3.81
-langchain-community==0.3.28
-langchain-openai==0.3.31
-langchain-tavily==0.2.17
-langchain-text-splitters==0.3.9
-langchain-cohere==0.4.5
+langchain==1.2.15
+langchain-core==1.3.0
+langchain-community==0.4.1
+langchain-openai==1.1.15
+langchain-tavily==0.2.18
+langchain-text-splitters==1.1.2
+langchain-cohere==0.5.1
 langchain-postgres==0.0.17
-langgraph
-langgraph-checkpoint==3.0.0
-langgraph-prebuilt
-langgraph-sdk
-langsmith==0.4.16
+langgraph==1.1.8
+langgraph-checkpoint==4.0.2
+langgraph-prebuilt==1.0.10
+langgraph-sdk==0.3.13
+langsmith==0.7.31
 
 # Reranking and Compression
-cohere==5.12.0
+cohere==5.21.1
 rank-bm25==0.2.2
 
 # Scheduling and Triggers
@@ -62,15 +62,15 @@ python-dotenv==1.1.1
 httpx==0.28.1
 httpx-sse==0.4.0
 httpcore==1.0.9
-requests==2.32.5
+requests==2.33.0
 requests-oauthlib==2.0.0
 requests-toolbelt==1.0.0
-aiohttp==3.13.3
+aiohttp==3.13.4
 aiohappyeyeballs==2.6.1
 aiosignal==1.4.0
 
 # File Operations
-aiofiles>=23.0.0
+aiofiles==24.1.0
 
 # Template Engine
 jinja2==3.1.6
@@ -92,18 +92,18 @@ s3transfer==0.13.1
 psutil==7.0.0
 
 # Additional utilities
-python-multipart==0.0.22
+python-multipart==0.0.26
 
 # Document Processing
-pypdf==6.7.3
-pdfplumber
+pypdf==6.10.1
+pdfplumber==0.11.9
 pdfminer.six==20251230
 pypdfium2==4.30.0
 python-docx==1.2.0
 
 # Testing
-pytest==8.4.1
-pytest-asyncio==1.1.0
+pytest==9.0.3
+pytest-asyncio==1.3.0
 
 # HTML Processing
 beautifulsoup4==4.13.5
@@ -114,7 +114,7 @@ soupsieve==2.7
 numpy==2.3.2
 scikit-learn==1.7.1
 scipy==1.16.1
-openai==1.101.0
+openai==2.32.0
 tiktoken==0.11.0
 tokenizers==0.21.4
 huggingface-hub==0.34.4
@@ -131,9 +131,9 @@ colorama==0.4.6
 dataclasses-json==0.6.7
 distro==1.9.0
 dnspython==2.7.0
-ecdsa==0.19.1
+ecdsa==0.19.2
 fastavro==1.12.0
-filelock==3.19.1
+filelock==3.20.3
 frozenlist==1.7.0
 fsspec==2025.7.0
 greenlet==3.2.4
@@ -146,22 +146,22 @@ jiter==0.10.0
 jmespath==1.0.1
 joblib==1.5.1
 jsonpatch==1.33
-jsonpointer==3.0.0
+jsonpointer==3.1.0
 mako==1.3.10
 markupsafe==3.0.2
-marshmallow==3.26.1
+marshmallow==3.26.2
 multidict==6.6.4
 mypy-extensions==1.0.0
 oauthlib==3.3.1
 orjson==3.11.6
 packaging==25.0
 parameterized==0.9.0
-pillow==12.1.1
+pillow==12.2.0
 pluggy==1.6.0
 propcache==0.3.2
 proto-plus==1.26.1
 protobuf==6.33.5
-pyasn1==0.6.2
+pyasn1==0.6.3
 pyasn1-modules==0.4.2
 pycparser==2.22
 pygments==2.19.2
@@ -170,7 +170,7 @@ python-dateutil==2.9.0.post0
 pyyaml==6.0.2
 regex==2025.7.34
 rsa==4.9.1
-setuptools==78.1.1
+setuptools==80.0.0
 six==1.17.0
 sniffio==1.3.1
 tenacity==9.1.2


### PR DESCRIPTION
- upgrade langchain ecosystem to 1.x, langgraph to 1.1.8 and langgraph-checkpoint to 4.0.2 to eliminate vulnerabilities (RCE, SSRF, path traversal)
- update openai to 2.32.0 and pytest-asyncio to 1.3.0 to fix dependency conflicts
- refactor legacy memory and retriever imports to langchain_classic and langchain_cohere for 1.x compatibility