### PR TITLE
fix: eliminate RCE, SSRF and path traversal risks by upgrading LangChain stack to 1.x

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -33,7 +33,7 @@ cryptography==46.0.7
 langchain==1.2.15
 langchain-core==1.3.0
 langchain-community==0.4.1
-langchain-openai==1.1.15
+langchain-openai==1.2.0
 langchain-tavily==0.2.18
 langchain-text-splitters==1.1.2
 langchain-cohere==0.5.1
@@ -56,7 +56,7 @@ tzdata==2025.2
 tzlocal==5.3.1
 
 # Environment
-python-dotenv==1.1.1
+python-dotenv==1.2.2
 
 # HTTP Client
 httpx==0.28.1
@@ -79,7 +79,7 @@ jinja2==3.1.6
 google-api-python-client==2.179.0
 google-auth==2.40.3
 google-auth-oauthlib==1.2.2
-google-auth-httplib2==0.2.0
+google-auth-httplib2==0.3.1
 google-api-core==2.25.1
 googleapis-common-protos==1.70.0
 
@@ -95,7 +95,7 @@ psutil==7.0.0
 python-multipart==0.0.26
 
 # Document Processing
-pypdf==6.10.1
+pypdf==6.10.2
 pdfplumber==0.11.9
 pdfminer.six==20251230
 pypdfium2==4.30.0
@@ -146,8 +146,8 @@ jiter==0.10.0
 jmespath==1.0.1
 joblib==1.5.1
 jsonpatch==1.33
-jsonpointer==3.1.0
-mako==1.3.10
+jsonpointer==3.1.1
+mako==1.3.11
 markupsafe==3.0.2
 marshmallow==3.26.2
 multidict==6.6.4


### PR DESCRIPTION
- upgrade langchain ecosystem to 1.x, langgraph to 1.1.8 and langgraph-checkpoint to 4.0.2 with patched versions
- update openai to 2.32.0 and pytest-asyncio to 1.3.0 to resolve dependency conflicts
- migrate legacy memory and retriever imports to langchain_classic and langchain_cohere for 1.x compatibility