### PR TITLE
fix: resolve provider edge animations

### DIFF
--- a/backend/app/core/graph_builder/__init__.py
+++ b/backend/app/core/graph_builder/__init__.py
@@ -127,6 +127,9 @@ class GraphBuilder:
         self.explicit_start_nodes: set[str] = set()
         self.end_nodes_for_connections: Dict[str, Dict[str, Any]] = {}
         self.graph: Optional[CompiledStateGraph] = None
+        self.visual_edges: List[Dict[str, Any]] = []
+        self._incoming_visual_edges: Dict[str, List[Dict[str, Any]]] = {}
+        self._outgoing_visual_edges: Dict[str, List[Dict[str, Any]]] = {}
         
         # Enhanced metrics and monitoring
         self._build_metrics: Dict[str, Any] = {}
@@ -230,6 +233,9 @@ class GraphBuilder:
         self.control_flow_nodes.clear()
         self.explicit_start_nodes.clear()
         self.end_nodes_for_connections.clear()
+        self.visual_edges.clear()
+        self._incoming_visual_edges.clear()
+        self._outgoing_visual_edges.clear()
 
         # Analyze existing nodes
         start_nodes = [n for n in nodes if n.get("type") == "StartNode"]
@@ -260,6 +266,43 @@ class GraphBuilder:
             "entry_node_ids": entry_node_ids,
             "end_node_ids": end_node_ids
         }
+
+    def _index_visual_edges(self, edges: List[Dict[str, Any]]) -> None:
+        """Index original canvas edges so stream events can reference real UI edge IDs."""
+        self.visual_edges = [edge for edge in edges if edge.get("source") and edge.get("target")]
+        self._incoming_visual_edges = {}
+        self._outgoing_visual_edges = {}
+
+        for edge in self.visual_edges:
+            self._incoming_visual_edges.setdefault(edge["target"], []).append(edge)
+            self._outgoing_visual_edges.setdefault(edge["source"], []).append(edge)
+
+    def _visual_edge_ids_for_node(
+        self,
+        node_id: str,
+        previous_node_id: Optional[str] = None,
+    ) -> List[str]:
+        """Return the canvas edge IDs that represent data entering node_id."""
+        incoming = self._incoming_visual_edges.get(node_id, [])
+        if not incoming:
+            return []
+
+        if previous_node_id:
+            matched = [edge for edge in incoming if edge.get("source") == previous_node_id]
+            if matched:
+                return [edge.get("id") or self._fallback_edge_id(edge) for edge in matched]
+
+        return [edge.get("id") or self._fallback_edge_id(edge) for edge in incoming]
+
+    def _visual_outgoing_edge_ids_for_node(self, node_id: str) -> List[str]:
+        outgoing = self._outgoing_visual_edges.get(node_id, [])
+        return [edge.get("id") or self._fallback_edge_id(edge) for edge in outgoing]
+
+    @staticmethod
+    def _fallback_edge_id(edge: Dict[str, Any]) -> str:
+        source_handle = edge.get("sourceHandle") or "output"
+        target_handle = edge.get("targetHandle") or "input"
+        return f"{edge.get('source')}-{source_handle}-{edge.get('target')}-{target_handle}"
 
     def _handle_start_end_nodes(self, workflow_data: Dict) -> Dict[str, Any]:
         """Handle StartNode, WebhookTrigger, KafkaConsumer/KafkaTrigger, and EndNode special cases."""
@@ -318,6 +361,8 @@ class GraphBuilder:
             # Update end_nodes and end_node_ids after adding virtual node
             end_nodes.append(virtual_end_node)
             end_node_ids.add("virtual-end-node")
+
+        self._index_visual_edges(edges)
 
         # Identify explicit start connections from StartNodes
         start_node_targets = {e["target"] for e in edges if e.get("source") in start_node_ids}
@@ -896,15 +941,24 @@ class GraphBuilder:
                 node_name = ev.get("name", "unknown")
                 
                 if ev_type == "on_chain_start":
+                    if node_name not in self.nodes:
+                        continue
+                    incoming_edge_ids = self._visual_edge_ids_for_node(node_name, previous_node_id)
                     yield {
                         "type": "node_start", 
                         "node_id": node_name,
-                        "previous_node_id": previous_node_id  # Include previous node for edge animation
+                        "previous_node_id": previous_node_id,
+                        "incoming_edge_ids": incoming_edge_ids,
+                        "active_edge_ids": incoming_edge_ids,
+                        "outgoing_edge_ids": self._visual_outgoing_edge_ids_for_node(node_name),
                     }
                 elif ev_type == "on_chain_end":
+                    if node_name not in self.nodes:
+                        continue
                     # Extract output from the event data for node_end
                     ev_data = ev.get("data", {})
                     node_output = ev_data.get("output", {})
+                    incoming_edge_ids = self._visual_edge_ids_for_node(node_name, previous_node_id)
                     
                     # Try to extract meaningful output from various formats
                     output_data = {}
@@ -924,6 +978,10 @@ class GraphBuilder:
                     yield {
                         "type": "node_end",
                         "node_id": node_name,
+                        "previous_node_id": previous_node_id,
+                        "incoming_edge_ids": incoming_edge_ids,
+                        "active_edge_ids": incoming_edge_ids,
+                        "outgoing_edge_ids": self._visual_outgoing_edge_ids_for_node(node_name),
                         "output": output_data
                     }
                     

--- a/backend/app/nodes/triggers/kafka_trigger.py
+++ b/backend/app/nodes/triggers/kafka_trigger.py
@@ -24,6 +24,31 @@ logger = logging.getLogger(__name__)
 
 # Kafka reconciliation loop execution interval (seconds)
 KAFKA_RECONCILIATION_INTERVAL_SECONDS = 60
