### PR TITLE
fix: upgrade langchain-core to maintain compatibility across LangChain backend packages

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -31,7 +31,7 @@ cryptography==46.0.7
 
 # AI/ML Framework
 langchain==1.2.16
-langchain-core==1.3.2
+langchain-core==1.3.3
 langchain-community==0.4.1
 langchain-openai==1.2.1
 langchain-tavily==0.2.18


### PR DESCRIPTION
- bump langchain-core from 1.3.2 to 1.3.3 in requirements.txt
- align backend dependency versions with current LangChain ecosystem releases
- prevent compatibility issues caused by mismatched LangChain package versions