### PR TITLE
fix: code node sandbox scope, escaping, and input handling bugs

### DIFF
--- a/backend/app/nodes/processing/code_node.py
+++ b/backend/app/nodes/processing/code_node.py
@@ -86,6 +86,9 @@ SAFE_PYTHON_BUILTINS = {
     "type", "zip", # Additional safe functions (note: broadens sandbox surface, kept for backward compatibility)
     "hasattr", "getattr", "setattr", "delattr", "hash", "id", "callable", "classmethod", "staticmethod", "property",
     "locals", "globals", "vars",
+    "Exception", "ValueError", "TypeError", "KeyError", "IndexError", "AttributeError", "RuntimeError",
+    "StopIteration", "GeneratorExit", "ArithmeticError", "ZeroDivisionError", "OverflowError",
+    "LookupError", "IOError", "OSError", "ImportError", "NotImplementedError",
 }
 
 SAFE_PYTHON_MODULES = {
@@ -204,16 +207,18 @@ class PythonSandbox:
             return f"Code validation error: {str(e)}"
 
     def _build_wrapper_script(self) -> str:
+        import base64 as _b64
         context_json = json.dumps(self.context, default=str, ensure_ascii=False)
-        context_json_escaped = context_json.replace("\\", "\\\\").replace('"""', '\\"\\"\\"')
+        context_b64 = _b64.b64encode(context_json.encode("utf-8")).decode("ascii")
 
-        user_code_escaped = self.code.replace("\\", "\\\\").replace('"""', '\\"\\"\\"')
+        user_code_b64 = _b64.b64encode(self.code.encode("utf-8")).decode("ascii")
 
         safe_builtins_list = list(SAFE_PYTHON_BUILTINS)
         safe_modules_list = sorted(SAFE_PYTHON_MODULES)
 
         wrapper = f'''# -*- coding: utf-8 -*-
 import sys
+import base64
 import json
 import math
 import random
@@ -258,7 +263,7 @@ def main():
     }}
 
     try:
-        context = json.loads("""{context_json_escaped}""")
+        context = json.loads(base64.b64decode("{context_b64}").decode("utf-8"))
         exec_globals.update(context)
     except Exception as ctx_err:
         print("{PY_MARKER_START}")
@@ -270,21 +275,21 @@ def main():
     exec_globals["_now"] = datetime.datetime.now
     exec_globals["_utcnow"] = lambda: datetime.datetime.now(datetime.timezone.utc)
 
-    exec_locals = {{}}
     try:
-        user_code = """{user_code_escaped}"""
-        exec(user_code, exec_globals, exec_locals)
+        user_code = base64.b64decode("{user_code_b64}").decode("utf-8")
+        exec(user_code, exec_globals)
 
-        output = exec_locals.get("output", exec_locals.get("result", None))
+        output = exec_globals.get("output", exec_globals.get("result", None))
 
         serializable_locals = {{}}
-        for k, v in exec_locals.items():
-            if not k.startswith("_") and not callable(v):
-                try:
-                    json.dumps(v, default=str)
-                    serializable_locals[k] = v
-                except Exception:
-                    serializable_locals[k] = str(v)
+        for k, v in exec_globals.items():
+            if k.startswith("_") or callable(v) or k == "__builtins__":
+                continue
+            try:
+                json.dumps(v, default=str)
+                serializable_locals[k] = v
+            except Exception:
+                serializable_locals[k] = str(v)
 
         print("{PY_MARKER_START}")
         print(json.dumps({{
@@ -581,6 +586,9 @@ def _extract_input_payload(input_data: Any) -> Any:
         if "content" in input_data:
             return input_data["content"]
 
+        if "value" in input_data and len(input_data) == 1:
+            return input_data["value"]
+
         return input_data
 
     if hasattr(input_data, "page_content"):
@@ -767,6 +775,8 @@ class CodeNode(ProcessorNode):
         input_data = connected_nodes.get("input", None)
         logger.info("RAW INPUT (before extraction): %s", input_data)
         input_data = _extract_input_payload(input_data)
+        if isinstance(input_data, str):
+            input_data = input_data.lstrip("﻿")
         logger.info("PROCESSED INPUT (after extraction): %s", input_data)
 
         context = {
@@ -789,10 +799,15 @@ class CodeNode(ProcessorNode):
             logger.info("Execution success=%s time=%.2fms", result.get("success"), execution_time_ms)
 
             if result.get("success"):
+                output_var = result.get("output")
                 stdout_output = (result.get("stdout") or "").strip()
-                
-                # SMART OUTPUT DETECTION: If stdout looks like a Python dict/list repr,
-                # automatically convert to proper JSON format
+
+                if output_var is not None:
+                    if not isinstance(output_var, str):
+                        output_var = json.dumps(output_var, default=str, ensure_ascii=False)
+                    return {"output": output_var}
+
+
                 if stdout_output and (
                     (stdout_output.startswith('{') and stdout_output.endswith('}')) or
                     (stdout_output.startswith('[') and stdout_output.endswith(']'))


### PR DESCRIPTION
## Summary
- **exec_locals scope bug**: Python 3 list comprehensions create their own scope and can't see variables in `exec_locals`, causing `NameError` inside comprehensions. Fixed by using single dict `exec(user_code, exec_globals)`.
- **Missing exception builtins**: `except Exception:` failed with `NameError` because `Exception`, `ValueError`, `TypeError` etc. were not in `SAFE_PYTHON_BUILTINS`. Added common exception types to the whitelist.
- **Triple-quote escaping**: User code containing `"""` broke the wrapper script. Switched to base64 encoding for both user code and context JSON.
- **Kafka consumer output**: Code node couldn't extract the `value` key from Kafka consumer output when it was the only key in the dict.
- **BOM character**: String input starting with BOM character caused parse failures. Added BOM stripping.
- **Output variable priority**: Code node now returns the `output` variable directly when set, instead of falling through to stdout parsing.

## Test plan
- [ ] Run code with list comprehension referencing outer variables → should not raise NameError
- [ ] Run code with `except Exception:` → should catch exceptions properly
- [ ] Run code containing triple quotes (`"""`) → should execute without wrapper corruption
- [ ] Send Kafka message with `{"value": "..."}` format → code node should extract value
- [ ] Send string input with BOM prefix → should be stripped before processing
- [ ] Set `output` variable in code → should be returned directly without stdout parsing