+KAFKA_STREAM_MAX_QUEUE_LENGTH = 100
+kafka_execution_subscribers: Dict[str, List[asyncio.Queue]] = {}
+
+
+async def broadcast_kafka_execution_event(listener_id: str, event: Dict[str, Any]) -> None:
+    """Broadcast Kafka-triggered workflow execution events to canvas subscribers."""
+    subscribers = kafka_execution_subscribers.get(listener_id, [])
+    if not subscribers:
+        return
+
+    stale_subscribers: List[asyncio.Queue] = []
+    for queue in subscribers.copy():
+        try:
+            if queue.qsize() >= KAFKA_STREAM_MAX_QUEUE_LENGTH:
+                stale_subscribers.append(queue)
+                continue
+            queue.put_nowait(event)
+        except asyncio.QueueFull:
+            stale_subscribers.append(queue)
+        except Exception:
+            stale_subscribers.append(queue)
+
+    for queue in stale_subscribers:
+        if queue in subscribers:
+            subscribers.remove(queue)
 
 
 # ══════════════════════════════════════════════════════════════════
@@ -530,11 +555,31 @@ class KafkaListenerService:
                 is_webhook=False,      # Kafka trigger webhook değil
             )
 
-            result = await executor.execute_workflow(
+            result_stream = await executor.execute_workflow(
                 ctx=ctx,
                 db=db,
-                stream=False,
+                stream=True,
             )
+
+            result = None
+            if hasattr(result_stream, "__aiter__"):
+                async for event_chunk in result_stream:
+                    if isinstance(event_chunk, dict):
+                        if event_chunk.get("type") in ("complete", "workflow_complete"):
+                            result = event_chunk
+
+                        ui_event = {
+                            "type": "kafka_execution_event",
+                            "listener_id": listener_id,
+                            "workflow_id": str(workflow.id),
+                            "execution_id": str(ctx.execution_id) if ctx.execution_id else None,
+                            "event": event_chunk,
+                            "kafka_payload": message_data,
+                            "timestamp": datetime.now(timezone.utc).isoformat(),
+                        }
+                        await broadcast_kafka_execution_event(listener_id, ui_event)
+            else:
+                result = result_stream
 
             # Check execution result for errors
             if isinstance(result, dict) and result.get("success") is False:
@@ -873,6 +918,42 @@ async def kafka_reconciliation_loop(interval: int = KAFKA_RECONCILIATION_INTERVA
 # ══════════════════════════════════════════════════════════════════
 
 kafka_router = APIRouter(prefix=f"/{API_START}/{API_VERSION}/kafka")
+
+
+@kafka_router.get("/listeners/{listener_id}/stream")
+async def stream_kafka_listener_execution(listener_id: str):
+    """Stream Kafka-triggered workflow execution events for the canvas UI."""
+
+    async def event_stream():
+        queue: asyncio.Queue = asyncio.Queue(maxsize=KAFKA_STREAM_MAX_QUEUE_LENGTH)
+        kafka_execution_subscribers.setdefault(listener_id, []).append(queue)
+
+        try:
+            yield f"data: {json.dumps({'type': 'connected', 'listener_id': listener_id, 'timestamp': datetime.now(timezone.utc).isoformat()}, ensure_ascii=False)}\n\n"
+
+            while True:
+                try:
+                    event = await asyncio.wait_for(queue.get(), timeout=30.0)
+                    yield f"data: {json.dumps(event, ensure_ascii=False, default=str)}\n\n"
+                except asyncio.TimeoutError:
+                    yield f"data: {json.dumps({'type': 'ping', 'timestamp': datetime.now(timezone.utc).isoformat()}, ensure_ascii=False)}\n\n"
+        except asyncio.CancelledError:
+            pass
+        finally:
+            subscribers = kafka_execution_subscribers.get(listener_id, [])
+            if queue in subscribers:
+                subscribers.remove(queue)
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Headers": "*",
+        },
+    )
 
 
 @kafka_router.post("/listeners/{listener_id}/stop")

--- a/backend/app/nodes/triggers/webhook_trigger.py
+++ b/backend/app/nodes/triggers/webhook_trigger.py
@@ -1021,7 +1021,7 @@ async def get_webhook_production(
     background_tasks: BackgroundTasks,
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(HTTPBearer(auto_error=False))
 ):
