### PR TITLE
fix: RespondToWebhook node was reading connected_nodes instead of pre…

### DIFF
--- a/backend/app/nodes/triggers/respond_to_webhook.py
+++ b/backend/app/nodes/triggers/respond_to_webhook.py
@@ -221,10 +221,9 @@ class RespondToWebhookNode(TerminatorNode):
         """
         logger.info(f"Configuring RespondToWebhook node")
         
-        # Extract inputs from kwargs (inputs dict contains all node properties)
         inputs = kwargs.get("inputs", {})
-        connected_nodes = kwargs.get("connected_nodes", {})
-        previous_node_output = connected_nodes if connected_nodes else None
+        previous_node = kwargs.get("previous_node")
+        previous_node_output = previous_node if previous_node else None
         # Store user configuration (inputs dict'ini direkt user_data'ya kaydet)
         self.user_data.update(inputs)
         
@@ -236,11 +235,9 @@ class RespondToWebhookNode(TerminatorNode):
         
         # Determine response_body based on response_config
         if response_config == "all_incoming_items":
-            data = connected_nodes if connected_nodes else {}
-            # Convert Document objects to dicts first, then make JSON serializable
+            data = previous_node_output if previous_node_output else {}
             data = _convert_documents_to_dict(data)
             data = make_json_serializable(data)
-            # Ensure JSON format: if string, wrap it; if already dict/list, use as is
             response_body = {"data": data} if isinstance(data, str) else (data if isinstance(data, (dict, list)) else {"data": data})
             logger.info(f"Using all incoming items as response body: {response_body}")
         elif response_config == "no_data":
@@ -256,10 +253,9 @@ class RespondToWebhookNode(TerminatorNode):
                 # Convert Document objects to dicts first, then make JSON serializable
                 response_body = _convert_documents_to_dict(previous_node_output)
                 response_body = make_json_serializable(response_body)
-            elif not response_body and connected_nodes:
-                logger.info(f"Using connected_nodes as response body: {connected_nodes}")
-                # Convert Document objects to dicts first, then make JSON serializable
-                response_body = _convert_documents_to_dict(connected_nodes)
+            elif not response_body and previous_node_output:
+                logger.info(f"Using previous_node output as response body: {previous_node_output}")
+                response_body = _convert_documents_to_dict(previous_node_output)
                 response_body = make_json_serializable(response_body)
         
         # Parse response_body if it's a JSON string and content_type is application/json


### PR DESCRIPTION
 Title: fix: RespondToWebhook empty body bug

  Description:

  RespondToWebhookNode.execute() metodu, önceki node'dan gelen veriyi connected_nodes parametresinden okuyordu. Ancak TERMINATOR tipi node'lara
  node_executor tarafından connected_nodes değil, previous_node parametresi geçiliyor (node_executor.py:187). Bu yüzden connected_nodes her zaman boş {}
  kalıyor ve webhook response body'si boş dönüyordu.

  Etkilenen durumlar:
  - "All Incoming Items" modu — her zaman boş {} dönüyordu
  - "JSON" modu (response_body boş bırakıldığında) — fallback olarak önceki node çıktısını alması gerekirken alamıyordu

  Fix: respond_to_webhook.py satır 226-227'de connected_nodes referansları previous_node ile değiştirildi.