### PR TITLE
feat: enable node duplication via context menu with clean state cloning

### DIFF
--- a/client/app/components/canvas/FlowCanvas.tsx
+++ b/client/app/components/canvas/FlowCanvas.tsx
@@ -42,6 +42,7 @@ import ChatHistorySidebar from "./ChatHistorySidebar";
 import SidebarToggleButton from "./SidebarToggleButton";
 import ErrorDisplayComponent from "./ErrorDisplayComponent";
 import ReactFlowCanvas from "./ReactFlowCanvas";
+import NodeContextMenu from "./NodeContextMenu";
 import Navbar from "../common/Navbar";
 import Sidebar from "../common/Sidebar";
 import EndNode from "../node/EndNode";
@@ -167,6 +168,13 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
   const [pendingNavigation, setPendingNavigation] = useState<string | null>(
     null
   );
+
+  // Context Menu state
+  const [contextMenu, setContextMenu] = useState<{
+    x: number;
+    y: number;
+    nodeId: string;
+  } | null>(null);
 
   // Auto-save settings modal ref
   const autoSaveSettingsModalRef = useRef<HTMLDialogElement>(null);
@@ -661,6 +669,74 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
     setHasUnsavedChanges,
     workflowName,
   ]);
+
+  // Context Menu Handlers
+  const onNodeContextMenu = useCallback(
+    (event: React.MouseEvent, node: Node) => {
+      event.preventDefault();
+      setContextMenu({
+        x: event.clientX,
+        y: event.clientY,
+        nodeId: node.id,
+      });
+    },
+    []
+  );
+
+  const onPaneClick = useCallback(() => {
+    setContextMenu(null);
+  }, []);
+
+  const duplicateNode = useCallback(
+    (nodeId: string) => {
+      setNodes((currentNodes) => {
+        const originalNode = currentNodes.find((n) => n.id === nodeId);
+        if (!originalNode) return currentNodes;
+
+        const clonedNode = JSON.parse(JSON.stringify(originalNode));
+        const newUuid = uuidv4();
+        const baseNodeType = clonedNode.type || "GenericNode";
+        const newId = `${baseNodeType}__${newUuid}`;
+
+        let originalName = clonedNode.data?.name || "Node";
+        let newName = `${originalName}_copy`; // Adds '_copy' cumulatively each time
+
+        let display_name = clonedNode.data?.display_name || clonedNode.data?.displayName || clonedNode.data?.metadata?.display_name || "Generic Node";
+        let newDisplayName = display_name; // Ensure the display name in the icon doesn't change
+
+        const newNode: Node = {
+          ...clonedNode,
+          id: newId,
+          position: {
+            x: clonedNode.position.x + 150,
+            y: clonedNode.position.y,
+          },
+          data: {
+            ...clonedNode.data,
+            id: newId,
+            name: newName, // Internal naming changes (e.g., agent_copy_copy)
+            display_name: newDisplayName, // Display name remains the same!
+            displayName: newDisplayName, // Added as a fallback
+          },
+          selected: false,
+        };
+
+        // Log the duplication process
+        console.log(`[Node Clone] Node duplicated: ${originalName} -> ${newName}`, {
+          originalId: originalNode.id,
+          newId: newNode.id,
+          nodeType: newNode.type,
+          nodeData: newNode.data
+        });
+
+        return [...currentNodes, newNode];
+      });
+
+      enqueueSnackbar("Node duplicated", { variant: "info", autoHideDuration: 2000 });
+      setContextMenu(null);
+    },
+    [setNodes, enqueueSnackbar]
+  );
 
   // Auto-save function
   const handleAutoSave = useCallback(async () => {
@@ -1389,7 +1465,20 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
             nodeStatus={nodeStatus}
             edgeStatus={edgeStatus}
             onNodeClick={handleNodeClick}
+            onNodeContextMenu={onNodeContextMenu}
+            onPaneClick={onPaneClick}
           />
+
+          {/* Context Menu Render */}
+          {contextMenu && (
+            <NodeContextMenu
+              x={contextMenu.x}
+              y={contextMenu.y}
+              nodeId={contextMenu.nodeId}
+              onDuplicate={duplicateNode}
+              onClose={() => setContextMenu(null)}
+            />
+          )}
 
           {/* Chat Toggle Button */}
           <button

--- a/client/app/components/canvas/NodeContextMenu.tsx
+++ b/client/app/components/canvas/NodeContextMenu.tsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useRef } from "react";
+import { Copy } from "lucide-react";
+
+interface NodeContextMenuProps {
+    x: number;
+    y: number;
+    nodeId: string;
+    onDuplicate: (nodeId: string) => void;
+    onClose: () => void;
+}
+
+const NodeContextMenu: React.FC<NodeContextMenuProps> = ({
+    x,
+    y,
+    nodeId,
+    onDuplicate,
+    onClose,
+}) => {
+    const menuRef = useRef<HTMLDivElement>(null);
+
+    // Dışarıya tıklandığında menüyü kapat
+    useEffect(() => {
+        const handleClickOutside = (e: MouseEvent) => {
+            if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+                onClose();
+            }
+        };
+
+        document.addEventListener("mousedown", handleClickOutside);
+        return () => {
+            document.removeEventListener("mousedown", handleClickOutside);
+        };
+    }, [onClose]);
+
+    return (
+        <div
+            ref={menuRef}
+            style={{
+                top: y,
+                left: x,
+            }}
+            className="fixed z-[1000] min-w-[150px] bg-black/80 backdrop-blur-md border border-white/10 rounded-xl shadow-2xl overflow-hidden animate-in fade-in zoom-in-95 duration-200"
+        >
+            <div className="py-1">
+                <button
+                    onClick={() => {
+                        onDuplicate(nodeId);
+                        onClose();
+                    }}
+                    className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-cyan-50 hover:bg-white/10 transition-colors bg-transparent border-none cursor-pointer text-left focus:outline-none"
+                >
+                    <Copy size={16} className="text-cyan-400" />
+                    <span className="font-medium">Clone Node</span>
+                </button>
+            </div>
+        </div>
+    );
+};
+
+export default NodeContextMenu;