-    return await handle_webhook_request(webhook_id, request, background_tasks, credentials, enable_frontend_stream=False)
+    return await handle_webhook_request(webhook_id, request, background_tasks, credentials, enable_frontend_stream=True)
 
 @webhook_production_router.post("/{webhook_id}")
 async def post_webhook_production(
@@ -1030,7 +1030,7 @@ async def post_webhook_production(
     background_tasks: BackgroundTasks,
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(HTTPBearer(auto_error=False))
 ):
-    return await handle_webhook_request(webhook_id, request, background_tasks, credentials, enable_frontend_stream=False)
+    return await handle_webhook_request(webhook_id, request, background_tasks, credentials, enable_frontend_stream=True)
 
 @webhook_production_router.put("/{webhook_id}")
 async def put_webhook_production(
@@ -1039,7 +1039,7 @@ async def put_webhook_production(
     background_tasks: BackgroundTasks,
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(HTTPBearer(auto_error=False))
 ):
-    return await handle_webhook_request(webhook_id, request, background_tasks, credentials, enable_frontend_stream=False)
+    return await handle_webhook_request(webhook_id, request, background_tasks, credentials, enable_frontend_stream=True)
 
 @webhook_production_router.patch("/{webhook_id}")
 async def patch_webhook_production(
@@ -1048,7 +1048,7 @@ async def patch_webhook_production(
     background_tasks: BackgroundTasks,
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(HTTPBearer(auto_error=False))
 ):
-    return await handle_webhook_request(webhook_id, request, background_tasks, credentials, enable_frontend_stream=False)
+    return await handle_webhook_request(webhook_id, request, background_tasks, credentials, enable_frontend_stream=True)
 
 @webhook_production_router.delete("/{webhook_id}")
 async def delete_webhook_production(
@@ -1057,7 +1057,7 @@ async def delete_webhook_production(
     background_tasks: BackgroundTasks,
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(HTTPBearer(auto_error=False))
 ):
-    return await handle_webhook_request(webhook_id, request, background_tasks, credentials, enable_frontend_stream=False)
+    return await handle_webhook_request(webhook_id, request, background_tasks, credentials, enable_frontend_stream=True)
 
 @webhook_production_router.head("/{webhook_id}")
 async def head_webhook_production(
@@ -1066,7 +1066,7 @@ async def head_webhook_production(
     background_tasks: BackgroundTasks,
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(HTTPBearer(auto_error=False))
 ):
-    return await handle_webhook_request(webhook_id, request, background_tasks, credentials, enable_frontend_stream=False)
+    return await handle_webhook_request(webhook_id, request, background_tasks, credentials, enable_frontend_stream=True)
 
 # Webhook streaming endpoint - PRODUCTION ROUTER (empty stream, no frontend events)
 @webhook_production_router.get("/{webhook_id}/stream")

--- a/client/app/components/canvas/FlowCanvas.tsx
+++ b/client/app/components/canvas/FlowCanvas.tsx
@@ -157,12 +157,12 @@ const isProviderNode = (node?: Node): boolean => {
   if (!node?.type) return false;
   const providerTypes = [
     "OpenAINode", "OpenAIChat", "OpenAICompatibleNode",
-    "OpenAIEmbeddingsProvider",
+    "OpenAIEmbeddingsProvider", "OpenAIEmbeddings", "CohereEmbeddings",
     "BufferMemoryNode", "BufferMemory",
     "ConversationMemoryNode", "ConversationMemory",
     "RetrieverProvider",
     "TavilySearchNode", "TavilySearch",
-    "CohereRerankerNode",
+    "CohereRerankerNode", "CohereRerankerProvider",
     "VectorStoreOrchestrator",
     "ChunkSplitterNode", "ChunkSplitter",
     "DocumentLoaderNode",
@@ -187,14 +187,29 @@ const resolveExecutionEdges = (
     const eventEdgeSet = new Set(eventEdgeIds);
     const eventEdges = edges.filter((edge) => eventEdgeSet.has(edge.id));
 
-    // Processor node ise (Agent gibi), backend'den gelmese bile provider'lardan gelen edge'leri ekle
     if (isProcessorNode(actualNode)) {
-      const allIncomingEdges = edges.filter((e) => e.target === actualNode.id);
-      const extraProviderEdges = allIncomingEdges.filter((edge) => {
-        if (eventEdgeSet.has(edge.id)) return false; // zaten listede var
-        const sourceNode = nodes.find((n) => n.id === edge.source);
-        return isProviderNode(sourceNode);
-      });
+      const extraProviderEdges: Edge[] = [];
+      const nodesToCheck = [actualNode.id];
+      const checkedNodes = new Set<string>();
+
+      while (nodesToCheck.length > 0) {
+        const currentNodeId = nodesToCheck.pop()!;
+        if (checkedNodes.has(currentNodeId)) continue;
+        checkedNodes.add(currentNodeId);
+
+        const incomingEdges = edges.filter((e) => e.target === currentNodeId);
+
+        for (const edge of incomingEdges) {
+          const sourceNode = nodes.find((n) => n.id === edge.source);
+          if (isProviderNode(sourceNode)) {
+            if (!eventEdgeSet.has(edge.id) && !extraProviderEdges.some(e => e.id === edge.id)) {
+              extraProviderEdges.push(edge);
+            }
+            nodesToCheck.push(sourceNode!.id);
+          }
+        }
+      }
+
       return [...eventEdges, ...extraProviderEdges];
     }
     return eventEdges;
@@ -1927,18 +1942,24 @@ function useChatExecutionListener(
             [actualNode.id]: "success",
           }));
 
-          // Only mark the edge that was set as pending (from node_start) as success
-          // This ensures only the actual execution flow edge gets marked
-          setEdgeStatus((prev) => {
-            const updated = { ...prev };
-            Object.keys(updated).forEach((edgeId) => {
-              const edge = edges.find((e) => e.id === edgeId);
-              if (edge && edge.target === actualNode.id && updated[edgeId] === "pending") {
-                updated[edgeId] = "success";
-              }
+          const completedEdges = resolveExecutionEdges(data, actualNode, nodes, edges);
+          if (completedEdges.length > 0) {
+            setEdgeStatus((prev) => ({
+              ...prev,
+              ...Object.fromEntries(completedEdges.map((e) => [e.id, "success" as const])),
+            }));
+          } else {
+            setEdgeStatus((prev) => {
+              const updated = { ...prev };
+              Object.keys(updated).forEach((edgeId) => {
+                const edge = edges.find((e) => e.id === edgeId);
+                if (edge && edge.target === actualNode.id && updated[edgeId] === "pending") {
+                  updated[edgeId] = "success";
+                }
+              });
+              return updated;
             });
-            return updated;
-          });
+          }
         }
       }
     };

--- a/client/app/components/canvas/FlowCanvas.tsx
+++ b/client/app/components/canvas/FlowCanvas.tsx
@@ -185,7 +185,19 @@ const resolveExecutionEdges = (
   const eventEdgeIds = getEventEdgeIds(eventData);
   if (eventEdgeIds.length > 0) {
     const eventEdgeSet = new Set(eventEdgeIds);
-    return edges.filter((edge) => eventEdgeSet.has(edge.id));
+    const eventEdges = edges.filter((edge) => eventEdgeSet.has(edge.id));
+
+    // Processor node ise (Agent gibi), backend'den gelmese bile provider'lardan gelen edge'leri ekle
+    if (isProcessorNode(actualNode)) {
+      const allIncomingEdges = edges.filter((e) => e.target === actualNode.id);
+      const extraProviderEdges = allIncomingEdges.filter((edge) => {
+        if (eventEdgeSet.has(edge.id)) return false; // zaten listede var
+        const sourceNode = nodes.find((n) => n.id === edge.source);
+        return isProviderNode(sourceNode);
+      });
+      return [...eventEdges, ...extraProviderEdges];
+    }
+    return eventEdges;
   }
 
   const allIncomingEdges = edges.filter((edge) => edge.target === actualNode.id);

--- a/client/app/components/canvas/FlowCanvas.tsx
+++ b/client/app/components/canvas/FlowCanvas.tsx
@@ -110,6 +110,121 @@ const normalizeFlowDataForComparison = (flowData: WorkflowData | undefined): str
   return stableStringify({ nodes: normalizedNodes, edges: normalizedEdges });
 };
 
+const findCanvasNode = (nodes: Node[], nodeId?: string): Node | undefined => {
+  if (!nodeId) return undefined;
+
+  const exact = nodes.find((n) => n.id === nodeId);
+  if (exact) return exact;
+
+  return nodes.find((n) => {
+    if (n.data?.name === nodeId || n.data?.node_name === nodeId) return true;
+    if (n.type === nodeId) {
+      return nodes.filter((node) => node.type === n.type).length === 1;
+    }
+
+    const cleanNodeId = nodeId.includes("__")
+      ? nodeId.split("__")[0]
+      : nodeId.replace(/\-\d+$/, "");
+
+    return !!n.type && n.type === cleanNodeId && nodes.filter((node) => node.type === n.type).length === 1;
+  });
+};
+
+const getEventEdgeIds = (eventData: any): string[] => {
+  const raw =
+    eventData?.active_edge_ids ??
+    eventData?.incoming_edge_ids ??
+    eventData?.edge_ids ??
+    eventData?.edge_id ??
+    [];
+
+  if (Array.isArray(raw)) return raw.filter(Boolean).map(String);
+  return raw ? [String(raw)] : [];
+};
+
+const isProcessorNode = (node?: Node): boolean => {
+  if (!node?.type) return false;
+  const processorTypes = [
+    "ReactAgentNode", "Agent",
+    "VectorStoreOrchestrator",
+    "ChunkSplitterNode", "ChunkSplitter",
+    "CodeNode", "ConditionNode", "JsonParserNode",
+  ];
+  return processorTypes.some((type) => node.type?.includes(type) || node.type === type);
+};
+
+const isProviderNode = (node?: Node): boolean => {
+  if (!node?.type) return false;
+  const providerTypes = [
+    "OpenAINode", "OpenAIChat", "OpenAICompatibleNode",
+    "OpenAIEmbeddingsProvider",
+    "BufferMemoryNode", "BufferMemory",
+    "ConversationMemoryNode", "ConversationMemory",
+    "RetrieverProvider",
+    "TavilySearchNode", "TavilySearch",
+    "CohereRerankerNode",
+    "VectorStoreOrchestrator",
+    "ChunkSplitterNode", "ChunkSplitter",
+    "DocumentLoaderNode",
+    "WebScraperNode", "WebScraper",
+    "StringInputNode",
+  ];
+  return providerTypes.some((type) =>
+    node.type?.includes(type) ||
+    (node.type ? type.includes(node.type) : false) ||
+    node.type === type
+  );
+};
+
+const resolveExecutionEdges = (
+  eventData: any,
+  actualNode: Node,
+  nodes: Node[],
+  edges: Edge[]
+): Edge[] => {
+  const eventEdgeIds = getEventEdgeIds(eventData);
+  if (eventEdgeIds.length > 0) {
+    const eventEdgeSet = new Set(eventEdgeIds);
+    return edges.filter((edge) => eventEdgeSet.has(edge.id));
+  }
+
+  const allIncomingEdges = edges.filter((edge) => edge.target === actualNode.id);
+  const previousNodeId = eventData?.previous_node_id;
+
+  let executionFlowEdge: Edge | null = null;
+  if (previousNodeId) {
+    executionFlowEdge =
+      allIncomingEdges.find((edge) => edge.source === previousNodeId) || null;
+
+    if (!executionFlowEdge) {
+      const cleanPrevId = previousNodeId.includes("__")
+        ? previousNodeId.split("__")[0]
+        : previousNodeId;
+      executionFlowEdge =
+        allIncomingEdges.find((edge) =>
+          edge.source.startsWith(cleanPrevId + "__") || edge.source === cleanPrevId
+        ) || null;
+    }
+  }
+
+  const providerInputEdges = isProcessorNode(actualNode)
+    ? allIncomingEdges.filter((edge) => {
+      if (executionFlowEdge && edge.id === executionFlowEdge.id) return false;
+      const sourceNode = nodes.find((node) => node.id === edge.source);
+      return isProviderNode(sourceNode);
+    })
+    : [];
+
+  const edgesToAnimate: Edge[] = [];
+  if (executionFlowEdge) {
+    edgesToAnimate.push(executionFlowEdge);
+  } else if (!previousNodeId && allIncomingEdges.length === 1) {
+    edgesToAnimate.push(allIncomingEdges[0]);
+  }
+
+  edgesToAnimate.push(...providerInputEdges);
+  return edgesToAnimate;
+};
 
 function FlowCanvas({ workflowId }: FlowCanvasProps) {
   const { enqueueSnackbar } = useSnackbar();
@@ -235,6 +350,17 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
     setActiveEdges,
     setActiveNodes,
     workflowId,
+    currentWorkflow?.id,
+    setCurrentExecutionForWorkflow
+  );
+
+  useKafkaExecutionListener(
+    nodes,
+    setNodeStatus,
+    edges,
+    setEdgeStatus,
+    setActiveEdges,
+    setActiveNodes,
     currentWorkflow?.id,
     setCurrentExecutionForWorkflow
   );
@@ -882,81 +1008,15 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
                 const t = evt.type as string | undefined;
                 if (t === "node_start") {
                   const nid = String(evt.node_id || "");
-                  const previousNodeId = evt.previous_node_id;
 
                   if (nid) {
                     setActiveNodes([nid]);
                     setNodeStatus((s) => ({ ...s, [nid]: "pending" }));
 
-                    // Get all incoming edges to this node
-                    const allIncomingEdges = (edges as Edge[]).filter(
-                      (e) => e.target === nid
-                    );
-
-                    // Separate edges into execution flow (from previous node) and provider inputs
-                    const executionFlowEdge = previousNodeId
-                      ? allIncomingEdges.find((e) => e.source === previousNodeId)
-                      : null;
-
-                    // Check if THIS node is a processor type that accepts provider inputs
                     const currentNode = nodes.find((n) => n.id === nid);
-                    const processorTypes = [
-                      'ReactAgentNode', 'Agent', // Added 'Agent'
-                      'VectorStoreOrchestrator',
-                      'ChunkSplitterNode', 'ChunkSplitter',
-                      'CodeNode', 'ConditionNode', 'JsonParserNode'
-                    ];
-                    const isProcessorNode = currentNode && processorTypes.some(pt =>
-                      currentNode.type?.includes(pt) || currentNode.type === pt
-                    );
-
-                    // Provider input edges - ONLY for processor nodes
-                    let providerInputEdges: Edge[] = [];
-                    if (isProcessorNode) {
-                      providerInputEdges = allIncomingEdges.filter((e) => {
-                        // Skip the execution flow edge
-                        if (executionFlowEdge && e.id === executionFlowEdge.id) return false;
-
-                        // Check if source node is a provider type
-                        const sourceNode = nodes.find((n) => n.id === e.source);
-                        if (!sourceNode) return false;
-
-                        // Provider node types that supply data to processors
-                        const providerTypes = [
-                          'OpenAINode', 'OpenAIChat', 'OpenAICompatibleNode',
-                          'OpenAIEmbeddingsProvider',
-                          'BufferMemoryNode', 'BufferMemory',
-                          'ConversationMemoryNode', 'ConversationMemory',
-                          'RetrieverProvider',
-                          'TavilySearchNode', 'TavilySearch',
-                          'CohereRerankerNode',
-                          'VectorStoreOrchestrator',
-                          'ChunkSplitterNode', 'ChunkSplitter',
-                          'DocumentLoaderNode',
-                          'WebScraperNode', 'WebScraper',
-                          'StringInputNode'
-                        ];
-
-                        return providerTypes.some(pt =>
-                          sourceNode.type?.includes(pt) ||
-                          (sourceNode.type && pt.includes(sourceNode.type)) ||
-                          sourceNode.type === pt
-                        );
-                      });
-                    }
-
-                    // Combine edges to animate
-                    const edgesToAnimate: Edge[] = [];
-
-                    if (executionFlowEdge) {
-                      edgesToAnimate.push(executionFlowEdge);
-                    } else if (!previousNodeId && allIncomingEdges.length === 1) {
-                      // First node with single incoming edge
-                      edgesToAnimate.push(allIncomingEdges[0]);
-                    }
-
-                    // Add provider input edges (only for processor nodes)
-                    edgesToAnimate.push(...providerInputEdges);
+                    const edgesToAnimate = currentNode
+                      ? resolveExecutionEdges(evt, currentNode, nodes, edges as Edge[])
+                      : [];
 
                     if (edgesToAnimate.length > 0) {
                       console.log(
@@ -1821,133 +1881,16 @@ function useChatExecutionListener(
       const { event: eventType, node_id, ...data } = event.detail;
 
       if (eventType === "node_start" && node_id) {
-        // PRIORITY 1: Exact ID match (most reliable)
-        let actualNode = nodes.find((n) => n.id === node_id);
-
-        // PRIORITY 2: If no exact match, try fuzzy matching as fallback
-        if (!actualNode) {
-          actualNode = nodes.find((n) => {
-            // Match by data.name (user-defined name)
-            if (n.data.name === node_id) {
-              return true;
-            }
-
-            // Match by type (only if exactly one node of this type exists)
-            if (n.type === node_id) {
-              const sameTypeNodes = nodes.filter((node) => node.type === n.type);
-              return sameTypeNodes.length === 1;
-            }
-
-            // Derive a clean node type/id token. New ids use `Type__UUID`.
-            const cleanNodeId = node_id.includes("__")
-              ? node_id.split("__")[0]
-              : node_id.replace(/\-\d+$/, "");
-
-            // Only use includes matching if there's exactly one node of this type
-            if (n.type && n.type === cleanNodeId) {
-              const sameTypeNodes = nodes.filter((node) => node.type === n.type);
-              return sameTypeNodes.length === 1;
-            }
-
-            // Match by data properties if available
-            if (n.data?.node_name && n.data.node_name === node_id) {
-              return true;
-            }
-
-            return false;
-          });
-        }
+        const actualNode = findCanvasNode(nodes, node_id);
 
         if (actualNode) {
-          // Set active node (for flow animation)
           setActiveNodes([actualNode.id]);
           setNodeStatus((prev) => ({
             ...prev,
-            [actualNode.id]: "pending", // Start with pending like in start node execution
+            [actualNode.id]: "pending",
           }));
 
-          // Get all incoming edges to this node
-          const allIncomingEdges = edges.filter((e) => e.target === actualNode.id);
-
-          // Use previous_node_id from backend to find execution flow edge
-          const previousNodeId = data.previous_node_id;
-
-          // Find execution flow edge (from previous node in sequence)
-          let executionFlowEdge: Edge | null = null;
-          if (previousNodeId) {
-            executionFlowEdge = allIncomingEdges.find(
-              (e) => e.source === previousNodeId
-            ) || null;
-
-            // Fuzzy match if exact not found
-            if (!executionFlowEdge) {
-              const cleanPrevId = previousNodeId.includes("__")
-                ? previousNodeId.split("__")[0]
-                : previousNodeId;
-              executionFlowEdge = allIncomingEdges.find((e) =>
-                e.source.startsWith(cleanPrevId + "__") || e.source === cleanPrevId
-              ) || null;
-            }
-          }
-
-          // Check if THIS node is a processor type that accepts provider inputs
-          const processorTypes = [
-            'ReactAgentNode', 'Agent', // Added 'Agent'
-            'VectorStoreOrchestrator',
-            'ChunkSplitterNode', 'ChunkSplitter',
-            'CodeNode', 'ConditionNode', 'JsonParserNode'
-          ];
-          const isProcessorNode = actualNode.type && processorTypes.some(pt =>
-            actualNode.type?.includes(pt) || actualNode.type === pt
-          );
-
-          // Provider input edges - ONLY for processor nodes
-          let providerInputEdges: Edge[] = [];
-          if (isProcessorNode) {
-            providerInputEdges = allIncomingEdges.filter((e) => {
-              // Skip execution flow edge
-              if (executionFlowEdge && e.id === executionFlowEdge.id) return false;
-
-              // Check if source is a provider node
-              const sourceNode = nodes.find((n) => n.id === e.source);
-              if (!sourceNode) return false;
-
-              const providerTypes = [
-                'OpenAINode', 'OpenAIChat', 'OpenAICompatibleNode',
-                'OpenAIEmbeddingsProvider',
-                'BufferMemoryNode', 'BufferMemory',
-                'ConversationMemoryNode', 'ConversationMemory',
-                'RetrieverProvider',
-                'TavilySearchNode', 'TavilySearch',
-                'CohereRerankerNode',
-                'VectorStoreOrchestrator',
-                'ChunkSplitterNode', 'ChunkSplitter',
-                'DocumentLoaderNode',
-                'WebScraperNode', 'WebScraper',
-                'StringInputNode'
-              ];
-
-              const isProvider = providerTypes.some(pt =>
-                sourceNode.type?.includes(pt) ||
-                (sourceNode.type && pt.includes(sourceNode.type)) ||
-                sourceNode.type === pt
-              );
-
-              return isProvider;
-            });
-          }
-
-          // Combine edges to animate
-          const edgesToAnimate: Edge[] = [];
-
-          if (executionFlowEdge) {
-            edgesToAnimate.push(executionFlowEdge);
-          } else if (!previousNodeId && allIncomingEdges.length === 1) {
-            edgesToAnimate.push(allIncomingEdges[0]);
-          }
-
-          // Add provider edges (only for processor nodes)
-          edgesToAnimate.push(...providerInputEdges);
+          const edgesToAnimate = resolveExecutionEdges(data, actualNode, nodes, edges);
 
           setActiveEdges(edgesToAnimate.map((e) => e.id));
           if (edgesToAnimate.length > 0) {
@@ -1957,49 +1900,14 @@ function useChatExecutionListener(
                 edgesToAnimate.map((e) => [e.id, "pending" as const])
               ),
             }));
-          } else if (allIncomingEdges.length > 0) {
+          } else if (edges.some((edge) => edge.target === actualNode.id)) {
             console.log("No matching edges to animate for", actualNode.id);
           }
         }
       }
 
       if (eventType === "node_end" && node_id) {
-        // PRIORITY 1: Exact ID match (most reliable)
-        let actualNode = nodes.find((n) => n.id === node_id);
-
-        // PRIORITY 2: If no exact match, try fuzzy matching as fallback
-        if (!actualNode) {
-          actualNode = nodes.find((n) => {
-            // Match by data.name (user-defined name)
-            if (n.data.name === node_id) {
-              return true;
-            }
-
-            // Match by type (only if exactly one node of this type exists)
-            if (n.type === node_id) {
-              const sameTypeNodes = nodes.filter((node) => node.type === n.type);
-              return sameTypeNodes.length === 1;
-            }
-
-            // Derive a clean node type/id token. New ids use `Type__UUID`.
-            const cleanNodeId = node_id.includes("__")
-              ? node_id.split("__")[0]
-              : node_id.replace(/\-\d+$/, "");
-
-            // Only use includes matching if there's exactly one node of this type
-            if (n.type && n.type === cleanNodeId) {
-              const sameTypeNodes = nodes.filter((node) => node.type === n.type);
-              return sameTypeNodes.length === 1;
-            }
-
-            // Match by data properties if available
-            if (n.data?.node_name && n.data.node_name === node_id) {
-              return true;
-            }
-
-            return false;
-          });
-        }
+        const actualNode = findCanvasNode(nodes, node_id);
 
         if (actualNode) {
           setNodeStatus((prev) => ({
@@ -2110,7 +2018,7 @@ function useWebhookExecutionListener(
     }>();
 
     // Get base URL with fallback
-    const baseUrl = import.meta.env.VITE_API_BASE_URL;
+    const baseUrl = config.API_BASE_URL;
 
     // Connect to webhook stream for each webhook node
     webhookNodes.forEach((node) => {
@@ -2331,25 +2239,7 @@ function useWebhookExecutionListener(
 
               // Handle node_start events
               if (eventType === "node_start" && node_id) {
-                const actualNode = nodes.find((n) => {
-                  if (
-                    n.id === node_id ||
-                    n.data?.name === node_id ||
-                    n.type === node_id
-                  ) {
-                    return true;
-                  }
-                  const cleanNodeId = node_id.includes("__")
-                    ? node_id.split("__")[0]
-                    : node_id.replace(/\-\d+$/, "");
-                  if (
-                    n.type &&
-                    (n.type.includes(cleanNodeId) || cleanNodeId.includes(n.type))
-                  ) {
-                    return true;
-                  }
-                  return false;
-                });
+                const actualNode = findCanvasNode(nodes, node_id);
 
                 if (actualNode) {
                   throttledUpdate(() => {
@@ -2359,13 +2249,13 @@ function useWebhookExecutionListener(
                       [actualNode.id]: "pending",
                     }));
 
-                    const incomingEdges = edges.filter((e) => e.target === actualNode.id);
+                    const incomingEdges = resolveExecutionEdges(executionEvent, actualNode, nodes, edges);
                     if (incomingEdges.length > 0) {
-                      setActiveEdges(incomingEdges.map((e) => e.id));
+                      setActiveEdges(incomingEdges.map((edge) => edge.id));
                       setEdgeStatus((prev) => ({
                         ...prev,
                         ...Object.fromEntries(
-                          incomingEdges.map((e) => [e.id, "pending" as const])
+                          incomingEdges.map((edge) => [edge.id, "pending" as const])
                         ),
                       }));
                     }
@@ -2375,25 +2265,7 @@ function useWebhookExecutionListener(
 
               // Handle node_end events
               if (eventType === "node_end" && node_id) {
-                const actualNode = nodes.find((n) => {
-                  if (
-                    n.id === node_id ||
-                    n.data?.name === node_id ||
-                    n.type === node_id
-                  ) {
-                    return true;
-                  }
-                  const cleanNodeId = node_id.includes("__")
-                    ? node_id.split("__")[0]
-                    : node_id.replace(/\-\d+$/, "");
-                  if (
-                    n.type &&
-                    (n.type.includes(cleanNodeId) || cleanNodeId.includes(n.type))
-                  ) {
-                    return true;
-                  }
-                  return false;
-                });
+                const actualNode = findCanvasNode(nodes, node_id);
 
                 if (actualNode) {
                   const isError = executionEvent.error || executionEvent.status === "error";
@@ -2403,13 +2275,13 @@ function useWebhookExecutionListener(
                       [actualNode.id]: isError ? "failed" : "success",
                     }));
 
-                    const incomingEdges = edges.filter((e) => e.target === actualNode.id);
+                    const incomingEdges = resolveExecutionEdges(executionEvent, actualNode, nodes, edges);
                     if (incomingEdges.length > 0) {
                       const edgeStatus: NodeStatus = isError ? "failed" : "success";
                       setEdgeStatus((prev) => ({
                         ...prev,
                         ...Object.fromEntries(
-                          incomingEdges.map((e) => [e.id, edgeStatus])
+                          incomingEdges.map((edge) => [edge.id, edgeStatus])
                         ),
                       }));
                     }
@@ -2453,7 +2325,148 @@ function useWebhookExecutionListener(
       pendingUpdates.length = 0;
       webhookExecutionData.clear();
     };
-  }, [nodes, workflowId, currentWorkflowId, setCurrentExecutionForWorkflow]);
+  }, [nodes, edges, workflowId, currentWorkflowId, setCurrentExecutionForWorkflow]);
+}
+
+function useKafkaExecutionListener(
+  nodes: Node[],
+  setNodeStatus: React.Dispatch<React.SetStateAction<Record<string, NodeStatus>>>,
+  edges: Edge[],
+  setEdgeStatus: React.Dispatch<React.SetStateAction<Record<string, NodeStatus>>>,
+  setActiveEdges: React.Dispatch<React.SetStateAction<string[]>>,
+  setActiveNodes: React.Dispatch<React.SetStateAction<string[]>>,
+  currentWorkflowId?: string,
+  setCurrentExecutionForWorkflow?: (workflowId: string, execution: any) => void
+) {
+  useEffect(() => {
+    const kafkaNodes = nodes.filter(
+      (node) => node.type === "KafkaConsumer" || node.type === "KafkaTrigger"
+    );
+
+    if (kafkaNodes.length === 0) return;
+
+    const eventSources: EventSource[] = [];
+    const executionData = new Map<string, {
+      executionId: string;
+      nodeOutputs: Record<string, any>;
+      executedNodes: string[];
+      sessionId?: string;
+      result?: any;
+      startedAt: string;
+      completedAt?: string;
+    }>();
+
+    kafkaNodes.forEach((node) => {
+      const listenerId = node.id;
+      const streamUrl = `${config.API_BASE_URL}/${config.API_START}/${config.API_VERSION_ONLY}/kafka/listeners/${listenerId}/stream`;
+      const eventSource = new EventSource(streamUrl);
+
+      eventSource.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data);
+          if (data.type === "connected" || data.type === "ping") return;
+          if (data.type !== "kafka_execution_event" || !data.event) return;
+
+          const executionEvent = data.event;
+          const eventType = executionEvent.type || executionEvent.event;
+          const nodeId = executionEvent.node_id;
+          const executionId = data.execution_id || "unknown";
+
+          if (!executionData.has(executionId)) {
+            executionData.set(executionId, {
+              executionId,
+              nodeOutputs: {},
+              executedNodes: [],
+              startedAt: data.timestamp || new Date().toISOString(),
+            });
+          }
+
+          const execData = executionData.get(executionId)!;
+
+          if (eventType === "node_start" && nodeId) {
+            if (!execData.executedNodes.includes(nodeId)) {
+              execData.executedNodes.push(nodeId);
+            }
+
+            const actualNode = findCanvasNode(nodes, nodeId);
+            if (actualNode) {
+              const activeFlowEdges = resolveExecutionEdges(executionEvent, actualNode, nodes, edges);
+              setActiveNodes([actualNode.id]);
+              setNodeStatus((prev) => ({ ...prev, [actualNode.id]: "pending" }));
+              setActiveEdges(activeFlowEdges.map((edge) => edge.id));
+              setEdgeStatus((prev) => ({
+                ...prev,
+                ...Object.fromEntries(activeFlowEdges.map((edge) => [edge.id, "pending" as const])),
+              }));
+            }
+          }
+
+          if (eventType === "node_end" && nodeId) {
+            execData.nodeOutputs[nodeId] = {
+              ...(execData.nodeOutputs[nodeId] || {}),
+              output: executionEvent.output || executionEvent.result,
+              outputs: executionEvent.output || executionEvent.result,
+              status: executionEvent.error ? "failed" : "completed",
+            };
+
+            const actualNode = findCanvasNode(nodes, nodeId);
+            if (actualNode) {
+              const isError = executionEvent.error || executionEvent.status === "error";
+              const activeFlowEdges = resolveExecutionEdges(executionEvent, actualNode, nodes, edges);
+              setNodeStatus((prev) => ({ ...prev, [actualNode.id]: isError ? "failed" : "success" }));
+              setEdgeStatus((prev) => ({
+                ...prev,
+                ...Object.fromEntries(activeFlowEdges.map((edge) => [edge.id, isError ? "failed" as const : "success" as const])),
+              }));
+            }
+          }
+
+          if (eventType === "complete" || eventType === "workflow_complete") {
+            execData.completedAt = data.timestamp || new Date().toISOString();
+            execData.result = executionEvent.result;
+            execData.nodeOutputs = {
+              ...execData.nodeOutputs,
+              ...(executionEvent.node_outputs || {}),
+            };
+            execData.executedNodes = executionEvent.executed_nodes || execData.executedNodes;
+            execData.sessionId = executionEvent.session_id;
+
+            if (currentWorkflowId && setCurrentExecutionForWorkflow) {
+              setCurrentExecutionForWorkflow(currentWorkflowId, {
+                id: executionId,
+                workflow_id: currentWorkflowId,
+                input_text: data.kafka_payload ? JSON.stringify(data.kafka_payload) : "",
+                result: {
+                  result: execData.result,
+                  executed_nodes: execData.executedNodes,
+                  node_outputs: execData.nodeOutputs,
+                  session_id: execData.sessionId,
+                  status: "completed" as const,
+                },
+                started_at: execData.startedAt,
+                completed_at: execData.completedAt,
+                status: "completed" as const,
+              });
+            }
+
+            setTimeout(() => {
+              setActiveEdges([]);
+              setActiveNodes([]);
+            }, 1500);
+          }
+        } catch (error) {
+          console.error("Error parsing Kafka execution event:", error);
+        }
+      };
+
+      eventSources.push(eventSource);
+    });
+
+    return () => {
+      eventSources.forEach((source) => source.close());
+      executionData.clear();
+    };
+  }, [nodes, edges, currentWorkflowId, setCurrentExecutionForWorkflow, setNodeStatus, setEdgeStatus, setActiveEdges, setActiveNodes]);
 }
 
 interface FlowCanvasWrapperProps {

--- a/client/app/components/common/CustomEdge.tsx
+++ b/client/app/components/common/CustomEdge.tsx
@@ -52,12 +52,12 @@ function CustomAnimatedEdge({
         style={{
           ...style,
           stroke:
-            status === 'success'
+            isActive
+              ? "url(#electric-gradient-" + id + ")"
+              : status === 'success'
               ? '#22c55e'
               : status === 'failed'
               ? '#ef4444'
-              : isActive
-              ? "url(#electric-gradient-" + id + ")"
               : "#6b7280",
           strokeWidth: isActive ? 3 : 2,
           strokeDasharray: isActive ? "12 8" : "none",

--- a/client/app/stores/chat.ts
+++ b/client/app/stores/chat.ts
@@ -64,6 +64,7 @@ const executeWorkflowWithStreaming = async (
     const stream = await executeWorkflowStream(executionData);
     const reader = stream.getReader();
     const decoder = new TextDecoder('utf-8');
+    let buffer = '';
 
     while (true) {
       const { value, done } = await reader.read();
@@ -72,8 +73,10 @@ const executeWorkflowWithStreaming = async (
         break;
       }
 
-      const chunk = decoder.decode(value, { stream: true });
-      const lines = chunk.split('\n');
+      buffer += decoder.decode(value, { stream: true });
+      const eventParts = buffer.split('\n\n');
+      buffer = eventParts.pop() || '';
+      const lines = eventParts.flatMap((part) => part.split('\n'));
 
       for (const line of lines) {
         if (line.startsWith('data: ')) {

--- a/client/app/types/api.ts
+++ b/client/app/types/api.ts
@@ -396,6 +396,12 @@ export interface ExecutionEvent {
   result?: any;
   error?: string;
   status?: "success" | "failed" | "error";
+  previous_node_id?: string;
+  edge_id?: string;
+  edge_ids?: string[];
+  active_edge_ids?: string[];
+  incoming_edge_ids?: string[];
+  outgoing_edge_ids?: string[];
   metadata?: Record<string, any>;
   event?: string; // Backward compatibility
   inputs?: Record<string, any>;


### PR DESCRIPTION
This PR fixes an issue where the "electric flow" animation would not render for edges connected to provider nodes.

Key changes:
Updated resolveExecutionEdges to properly include incoming edges from provider nodes (like OpenAI, Memory, Retriever) when the target is a processor node.
This ensures that flows like Start -> TextNode -> AgentNode <- OpenAICompatibleNode display all active edge animations correctly during execution.