### PR TITLE
feat: standardize recursive Jinja rendering across provider node execution

### DIFF
--- a/backend/app/core/graph_builder/__init__.py
+++ b/backend/app/core/graph_builder/__init__.py
@@ -585,6 +585,9 @@ class GraphBuilder:
             try:
                 logger.info(f"EXECUTING: {node_id} ({gnode.type}) with NodeExecutor")
                 
+                # Inject nodes registry into state so that nodes can resolve Jinja variables with friendly names
+                state.nodes_registry = self.nodes
+                
                 # Merge user data into node instance before execution
                 gnode.node_instance.user_data.update(gnode.user_data)
                 

--- a/backend/app/core/graph_builder/node_executor.py
+++ b/backend/app/core/graph_builder/node_executor.py
@@ -21,16 +21,6 @@ import datetime
 import traceback
 import re
 import json
-from jinja2 import Environment
-
-# Custom Jinja2 environment with Unicode-safe tojson filter
-# This prevents Turkish/Unicode characters from being escaped to \uXXXX format
-def _tojson_unicode(value):
-    """JSON encode preserving Unicode characters (no ASCII escaping)"""
-    return json.dumps(value, ensure_ascii=False, default=str)
-
-_jinja_env = Environment()
-_jinja_env.filters['tojson'] = _tojson_unicode
 
 from .types import (
     GraphNodeInstance,
@@ -42,6 +32,7 @@ from .types import (
 )
 from .exceptions import NodeExecutionError
 from app.core.state import FlowState
+from app.core.templating import apply_jinja_to_inputs
 from app.core.output_cache import default_connection_extractor
 from app.core.node_handlers import node_handler_registry
 from app.core.connection_pool import ConnectionPool, PooledConnection
@@ -152,7 +143,7 @@ class NodeExecutor:
             logger.debug(f"User inputs extracted: {list(user_inputs.keys()) if user_inputs else 'None'}")
             
             # Apply node-output templating so processor inputs can reference upstream node outputs
-            user_inputs = self._apply_node_output_templating(gnode, user_inputs, state)
+            user_inputs = apply_jinja_to_inputs(user_inputs, state, node_id, self._nodes_registry)
             logger.debug(f"Templated user inputs: {list(user_inputs.keys()) if user_inputs else 'None'}")
             
             # Extract connected node instances
@@ -374,254 +365,9 @@ class NodeExecutor:
         logger.debug(f"Processor {gnode.id} resolved user_inputs: {user_inputs}")
         return user_inputs
     
-    def _normalize_display_name_for_template(self, name: str) -> str:
-        """
-        Normalize a node display name to a Jinja-safe identifier.
-        
-        Example:
-            "OpenAI GPT" -> "openai_gpt"
-        """
-        if not name:
-            return ""
-        
-        normalized = re.sub(r"[^0-9a-zA-Z_]+", "_", name).strip("_")
-        if not normalized:
-            return ""
-        
-        # Jinja identifiers should not start with a digit
-        if normalized[0].isdigit():
-            normalized = f"n_{normalized}"
-        
-        return normalized
-    
-    def _get_primary_output_for_node(self, node_id: str, state: FlowState) -> Any:
-        """
-        Determine the primary output value for a given node from FlowState.
-
-        Heuristic:
-        - If node_outputs[node_id] is a dict:
-          - Prefer 'output'
-          - Then 'content'
-          - If only one key, return that single value
-          - Otherwise return the entire dict
-        - Otherwise, return the stored value directly.
-        """
-        if not hasattr(state, "node_outputs"):
-            return None
-        
-        node_output = state.node_outputs.get(node_id)
-        if node_output is None:
-            return None
-        
-        if isinstance(node_output, dict):
-            if "output" in node_output:
-                return node_output["output"]
-            if "content" in node_output:
-                return node_output["content"]
-            if len(node_output) == 1:
-                return next(iter(node_output.values()))
-            return node_output
-        
-        return node_output
-    
-    def _render_template_string(self, template_str: str, context: Dict[str, Any], node_id: str) -> str:
-        """
-        Render a Jinja2 template string with the given context.
-
-        Supports both ${{var}} and {{var}} syntax for variables.
-        ${{var}} syntax avoids conflicts with { } characters commonly used in system prompts (JSON schemas, etc.).
-        {{var}} syntax is also supported for compatibility.
-        """
-        # Only process templates with {{...}} syntax (either ${{...}} or {{...}})
-        if "{{" not in template_str or "}}" not in template_str:
-            return template_str
-
-        try:
-            # Convert ${{var}} to {{var}} for Jinja2 rendering (if not already)
-            processed_template = template_str.replace("${" + "{", "{{").replace("}}", "}}")
-
-            template = _jinja_env.from_string(processed_template)
-            return template.render(**context)
-        except Exception as e:
-            logger.warning(f"Node templating failed for {node_id}: {e}")
-            return template_str
-    
-    def _apply_node_output_templating(
-        self,
-        gnode: GraphNodeInstance,
-        user_inputs: Dict[str, Any],
-        state: FlowState
-    ) -> Dict[str, Any]:
-        """
-        Apply Jinja2 templating to processor user inputs so they can reference upstream node outputs by normalized display name.
-
-        Example usage in processor node input:
-        "Use previous answer: {{openai_gpt}}"
-        where "OpenAI GPT" is the display name of the upstream node.
-        """
-        try:
-            # This method is only called from execute_processor_node, so no additional gnode.type filter needed here.
-
-            # Apply templating for all processor nodes.
-            # IMPORTANT: Do NOT exit early just because node_outputs is empty.
-            # webhook_trigger / current_input context must be built even when this
-            # node is the very first processor in the graph (nothing in node_outputs yet).
-            has_node_outputs = hasattr(state, "node_outputs") and bool(state.node_outputs)
-            has_registry = bool(getattr(self, "_nodes_registry", None))
-            
-            # Build templating context from executed nodes' primary outputs
-            context: Dict[str, Any] = {}
-
-            # SPECIAL CASE: Add current_input as 'input' for chat-like behavior
-            # This allows {{input}} to work even when running with StartNode
-            if hasattr(state, 'current_input') and state.current_input is not None:
-                context['input'] = state.current_input
-
-            # SPECIAL CASE: Add webhook data for webhook-triggered workflows
-            # This allows {{webhook_trigger.anyfield}} and {{webhook_data}} templates
-            if hasattr(state, 'webhook_data') and state.webhook_data:
-                context['webhook_data'] = state.webhook_data
-                # webhook_trigger = the actual payload data for easy access
-                webhook_payload = state.webhook_data.get('data', state.webhook_data)
-                context['webhook_trigger'] = webhook_payload
-                logger.info(f"[TEMPLATE] Added webhook_trigger to context: {list(webhook_payload.keys()) if isinstance(webhook_payload, dict) else type(webhook_payload)}")
-
-            # Only iterate node outputs when they are available
-            if has_node_outputs and has_registry:
-                for other_node_id in state.node_outputs.keys():
-                    graph_node = self._nodes_registry.get(other_node_id)
-                    if not graph_node:
-                        continue
-
-                    # Build a prioritized list of candidate names for this node:
-
-                    # 1) UI-visible name from user_data["name"] (what you see on the canvas)
-                    # 2) NodeMetadata.display_name
-                    # 3) NodeMetadata.name
-                    # 4) GraphNodeInstance.metadata["display_name"/"name"]
-                    # 5) Fallback: node_id
-                    alias_candidates: list[tuple[str, str]] = []
-
-                    # 1) UI name (highest priority, what the user edited on the frontend)
-                    ui_name = None
-                    try:
-                        user_data = getattr(graph_node, "user_data", {}) or {}
-                        if isinstance(user_data, dict):
-                            ui_name = user_data.get("name")
-                    except Exception:
-                        user_data = {}
-                        ui_name = None
-
-                    if ui_name:
-                        alias_candidates.append(("ui_name", str(ui_name)))
-
-                    # 2) Pydantic NodeMetadata from node instance
-                    node_meta_model = None
-                    try:
-                        node_meta_model = getattr(graph_node.node_instance, "metadata", None)
-                    except Exception:
-                        node_meta_model = None
-
-                    if node_meta_model is not None:
-                        display_name = getattr(node_meta_model, "display_name", None)
-                        meta_name = getattr(node_meta_model, "name", None)
-
-                        if display_name:
-                            alias_candidates.append(("display_name", str(display_name)))
-                        if meta_name and meta_name != display_name:
-                            alias_candidates.append(("meta_name", str(meta_name)))
-
-                    # 3) Fallback to GraphNodeInstance.metadata dict
-                    metadata_dict = getattr(graph_node, "metadata", {}) or {}
-                    if isinstance(metadata_dict, dict):
-                        md_display = metadata_dict.get("display_name")
-                        md_name = metadata_dict.get("name")
-
-                        if md_display:
-                            alias_candidates.append(("graph_display_name", str(md_display)))
-                        if md_name and md_name != md_display:
-                            alias_candidates.append(("graph_name", str(md_name)))
-
-                    # 4) Final fallback: raw node_id
-                    alias_candidates.append(("node_id", str(other_node_id)))
-
-                    primary_value = self._get_primary_output_for_node(other_node_id, state)
-                    if primary_value is None:
-                        continue
-
-                    # SPECIAL CASE: If this is a StartNode, also add its output as 'input'.
-                    # This allows {{input}} to work like a chat system with StartNode.
-                    try:
-                        if hasattr(graph_node, 'type') and graph_node.type == 'StartNode':
-                            if 'input' not in context:  # Don't overwrite if already set
-                                context['input'] = primary_value
-                                print(f"[TEMPLATE DEBUG] Added 'input' context from StartNode output: {primary_value}")
-                    except Exception:
-                        pass
-
-                    # Normalize and save all aliases without overwriting existing keys.
-                    # This preserves backward compatibility (type-based aliases) while
-                    # allowing clean UI-based aliases like {{openai_gpt}}.
-                    for source_type, raw_name in alias_candidates:
-                        normalized = self._normalize_display_name_for_template(raw_name)
-                        if not normalized:
-                            continue
-
-                        if normalized in context:
-                            # Do not overwrite existing mapping; just log once for visibility
-                            logger.debug(
-                                f"[TEMPLATE] Skipping duplicate alias '{normalized}' from {source_type} "
-                                f"for node {other_node_id} while building context for {gnode.id}"
-                            )
-                            continue
-
-                        context[normalized] = primary_value
-                        logger.debug(
-                            f"[TEMPLATE] Added alias '{normalized}' from {source_type} "
-                            f"for node '{other_node_id}' (raw='{raw_name}') into context for {gnode.id}"
-                        )
-
-            # Bail out only if no context at all was built (no webhook, no input, no upstream outputs)
-            if not context:
-                logger.debug(f"[TEMPLATE] No context built for node {gnode.id}; skipping templating")
-                return user_inputs
-            
-            logger.debug(
-                f"[TEMPLATE] Built templating context for node {gnode.id}: "
-                f"keys={list(context.keys())}"
-            )
-            
-            # Apply templating only to string inputs containing '{{' and '}}'
-            rendered_inputs: Dict[str, Any] = {}
-            for key, value in user_inputs.items():
-                if isinstance(value, str) and "{{" in value and "}}" in value:
-                    original = value
-                    rendered = self._render_template_string(
-                        original, context, gnode.id
-                    )
-                    print(
-                        f"[TEMPLATE DEBUG] Node {gnode.id} input '{key}' "
-                        f"before='{original}' after='{rendered}'"
-                    )
-                    if rendered != original:
-                        logger.info(
-                            f"[TEMPLATE] Node {gnode.id} input '{key}' templated from "
-                            f"'{original}' to '{rendered}'"
-                        )
-                    else:
-                        logger.info(
-                            f"[TEMPLATE] Node {gnode.id} input '{key}' contained templates "
-                            f"but rendered unchanged: '{original}'"
-                        )
-                    rendered_inputs[key] = rendered
-                else:
-                    rendered_inputs[key] = value
-            
-            return rendered_inputs
-        
-        except Exception as e:
-            logger.error(f"Failed to apply node output templating for {gnode.id}: {e}")
-            return user_inputs
+    # Note: Redundant helper methods _normalize_display_name_for_template, _get_primary_output_for_node,
+    # _render_template_string, and _apply_node_output_templating were removed.
+    # Centralized templating from app.core.templating is used instead.
     
     def extract_connected_node_instances(self, gnode: GraphNodeInstance, state: FlowState) -> Dict[str, Any]:
         """

--- a/backend/app/core/node_handlers.py
+++ b/backend/app/core/node_handlers.py
@@ -20,11 +20,11 @@ import logging
 import re
 import json
 import uuid
-from jinja2 import Environment
 
 from app.core.state import FlowState
 from app.nodes.base import NodeType
 from app.core.credential_provider import credential_provider
+from app.core.templating import apply_jinja_to_inputs
 
 logger = logging.getLogger(__name__)
 
@@ -151,176 +151,12 @@ class MemoryNodeHandler(NodeExecutionHandler):
         # Pass current state variables to memory node (allows templated/variable-driven config)
         memory_inputs.update(state.variables)
 
-
         # Apply Jinja templating to memory inputs so they can reference upstream node outputs
-        memory_inputs = self._apply_jinja_templating(memory_inputs, source_node_instance, state)
+        node_id = getattr(source_node_instance, "node_id", "MemoryNode")
+        memory_inputs = apply_jinja_to_inputs(memory_inputs, state, node_id, self.nodes_registry)
 
         return memory_inputs
 
-
-    def _apply_jinja_templating(
-        self,
-        memory_inputs: Dict[str, Any],
-        source_node_instance: Any,
-        state: FlowState,
-    ) -> Dict[str, Any]:
-
-        # Quick check: any input actually contain a template marker?
-        has_templates = any(
-            isinstance(v, str) and "{{" in v and "}}" in v
-            for v in memory_inputs.values()
-        )
-        if not has_templates:
-            return memory_inputs
-
-        # We need node_outputs and a populated nodes_registry.
-        if not hasattr(state, "node_outputs") or not state.node_outputs:
-            return memory_inputs
-        if not getattr(self, "nodes_registry", None):
-            return memory_inputs
-
-        try:
-            # Build templating context from executed nodes' primary outputs
-            context: Dict[str, Any] = {}
-
-            # Add current_input as 'input'
-            if hasattr(state, "current_input") and state.current_input is not None:
-                context["input"] = state.current_input
-
-            # Add webhook data
-            if hasattr(state, "webhook_data") and state.webhook_data:
-                context["webhook_data"] = state.webhook_data
-                webhook_payload = state.webhook_data.get("data", state.webhook_data)
-                context["webhook_trigger"] = webhook_payload
-
-            for other_node_id in state.node_outputs.keys():
-                graph_node = self.nodes_registry.get(other_node_id)
-                if not graph_node:
-                    continue
-
-                # Collect candidate alias names (same priority as NodeExecutor)
-                alias_candidates: list[tuple[str, str]] = []
-
-                # 1) UI name
-                try:
-                    user_data = getattr(graph_node, "user_data", {}) or {}
-                    ui_name = user_data.get("name") if isinstance(user_data, dict) else None
-                except Exception:
-                    ui_name = None
-                if ui_name:
-                    alias_candidates.append(("ui_name", str(ui_name)))
-
-                # 2) Pydantic NodeMetadata
-                node_meta = getattr(graph_node.node_instance, "metadata", None) if hasattr(graph_node, "node_instance") else None
-                if node_meta is not None:
-                    dn = getattr(node_meta, "display_name", None)
-                    mn = getattr(node_meta, "name", None)
-                    if dn:
-                        alias_candidates.append(("display_name", str(dn)))
-                    if mn and mn != dn:
-                        alias_candidates.append(("meta_name", str(mn)))
-
-                # 3) GraphNodeInstance metadata dict
-                metadata_dict = getattr(graph_node, "metadata", {}) or {}
-                if isinstance(metadata_dict, dict):
-                    md_display = metadata_dict.get("display_name")
-                    md_name = metadata_dict.get("name")
-                    if md_display:
-                        alias_candidates.append(("graph_display_name", str(md_display)))
-                    if md_name and md_name != md_display:
-                        alias_candidates.append(("graph_name", str(md_name)))
-
-                # 4) Fallback: node_id
-                alias_candidates.append(("node_id", str(other_node_id)))
-
-                # Get primary output value
-                primary_value = self._get_primary_output(other_node_id, state)
-                if primary_value is None:
-                    continue
-
-                # StartNode → 'input' alias
-                try:
-                    if hasattr(graph_node, "type") and graph_node.type == "StartNode":
-                        if "input" not in context:
-                            context["input"] = primary_value
-                except Exception:
-                    pass
-
-                for _, raw_name in alias_candidates:
-                    normalized = self._normalize_name(raw_name)
-                    if normalized and normalized not in context:
-                        context[normalized] = primary_value
-
-            if not context:
-                return memory_inputs
-
-            logger.debug(
-                f"[TEMPLATE-MEMORY] Built context for memory node: keys={list(context.keys())}"
-            )
-
-            # Render templates in string inputs
-            rendered: Dict[str, Any] = {}
-            for key, value in memory_inputs.items():
-                if isinstance(value, str) and "{{" in value and "}}" in value:
-                    rendered[key] = self._render_template(value, context)
-                    if rendered[key] != value:
-                        logger.info(
-                            f"[TEMPLATE-MEMORY] Input '{key}' rendered: "
-                            f"'{value}' → '{rendered[key]}'"
-                        )
-                else:
-                    rendered[key] = value
-
-            return rendered
-
-        except Exception as e:
-            logger.error(f"[TEMPLATE-MEMORY] Failed to apply templating: {e}")
-            return memory_inputs
-
-    @staticmethod
-    def _normalize_name(name: str) -> str:
-        """Normalize a display name to a Jinja-safe identifier."""
-        if not name:
-            return ""
-        normalized = re.sub(r"[^0-9a-zA-Z_]+", "_", name).strip("_")
-        if not normalized:
-            return ""
-        if normalized[0].isdigit():
-            normalized = f"n_{normalized}"
-        return normalized
-
-    @staticmethod
-    def _get_primary_output(node_id: str, state: FlowState) -> Any:
-        """Get the primary output value for a node from state.node_outputs."""
-        node_output = state.node_outputs.get(node_id)
-        if node_output is None:
-            return None
-        if isinstance(node_output, dict):
-            if "output" in node_output:
-                return node_output["output"]
-            if "content" in node_output:
-                return node_output["content"]
-            if len(node_output) == 1:
-                return next(iter(node_output.values()))
-            return node_output
-        return node_output
-
-    @staticmethod
-    def _render_template(template_str: str, context: Dict[str, Any]) -> str:
-        """Render a Jinja2 template string. Supports ${{var}} and {{var}}."""
-        try:
-            def _tojson_unicode(value):
-                return json.dumps(value, ensure_ascii=False, default=str)
-
-            env = Environment()
-            env.filters["tojson"] = _tojson_unicode
-
-            processed = template_str.replace("${" + "{", "{{").replace("}}", "}}")
-            template = env.from_string(processed)
-            return template.render(**context)
-        except Exception as e:
-            logger.warning(f"[TEMPLATE-MEMORY] Render failed: {e}")
-            return template_str
 
 
 class ProviderNodeHandler(NodeExecutionHandler):
@@ -347,6 +183,7 @@ class ProviderNodeHandler(NodeExecutionHandler):
         try:
             # Extract provider-specific inputs from user configuration
             provider_inputs = self._extract_provider_inputs(source_node_instance, state)
+            provider_inputs = apply_jinja_to_inputs(provider_inputs, state, node_id, self.nodes_registry)
             
             # NEW: Extract connected inputs for provider nodes that need them
             connected_inputs = self._extract_connected_inputs(source_node_instance, gnode_instance, state)
@@ -424,6 +261,7 @@ class ProviderNodeHandler(NodeExecutionHandler):
                     if source_node_type.value == "provider":
                         # Execute source provider to get its instance
                         provider_inputs = self._extract_provider_inputs(source_instance, state)
+                        provider_inputs = apply_jinja_to_inputs(provider_inputs, state, source_node_id, self.nodes_registry)
                         
                         # Inject user_id if supported
                         self._inject_user_context(source_instance, state, source_node_id)
@@ -492,7 +330,7 @@ class ProcessorNodeHandler(NodeExecutionHandler):
             # Inject user_id if supported
             self._inject_user_context(source_node_instance, state, node_id)
             
-            return self._re_execute_processor(source_node_instance, gnode_instance, state)
+            return self._re_execute_processor(source_node_instance, gnode_instance, state, node_id)
             
         except Exception as e:
             logger.error(f"[ERROR] Failed to extract processor node {node_id}: {e}")
@@ -532,7 +370,7 @@ class ProcessorNodeHandler(NodeExecutionHandler):
         logger.debug("[DEBUG] Using full stored result as fallback")
         return stored_result
     
-    def _re_execute_processor(self, source_node_instance: Any, gnode_instance: Any, state: FlowState) -> Any:
+    def _re_execute_processor(self, source_node_instance: Any, gnode_instance: Any, state: FlowState, node_id: str) -> Any:
         """
         Re-execute a processor node when cached output is not available.
         
@@ -542,6 +380,7 @@ class ProcessorNodeHandler(NodeExecutionHandler):
         
         # Extract user inputs for processor
         processor_inputs = self._extract_processor_inputs(source_node_instance, state)
+        processor_inputs = apply_jinja_to_inputs(processor_inputs, state, node_id, self.nodes_registry)
         
         # Build connected nodes for processor (recursive but controlled)
         processor_connected_nodes = self._build_connected_nodes_for_processor(
@@ -648,8 +487,9 @@ class TerminatorNodeHandler(NodeExecutionHandler):
             # Inject user_id
             self._inject_user_context(source_node_instance, state, node_id)
             
-            # Simple execution for terminator (passing current state as inputs)
-            result = source_node_instance.execute(state.variables, {})
+            # Simple execution for terminator (passing current state as inputs, templated dynamically)
+            templated_inputs = apply_jinja_to_inputs(state.variables, state, node_id, self.nodes_registry)
+            result = source_node_instance.execute(templated_inputs, {})
             return result
         except Exception as e:
             logger.warning(f"[TERMINATOR] Re-execution failed for {node_id}: {e}")

--- a/backend/app/core/templating.py
+++ b/backend/app/core/templating.py
@@ -1,0 +1,249 @@
+"""
+KAI-Flow Centralized Templating Engine
+======================================
+
+Provides unified, recursive, and Unicode-safe Jinja2 rendering utilities
+for resolving templates in user inputs, nested configurations (dicts, lists),
+and connection contexts across all node types.
+
+AUTHORS: KAI-Flow Workflow Orchestration Team
+VERSION: 1.0.0
+LICENSE: Proprietary - KAI-Flow Platform
+"""
+
+import re
+import json
+import logging
+from typing import Dict, Any, Optional, List, Union
+
+from jinja2 import Environment
+from app.core.state import FlowState
+
+logger = logging.getLogger(__name__)
+
+# Custom Jinja2 environment with Unicode-safe tojson filter
+# This prevents Turkish/Unicode characters from being escaped to \uXXXX format
+def _tojson_unicode(value):
+    """JSON encode preserving Unicode characters (no ASCII escaping)"""
+    return json.dumps(value, ensure_ascii=False, default=str)
+
+_jinja_env = Environment()
+_jinja_env.filters['tojson'] = _tojson_unicode
+
+
+def normalize_display_name(name: str) -> str:
+    """Normalize a display name to a Jinja-safe identifier.
+    
+    Example:
+        "OpenAI GPT" -> "openai_gpt"
+    """
+    if not name:
+        return ""
+    
+    normalized = re.sub(r"[^0-9a-zA-Z_]+", "_", name).strip("_")
+    if not normalized:
+        return ""
+    
+    # Jinja identifiers should not start with a digit
+    if normalized[0].isdigit():
+        normalized = f"n_{normalized}"
+    
+    return normalized
+
+
+def get_primary_output(node_id: str, state: FlowState) -> Any:
+    """Determine the primary output value for a given node from FlowState.
+
+    Heuristic:
+    - If node_outputs[node_id] is a dict:
+      - Prefer 'output'
+      - Then 'content'
+      - If only one key, return that single value
+      - Otherwise return the entire dict
+    - Otherwise, return the stored value directly.
+    """
+    if not hasattr(state, "node_outputs"):
+        return None
+    
+    node_output = state.node_outputs.get(node_id)
+    if node_output is None:
+        return None
+    
+    if isinstance(node_output, dict):
+        if "output" in node_output:
+            return node_output["output"]
+        if "content" in node_output:
+            return node_output["content"]
+        if len(node_output) == 1:
+            return next(iter(node_output.values()))
+        return node_output
+    
+    return node_output
+
+
+def build_template_context(state: FlowState, nodes_registry: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Build the templating context from state, inputs, webhook data, and node outputs."""
+    context: Dict[str, Any] = {}
+    
+    # 1. Add current_input as 'input' (allows {{input}} to work like a chat system)
+    if hasattr(state, 'current_input') and state.current_input is not None:
+        context['input'] = state.current_input
+        
+    # 2. Add webhook data for webhook-triggered workflows
+    if hasattr(state, 'webhook_data') and state.webhook_data:
+        context['webhook_data'] = state.webhook_data
+        webhook_payload = state.webhook_data.get('data', state.webhook_data)
+        context['webhook_trigger'] = webhook_payload
+        logger.debug(f"[TEMPLATE] Added webhook_trigger to context keys: {list(webhook_payload.keys()) if isinstance(webhook_payload, dict) else type(webhook_payload)}")
+
+    # 3. Add executed node outputs with friendly aliases
+    has_node_outputs = hasattr(state, "node_outputs") and bool(state.node_outputs)
+    
+    if has_node_outputs:
+        for other_node_id in state.node_outputs.keys():
+            alias_candidates: List[tuple[str, str]] = []
+            
+            # Lookup node definition from registry if available
+            graph_node = None
+            if nodes_registry:
+                graph_node = nodes_registry.get(other_node_id)
+                
+            if graph_node:
+                # UI Name (user_data["name"]) - highest priority
+                ui_name = None
+                try:
+                    user_data = getattr(graph_node, "user_data", {}) or {}
+                    if isinstance(user_data, dict):
+                        ui_name = user_data.get("name")
+                except Exception:
+                    pass
+                if ui_name:
+                    alias_candidates.append(("ui_name", str(ui_name)))
+                
+                # Pydantic NodeMetadata from node instance
+                node_meta_model = None
+                try:
+                    node_meta_model = getattr(graph_node.node_instance, "metadata", None)
+                except Exception:
+                    pass
+                if node_meta_model is not None:
+                    display_name = getattr(node_meta_model, "display_name", None)
+                    meta_name = getattr(node_meta_model, "name", None)
+                    if display_name:
+                        alias_candidates.append(("display_name", str(display_name)))
+                    if meta_name and meta_name != display_name:
+                        alias_candidates.append(("meta_name", str(meta_name)))
+                        
+                # GraphNodeInstance metadata dict fallback
+                metadata_dict = getattr(graph_node, "metadata", {}) or {}
+                if isinstance(metadata_dict, dict):
+                    md_display = metadata_dict.get("display_name")
+                    md_name = metadata_dict.get("name")
+                    if md_display:
+                        alias_candidates.append(("graph_display_name", str(md_display)))
+                    if md_name and md_name != md_display:
+                        alias_candidates.append(("graph_name", str(md_name)))
+            
+            # Final fallback: node_id
+            alias_candidates.append(("node_id", str(other_node_id)))
+            
+            primary_value = get_primary_output(other_node_id, state)
+            if primary_value is None:
+                continue
+                
+            # If the node is a StartNode, also allow {{input}} fallback mapping
+            try:
+                node_type = getattr(graph_node, 'type', None)
+                if node_type == 'StartNode' and 'input' not in context:
+                    context['input'] = primary_value
+            except Exception:
+                pass
+                
+            # Normalize and assign aliases without overwriting existing keys
+            for source_type, raw_name in alias_candidates:
+                normalized = normalize_display_name(raw_name)
+                if not normalized:
+                    continue
+                if normalized in context:
+                    continue
+                context[normalized] = primary_value
+                logger.debug(f"[TEMPLATE] Added alias '{normalized}' ({source_type}) into context")
+                
+    return context
+
+
+def render_template_string(template_str: str, context: Dict[str, Any], node_id: str) -> str:
+    """Render a single template string using context. Supports both ${{var}} and {{var}}."""
+    if "{{" not in template_str or "}}" not in template_str:
+        return template_str
+
+    try:
+        # Convert ${{var}} to {{var}} syntax for standard Jinja rendering
+        processed_template = template_str.replace("${" + "{", "{{").replace("}}", "}}")
+        template = _jinja_env.from_string(processed_template)
+        return template.render(**context)
+    except Exception as e:
+        logger.warning(f"Jinja rendering failed for node {node_id}: {e}")
+        return template_str
+
+
+def render_value_recursively(value: Any, context: Dict[str, Any], node_id: str) -> Any:
+    """Walk value and render any strings recursively (dicts, lists, tuples)."""
+    if isinstance(value, str):
+        return render_template_string(value, context, node_id)
+    elif isinstance(value, dict):
+        return {k: render_value_recursively(v, context, node_id) for k, v in value.items()}
+    elif isinstance(value, list):
+        return [render_value_recursively(v, context, node_id) for v in value]
+    elif isinstance(value, tuple):
+        return tuple(render_value_recursively(v, context, node_id) for v in value)
+    return value
+
+
+def apply_jinja_to_inputs(
+    inputs: Dict[str, Any],
+    state: FlowState,
+    node_id: str,
+    nodes_registry: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
+    """Resolve Jinja templates dynamically on all input fields, including nested dictionaries/lists.
+    
+    If state has variables, those are also merged into context.
+    """
+    if not inputs:
+        return inputs
+        
+    try:
+        context = build_template_context(state, nodes_registry)
+        
+        # Merge state variables into context (do not overwrite primary context values)
+        if hasattr(state, 'variables') and isinstance(state.variables, dict):
+            for k, v in state.variables.items():
+                if k not in context:
+                    context[k] = v
+                    
+        if not context:
+            logger.debug(f"[TEMPLATE] No context built for node {node_id}; skipping templating")
+            return inputs
+            
+        logger.debug(f"[TEMPLATE] Applying dynamic templating to inputs of node {node_id}")
+        rendered_inputs = render_value_recursively(inputs, context, node_id)
+        
+        # Check if the inputs contain Jinja templates
+        has_jinja = False
+        try:
+            has_jinja = "{{" in str(inputs)
+        except Exception:
+            pass
+
+        # Print before and after for terminal visualization if there's any Jinja template in inputs
+        if has_jinja:
+            print(f"\n[JINJA TEMPLATING] Node: {node_id}")
+            print(f"   BEFORE: {inputs}")
+            print(f"   AFTER : {rendered_inputs}\n")
+            
+        return rendered_inputs
+        
+    except Exception as e:
+        logger.error(f"Failed to apply dynamic templating for node {node_id}: {e}")
+        return inputs

--- a/backend/app/nodes/base.py
+++ b/backend/app/nodes/base.py
@@ -719,15 +719,20 @@ class BaseNode(ABC):
                 metadata = self.metadata
                 node_id = getattr(self, 'node_id', f"{self.__class__.__name__}_{id(self)}")
                 
+                from app.core.templating import apply_jinja_to_inputs
+                nodes_registry = getattr(state, "nodes_registry", None)
+
                 # Prepare inputs based on node type and connections
                 if self.metadata.node_type == NodeType.PROVIDER:
                     # Provider nodes create objects from user inputs only
                     inputs = self._extract_user_inputs(state, metadata.inputs)
+                    inputs = apply_jinja_to_inputs(inputs, state, node_id, nodes_registry)
                     result = self.execute(**inputs)
                     
                 elif self.metadata.node_type == NodeType.PROCESSOR:
                     # Processor nodes need both connected nodes and user inputs
                     user_inputs = self._extract_user_inputs(state, metadata.inputs)
+                    user_inputs = apply_jinja_to_inputs(user_inputs, state, node_id, nodes_registry)
                     connected_nodes = self._extract_connected_inputs(state, metadata.inputs)
                     
                     # Log connection details for debugging
@@ -740,6 +745,7 @@ class BaseNode(ABC):
                     # Terminator nodes process previous node output
                     connected_inputs = self._extract_connected_inputs(state, metadata.inputs)
                     user_inputs = self._extract_user_inputs(state, metadata.inputs)
+                    user_inputs = apply_jinja_to_inputs(user_inputs, state, node_id, nodes_registry)
                     
                     # Get the primary input from connections
                     previous_node = None
@@ -752,6 +758,7 @@ class BaseNode(ABC):
                 else:
                     # Fallback for unknown node types
                     inputs = self._extract_all_inputs(state, metadata.inputs)
+                    inputs = apply_jinja_to_inputs(inputs, state, node_id, nodes_registry)
                     result = self.execute(**inputs)
                 
                 # Handle different result types

--- a/backend/app/nodes/llms/openai_compatible_node.py
+++ b/backend/app/nodes/llms/openai_compatible_node.py
@@ -290,34 +290,66 @@ class OpenAICompatibleNode(BaseNode):
         """Execute Node to create the ChatOpenAI instance."""
         logger.info("\nOPENAI COMPATIBLE NODE SETUP")
         
-        # Extract configuration
-        base_url = self.user_data.get("base_url", "https://openrouter.ai/api/v1")
-        model_name = self.user_data.get("model_name", "google/gemma-3n-e4b-it")
-        temperature = float(self.user_data.get("temperature", 0.7))
-        max_tokens = int(self.user_data.get("max_tokens", 4096))
+        # Get configuration from kwargs or user_data fallback
+        base_url = kwargs.get("base_url") or self.user_data.get("base_url", "https://openrouter.ai/api/v1")
+        model_name = kwargs.get("model_name") or self.user_data.get("model_name", "google/gemma-3n-e4b-it")
+        
+        temperature_val = kwargs.get("temperature")
+        if temperature_val is None:
+            temperature_val = self.user_data.get("temperature", 0.7)
+        temperature = float(temperature_val)
+        
+        max_tokens_val = kwargs.get("max_tokens")
+        if max_tokens_val is None:
+            max_tokens_val = self.user_data.get("max_tokens", 4096)
+        max_tokens = int(max_tokens_val)
 
         # Determine which optional fields the user explicitly enabled
         active_optional = set(self.user_data.get("_active_optional_fields", []))
 
-        # Optional parameters - only use if explicitly activated by the user
-        top_p = float(self.user_data["top_p"]) if "top_p" in active_optional and "top_p" in self.user_data else None
-        frequency_penalty = float(self.user_data["frequency_penalty"]) if "frequency_penalty" in active_optional and "frequency_penalty" in self.user_data else None
-        presence_penalty = float(self.user_data["presence_penalty"]) if "presence_penalty" in active_optional and "presence_penalty" in self.user_data else None
-        timeout = int(self.user_data["timeout"]) if "timeout" in active_optional and "timeout" in self.user_data else None
-        streaming = bool(self.user_data["streaming"]) if "streaming" in active_optional and "streaming" in self.user_data else False
+        # Optional parameters - check kwargs first, then only use user_data if explicitly activated by the user
+        top_p = kwargs.get("top_p")
+        if top_p is None and "top_p" in active_optional and "top_p" in self.user_data:
+            top_p = float(self.user_data["top_p"])
+            
+        frequency_penalty = kwargs.get("frequency_penalty")
+        if frequency_penalty is None and "frequency_penalty" in active_optional and "frequency_penalty" in self.user_data:
+            frequency_penalty = float(self.user_data["frequency_penalty"])
+            
+        presence_penalty = kwargs.get("presence_penalty")
+        if presence_penalty is None and "presence_penalty" in active_optional and "presence_penalty" in self.user_data:
+            presence_penalty = float(self.user_data["presence_penalty"])
+            
+        timeout = kwargs.get("timeout")
+        if timeout is None and "timeout" in active_optional and "timeout" in self.user_data:
+            timeout = int(self.user_data["timeout"])
+            
+        streaming_val = kwargs.get("streaming")
+        if streaming_val is None:
+            if "streaming" in active_optional and "streaming" in self.user_data:
+                streaming_val = self.user_data["streaming"]
+            else:
+                streaming_val = False
+        if isinstance(streaming_val, str):
+            streaming = streaming_val.lower() in ("true", "1", "yes")
+        else:
+            streaming = bool(streaming_val)
         
         # SSL verification - default to True (secure) unless explicitly disabled
-        verify_ssl = self.user_data.get("verify_ssl", True)
-        if isinstance(verify_ssl, str):
-            verify_ssl = verify_ssl.lower() not in ("false", "0", "no")
-        verify_ssl = bool(verify_ssl)
+        verify_ssl_val = kwargs.get("verify_ssl")
+        if verify_ssl_val is None:
+            verify_ssl_val = self.user_data.get("verify_ssl", True)
+        if isinstance(verify_ssl_val, str):
+            verify_ssl = verify_ssl_val.lower() not in ("false", "0", "no")
+        else:
+            verify_ssl = bool(verify_ssl_val)
         
         # OpenRouter specific params
-        site_url = self.user_data.get("site_url", "")
-        site_name = self.user_data.get("site_name", "KAI-Flow")
+        site_url = kwargs.get("site_url") or self.user_data.get("site_url", "")
+        site_name = kwargs.get("site_name") or self.user_data.get("site_name", "KAI-Flow")
         
         # Get API Key
-        credential_id = self.user_data.get("credential_id")
+        credential_id = kwargs.get("credential_id") or self.user_data.get("credential_id")
         logger.info(f"[DEBUG][COMPATIBLE] credential_id: {credential_id}")
         
         api_key_value = ""
@@ -329,10 +361,16 @@ class OpenAICompatibleNode(BaseNode):
                 logger.info(f"[DEBUG][COMPATIBLE] API key length: {len(api_key_value)}")
         
         if not api_key_value:
-             # Some local endpoints might not require a key.
-             # We provide a dummy key because langchain/openai usually expects one.
-             api_key_value = "sk-no-key-required"
-             logger.info("INFO: No API Key provided. Using placeholder key.")
+             # Try environment variables as fallback
+             import os
+             api_key_value = os.getenv("OPENAI_API_KEY") or os.getenv("OPENAI_COMPATIBLE_API_KEY")
+             if api_key_value:
+                 logger.info("INFO: Using API Key from environment.")
+             else:
+                 # Some local endpoints might not require a key.
+                 # We provide a dummy key because langchain/openai usually expects one.
+                 api_key_value = "sk-no-key-required"
+                 logger.info("INFO: No API Key provided. Using placeholder key.")
         
         # Prepare Extra Headers
         extra_headers = {}
@@ -343,7 +381,7 @@ class OpenAICompatibleNode(BaseNode):
                 extra_headers["HTTP-Referer"] = site_url
             if site_name:
                 extra_headers["X-Title"] = site_name
-
+ 
         # Build LLM Configuration
         llm_config = {
             "model": model_name,
@@ -353,7 +391,7 @@ class OpenAICompatibleNode(BaseNode):
             "max_tokens": max_tokens,
             "streaming": streaming,
         }
-
+ 
         # Only include optional parameters if explicitly set by user
         if top_p is not None:
             llm_config["top_p"] = top_p
@@ -363,7 +401,7 @@ class OpenAICompatibleNode(BaseNode):
             llm_config["presence_penalty"] = presence_penalty
         if timeout is not None:
             llm_config["timeout"] = timeout
-
+ 
         if extra_headers:
             llm_config["model_kwargs"] = {"extra_headers": extra_headers}
         

--- a/backend/app/nodes/llms/openai_node.py
+++ b/backend/app/nodes/llms/openai_node.py
@@ -748,20 +748,60 @@ class OpenAINode(BaseNode):
         """Execute OpenAI node with enhanced configuration and validation."""
         logger.info("\nOPENAI LLM SETUP")
         
-        # Get configuration from user_data
-        model_name = self.user_data.get("model_name", "gpt-4o")
-        temperature = float(self.user_data.get("temperature", 0.1))
-        max_tokens = self.user_data.get("max_tokens", 10000)  # Default to 10000 tokens
-        top_p = float(self.user_data.get("top_p", 1.0))
-        frequency_penalty = float(self.user_data.get("frequency_penalty", 0.0))
-        presence_penalty = float(self.user_data.get("presence_penalty", 0.0))
-        streaming = bool(self.user_data.get("streaming", False))
-        timeout = int(self.user_data.get("timeout", 60))
+        # Get configuration from kwargs or user_data fallback
+        model_name = kwargs.get("model_name") or self.user_data.get("model_name", "gpt-4o")
+        
+        temperature_val = kwargs.get("temperature")
+        if temperature_val is None:
+            temperature_val = self.user_data.get("temperature", 0.1)
+        temperature = float(temperature_val)
+        
+        max_tokens = kwargs.get("max_tokens")
+        if max_tokens is None:
+            max_tokens = self.user_data.get("max_tokens", 10000)
+        if max_tokens is not None:
+            max_tokens = int(max_tokens)
+            
+        top_p_val = kwargs.get("top_p")
+        if top_p_val is None:
+            top_p_val = self.user_data.get("top_p", 1.0)
+        top_p = float(top_p_val)
+        
+        frequency_penalty_val = kwargs.get("frequency_penalty")
+        if frequency_penalty_val is None:
+            frequency_penalty_val = self.user_data.get("frequency_penalty", 0.0)
+        frequency_penalty = float(frequency_penalty_val)
+        
+        presence_penalty_val = kwargs.get("presence_penalty")
+        if presence_penalty_val is None:
+            presence_penalty_val = self.user_data.get("presence_penalty", 0.0)
+        presence_penalty = float(presence_penalty_val)
+        
+        streaming_val = kwargs.get("streaming")
+        if streaming_val is None:
+            streaming_val = self.user_data.get("streaming", False)
+        if isinstance(streaming_val, str):
+            streaming = streaming_val.lower() in ("true", "1", "yes")
+        else:
+            streaming = bool(streaming_val)
+            
+        timeout_val = kwargs.get("timeout")
+        if timeout_val is None:
+            timeout_val = self.user_data.get("timeout", 60)
+        timeout = int(timeout_val)
         
         # Get API key from user configuration (database/UI)
-        credential_id = self.user_data.get("credential_id")
-        api_key = self.get_credential(credential_id).get('secret').get('api_key')
+        credential_id = kwargs.get("credential_id") or self.user_data.get("credential_id")
+        api_key = None
+        if credential_id:
+            cred = self.get_credential(credential_id)
+            if cred and cred.get('secret'):
+                api_key = cred.get('secret').get('api_key')
         
+        if not api_key:
+            import os
+            api_key = os.getenv("OPENAI_API_KEY")
+            
         if not api_key:
             raise ValueError(
                 "OpenAI API key is required. Please provide it in the node configuration through the UI."

--- a/backend/app/nodes/tools/cohere_reranker.py
+++ b/backend/app/nodes/tools/cohere_reranker.py
@@ -201,8 +201,11 @@ class CohereRerankerNode(ProviderNode):
         # Note: max_chunks_per_doc removed as it's not supported by LangChain CohereRerank
 
         # If credential_id is present, fetch the actual API key
-        credential_id = self.user_data.get("credential_id")
-        cohere_api_key = self.get_credential(credential_id).get('secret').get('api_key')
+        credential_id = kwargs.get("credential_id") or self.user_data.get("credential_id")
+        if credential_id:
+            cred = self.get_credential(credential_id)
+            if cred and cred.get('secret'):
+                cohere_api_key = cred.get('secret').get('api_key')
         
         # Validate API key
         if not cohere_api_key:

--- a/backend/app/nodes/tools/tavily_search.py
+++ b/backend/app/nodes/tools/tavily_search.py
@@ -527,17 +527,20 @@ class TavilySearchNode(ProviderNode):
         logger.info("\nTAVILY SEARCH SETUP")
 
         try:
-            # Get API key from user configuration (database/UI)
+            # Get API key from user configuration (database/UI) or kwargs
             api_key = None
-            credential_id = self.user_data.get("credential_id")
-            api_key = self.get_credential(credential_id).get('secret').get('api_key')
+            credential_id = kwargs.get("credential_id") or self.user_data.get("credential_id")
+            if credential_id:
+                cred = self.get_credential(credential_id)
+                if cred and cred.get('secret'):
+                    api_key = cred.get('secret').get('api_key')
                         
             if not api_key:
                 api_key = os.getenv("TAVILY_API_KEY")
             
             logger.info(f"   API Key: {'Found' if api_key else 'Missing'}")
             if api_key:
-                logger.info(f"   Source: {'User Config' if self.user_data.get('tavily_api_key') else 'Environment'}")
+                logger.info(f"   Source: {'User Config' if credential_id else 'Environment'}")
             
             if not api_key:
                 raise ValueError(
@@ -545,19 +548,51 @@ class TavilySearchNode(ProviderNode):
                     "or set TAVILY_API_KEY environment variable."
                 )
 
-            # 2. Get all other parameters from user data with defaults.
-            max_results = int(self.user_data.get("max_results", 5))
-            search_depth = self.user_data.get("search_depth", "basic")
-            include_answer = bool(self.user_data.get("include_answer", True))
-            include_raw_content = bool(self.user_data.get("include_raw_content", False))
-            include_images = bool(self.user_data.get("include_images", False))
+            # 2. Get all other parameters from kwargs or user data with defaults.
+            max_results_val = kwargs.get("max_results")
+            if max_results_val is None:
+                max_results_val = self.user_data.get("max_results", 5)
+            max_results = int(max_results_val)
+            
+            search_depth = kwargs.get("search_depth") or self.user_data.get("search_depth", "basic")
+            
+            include_answer_val = kwargs.get("include_answer")
+            if include_answer_val is None:
+                include_answer_val = self.user_data.get("include_answer", True)
+            if isinstance(include_answer_val, str):
+                include_answer = include_answer_val.lower() in ("true", "1", "yes")
+            else:
+                include_answer = bool(include_answer_val)
+                
+            include_raw_content_val = kwargs.get("include_raw_content")
+            if include_raw_content_val is None:
+                include_raw_content_val = self.user_data.get("include_raw_content", False)
+            if isinstance(include_raw_content_val, str):
+                include_raw_content = include_raw_content_val.lower() in ("true", "1", "yes")
+            else:
+                include_raw_content = bool(include_raw_content_val)
+                
+            include_images_val = kwargs.get("include_images")
+            if include_images_val is None:
+                include_images_val = self.user_data.get("include_images", False)
+            if isinstance(include_images_val, str):
+                include_images = include_images_val.lower() in ("true", "1", "yes")
+            else:
+                include_images = bool(include_images_val)
 
             # 3. Safely parse domain lists.
-            include_domains_str = self.user_data.get("include_domains", "")
-            exclude_domains_str = self.user_data.get("exclude_domains", "")
+            include_domains_str = kwargs.get("include_domains") or self.user_data.get("include_domains", "")
+            exclude_domains_str = kwargs.get("exclude_domains") or self.user_data.get("exclude_domains", "")
             
-            include_domains = [d.strip() for d in include_domains_str.split(",") if d.strip()]
-            exclude_domains = [d.strip() for d in exclude_domains_str.split(",") if d.strip()]
+            if isinstance(include_domains_str, list):
+                include_domains = [str(d).strip() for d in include_domains_str if str(d).strip()]
+            else:
+                include_domains = [d.strip() for d in str(include_domains_str).split(",") if d.strip()]
+                
+            if isinstance(exclude_domains_str, list):
+                exclude_domains = [str(d).strip() for d in exclude_domains_str if str(d).strip()]
+            else:
+                exclude_domains = [d.strip() for d in str(exclude_domains_str).split(",") if d.strip()]
 
             # 4. Build search configuration
             search_config = {


### PR DESCRIPTION
- centralize Unicode-safe recursive Jinja2 rendering inside backend templating utilities
- inject node registry into FlowState to resolve templates via node aliases and display names
- refactor node execution pipeline to eliminate duplicated template resolution logic
- enable automatic dynamic input rendering in BaseNode for all inherited node implementations
- prioritize resolved template kwargs over raw payload values in provider node execution flow
- support null-safe credential validation with environment variable API key fallback handling
- add before/after template evaluation logging to trace Jinja render output during execution