--- a/client/app/components/canvas/ReactFlowCanvas.tsx
+++ b/client/app/components/canvas/ReactFlowCanvas.tsx
@@ -29,6 +29,8 @@ interface ReactFlowCanvasProps {
   nodeStatus?: Record<string, 'success' | 'failed' | 'pending'>;
   edgeStatus?: Record<string, 'success' | 'failed' | 'pending'>;
   onNodeClick?: (event: React.MouseEvent, node: Node) => void;
+  onNodeContextMenu?: (event: React.MouseEvent, node: Node) => void;
+  onPaneClick?: (event: React.MouseEvent) => void;
 }
 
 export default function ReactFlowCanvas({
@@ -46,6 +48,8 @@ export default function ReactFlowCanvas({
   nodeStatus = {},
   edgeStatus = {},
   onNodeClick,
+  onNodeContextMenu,
+  onPaneClick,
 }: ReactFlowCanvasProps) {
   return (
     <div
@@ -85,6 +89,8 @@ export default function ReactFlowCanvas({
         snapGrid={[10, 10]}
         fitView
         onNodeClick={onNodeClick}
+        onNodeContextMenu={onNodeContextMenu}
+        onPaneClick={onPaneClick}
         proOptions={{ hideAttribution: true }}
       >
         <Controls position="top-right" className="bg-background text-black" />


### PR DESCRIPTION
- add NodeContextMenu for right-click duplication with glass-style UI
- handle onNodeContextMenu and onPaneClick events in ReactFlowCanvas
- deep clone nodes without React event bindings or edge references
- append incremental _copy suffix to internal node names to avoid conflicts
- preserve display_name for consistent UI rendering
- position duplicated nodes with +150px offset