### PR TITLE
fix: prevent consumer deadlocks and apply workflow visibility changes without delay

### DIFF
--- a/backend/app/api/workflows.py
+++ b/backend/app/api/workflows.py
@@ -670,8 +670,11 @@ async def update_workflow_visibility(
         
         if not workflow:
             raise HTTPException(status_code=404, detail="Workflow not found")
+            
+        from app.nodes.triggers.kafka_trigger import kafka_reconciliation_wakeup
+        kafka_reconciliation_wakeup.set()
         
-        logger.info(f"Updated workflow {workflow_id} visibility to {'public' if is_public else 'private'}")
+        logger.info(f"Updated workflow {workflow_id} visibility to {'public' if is_public else 'private'} and triggered reconciliation")
         return {"message": f"Workflow visibility updated to {'public' if is_public else 'private'}"}
     except HTTPException:
         raise

--- a/backend/app/nodes/triggers/kafka_trigger.py
+++ b/backend/app/nodes/triggers/kafka_trigger.py
@@ -164,16 +164,20 @@ class KafkaListenerService:
 
         task = entry.get("task")
         if task and not task.done():
-            task.cancel()
             try:
-                await asyncio.wait_for(asyncio.shield(task), timeout=10)
-            except (asyncio.CancelledError, asyncio.TimeoutError):
-                pass
+                await asyncio.wait_for(task, timeout=5.0)
+            except asyncio.TimeoutError:
+                logger.warning(f"Consumer {listener_id} It wasn't shut down on time; it's being forcibly cancelled.")
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
 
         # Memory leak fix: stopped listener'ı dict'ten sil
         del cls._listeners[listener_id]
 
-        logger.info(f"Kafka listener durduruldu ve temizlendi: {listener_id}")
+        logger.info(f"Kafka listener has been stopped and cleaned: {listener_id}")
 
         return {"status": "stopped", "listener_id": listener_id}
 
@@ -766,6 +770,8 @@ async def _start_from_desired(node_id: str, desired_entry: Dict[str, Any]):
     )
 
 
+kafka_reconciliation_wakeup = asyncio.Event()
+
 async def kafka_reconciliation_loop(interval: int = KAFKA_RECONCILIATION_INTERVAL_SECONDS):
     """
     Periyodik Kafka listener reconciliation döngüsü.
@@ -787,7 +793,11 @@ async def kafka_reconciliation_loop(interval: int = KAFKA_RECONCILIATION_INTERVA
 
     while True:
         if not first_run:
-            await asyncio.sleep(interval)
+            try:
+                await asyncio.wait_for(kafka_reconciliation_wakeup.wait(), timeout=interval)
+                kafka_reconciliation_wakeup.clear()
+            except asyncio.TimeoutError:
+                pass
         first_run = False
 
         try:


### PR DESCRIPTION
- wait for consumer tasks to complete in stop_listener to ensure proper shutdown and avoid thread pool exhaustion
- add kafka_reconciliation_wakeup event to trigger immediate reconciliation
- trigger wakeup from update_workflow_visibility endpoint to apply visibility changes instantly
- improve logging for Kafka consumer shutdown process