### PR TITLE
fix: credential test false negative for OpenAI Compatible providers

### DIFF
--- a/backend/app/api/credentials.py
+++ b/backend/app/api/credentials.py
@@ -379,10 +379,11 @@ async def _test_openai_compatible(secret: Dict[str, Any]) -> CredentialTestRespo
                 timeout=10
             )
         except Exception as auth_test_e:
-            err_msg = str(auth_test_e).lower()
-            if "401" in err_msg or "unauthorized" in err_msg or "invalid" in err_msg:
+            status_code = getattr(auth_test_e, "status_code", None)
+            if status_code == 401:
                 return CredentialTestResponse(success=False, message="Invalid API Key or Unauthorized.")
-            # If it's a 400 Bad Request or 404 Model Not Found, it means authentication passed!
+            if status_code == 403:
+                return CredentialTestResponse(success=False, message="API Key forbidden (403).")
             pass
 
         msg = "Connected to OpenAI Compatible provider successfully."


### PR DESCRIPTION
## Summary
- OpenAI Compatible credential test was using string matching (`"401" in err_msg or "unauthorized" in err_msg or "invalid" in err_msg`) to detect auth failures
- This caused false negatives when unrelated error messages happened to contain words like "invalid"
- Switched to `status_code` attribute check for reliable 401/403 detection

## Test plan
- [ ] Test with valid API key → should return success
- [ ] Test with invalid API key → should return 401 error
- [ ] Test with forbidden key → should return 403 error
- [ ] Test with unreachable provider → should not false-negative on error message content