### PR TITLE
feat: standardize node outputs and enable nested Jinja path resolution across execution flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
 lerna-debug.log*
+.agents
 
 # IDE
 .idea/

--- a/backend/app/api/workflows.py
+++ b/backend/app/api/workflows.py
@@ -1353,3 +1353,47 @@ async def execute_timer_node_manually(
     except Exception as e:
         logger.error(f"Error during manual TimerStartNode execution: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Failed to execute TimerStartNode: {str(e)}")
+
+
+@router.get("/error-trigger/{workflow_id}/stream")
+async def stream_error_trigger_execution(workflow_id: str):
+    """Stream error-trigger workflow execution events for the canvas UI."""
+    from app.services.error_handler_service import error_trigger_subscribers
+    
+    async def event_stream():
+        import asyncio
+        import json
+        from datetime import datetime, timezone
+        from app.core.json_utils import make_json_serializable
+        
+        queue: asyncio.Queue = asyncio.Queue(maxsize=100)
+        error_trigger_subscribers.setdefault(workflow_id, []).append(queue)
+        
+        try:
+            yield f"data: {json.dumps({'type': 'connected', 'workflow_id': workflow_id, 'timestamp': datetime.now(timezone.utc).isoformat()}, ensure_ascii=False)}\n\n"
+            
+            while True:
+                try:
+                    event = await asyncio.wait_for(queue.get(), timeout=30.0)
+                    serializable_event = make_json_serializable(event)
+                    yield f"data: {json.dumps(serializable_event, ensure_ascii=False)}\n\n"
+                except asyncio.TimeoutError:
+                    yield f"data: {json.dumps({'type': 'ping', 'timestamp': datetime.now(timezone.utc).isoformat()}, ensure_ascii=False)}\n\n"
+        except asyncio.CancelledError:
+            pass
+        finally:
+            subscribers = error_trigger_subscribers.get(workflow_id, [])
+            if queue in subscribers:
+                subscribers.remove(queue)
+                
+    from fastapi.responses import StreamingResponse
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Headers": "*",
+        },
+    )

--- a/backend/app/core/graph_builder/__init__.py
+++ b/backend/app/core/graph_builder/__init__.py
@@ -172,6 +172,10 @@ class GraphBuilder:
             # Step 5: Compile final LangGraph
             compiled_graph = self._compile_final_graph()
             
+            # Register this builder's nodes registry globally for templating fallback
+            from app.core.templating import register_global_registry
+            register_global_registry(flow_data.get("id") if isinstance(flow_data, dict) else None, self.nodes)
+            
             # Step 6: Record build metrics
             build_duration = time.time() - start_time
             self._build_metrics = {
@@ -582,11 +586,16 @@ class GraphBuilder:
         """Enhanced node wrapper that uses NodeExecutor for execution."""
         
         def wrapper(state: FlowState) -> Dict[str, Any]:
+            import time
+            start_time = time.time()
             try:
                 logger.info(f"EXECUTING: {node_id} ({gnode.type}) with NodeExecutor")
                 
                 # Inject nodes registry into state so that nodes can resolve Jinja variables with friendly names
-                state.nodes_registry = self.nodes
+                if isinstance(state, dict):
+                    state["nodes_registry"] = self.nodes
+                else:
+                    state.nodes_registry = self.nodes
                 
                 # Merge user data into node instance before execution
                 gnode.node_instance.user_data.update(gnode.user_data)
@@ -619,26 +628,77 @@ class GraphBuilder:
                 
                 logger.error(f"Node {node_id} ({gnode.type}) execution failed: {str(e)}")
                 
+                # Standardize error output
+                try:
+                    from app.core.json_utils import format_standard_node_output
+                    execution_time_ms = round((time.time() - start_time) * 1000, 2)
+                    standard_error_output = format_standard_node_output(
+                        node_id=node_id,
+                        node_type=gnode.type,
+                        success=False,
+                        status_code=500,
+                        execution_time_ms=execution_time_ms,
+                        inputs=gnode.user_data,
+                        output=None,
+                        error=error_details,
+                        node_instance=gnode.node_instance
+                    )
+                    
+                    if isinstance(state, dict):
+                        if "node_outputs" not in state or not isinstance(state["node_outputs"], dict):
+                            state["node_outputs"] = {}
+                        state["node_outputs"][node_id] = standard_error_output
+                    else:
+                        if not hasattr(state, 'node_outputs') or not isinstance(state.node_outputs, dict):
+                            state.node_outputs = {}
+                        state.node_outputs[node_id] = standard_error_output
+                except Exception as formatting_err:
+                    logger.warning(f"Failed to record standardized error in _wrap_node_enhanced: {formatting_err}")
+
                 # Update state with error
-                if hasattr(state, 'add_error'):
-                    state.add_error(f"Node {node_id} failed: {str(e)}")
+                if isinstance(state, dict):
+                    if "errors" not in state or not isinstance(state["errors"], list):
+                        state["errors"] = []
+                    state["errors"].append(f"Node {node_id} failed: {str(e)}")
+                    state["last_output"] = f"ERROR in {node_id}: {str(e)}"
                 else:
-                    if not hasattr(state, 'errors'):
-                        state.errors = []
-                    state.errors.append(f"Node {node_id} failed: {str(e)}")
+                    if hasattr(state, 'add_error'):
+                        state.add_error(f"Node {node_id} failed: {str(e)}")
+                    else:
+                        if not hasattr(state, 'errors') or not isinstance(state.errors, list):
+                            state.errors = []
+                        state.errors.append(f"Node {node_id} failed: {str(e)}")
+                    state.last_output = f"ERROR in {node_id}: {str(e)}"
                 
                 # Store detailed error information
-                if not hasattr(state, 'error_details'):
-                    state.error_details = {}
-                state.error_details[node_id] = error_details
-                
-                state.last_output = f"ERROR in {node_id}: {str(e)}"
+                if isinstance(state, dict):
+                    if "error_details" not in state or not isinstance(state["error_details"], dict):
+                        state["error_details"] = {}
+                    state["error_details"][node_id] = error_details
+                else:
+                    if not hasattr(state, 'error_details') or not isinstance(state.error_details, dict):
+                        state.error_details = {}
+                    state.error_details[node_id] = error_details
                 
                 # Raise the exception to stop execution
-                if isinstance(e, NodeExecutionError):
-                    raise  # Re-raise NodeExecutor exceptions
+                if isinstance(state, dict):
+                    node_outs = state.get("node_outputs", {}).copy()
+                    exec_nodes = state.get("executed_nodes", []).copy()
                 else:
-                    raise NodeExecutionError(node_id, gnode.type, e) from e
+                    node_outs = state.node_outputs.copy() if hasattr(state, 'node_outputs') and state.node_outputs else {}
+                    exec_nodes = state.executed_nodes.copy() if hasattr(state, 'executed_nodes') and state.executed_nodes else []
+                
+                if isinstance(e, NodeExecutionError):
+                    if not e.context:
+                        e.context = {}
+                    e.context["node_outputs"] = node_outs
+                    e.context["executed_nodes"] = exec_nodes
+                    raise
+                else:
+                    err = NodeExecutionError(node_id, gnode.type, e)
+                    err.context["node_outputs"] = node_outs
+                    err.context["executed_nodes"] = exec_nodes
+                    raise err from e
 
         wrapper.__name__ = f"node_{node_id}"
         return wrapper
@@ -718,7 +778,10 @@ class GraphBuilder:
         def route_condition(state: FlowState) -> str:
             """Route based on ConditionNode's _route output."""
             # Get the node's output from state
-            node_outputs = getattr(state, 'node_outputs', {})
+            if isinstance(state, dict):
+                node_outputs = state.get('node_outputs', {})
+            else:
+                node_outputs = getattr(state, 'node_outputs', {})
             condition_output = node_outputs.get(node_id, {})
             
             # Check for _route key in output
@@ -845,13 +908,105 @@ class GraphBuilder:
             webhook_data=webhook_data,  # Add webhook data for templating
         )
 
+        # Register this session/workflow registry globally for templating fallback
+        from app.core.templating import register_global_registry
+        register_global_registry(init_state.session_id, self.nodes)
+        if workflow_id:
+            register_global_registry(workflow_id, self.nodes)
+
         # Inject Kafka data into node_outputs if present
         kafka_data = inputs.get("kafka_data")
         listener_id = inputs.get("listener_id")
-        if inputs.get("kafka_trigger") and kafka_data and listener_id:
-            logger.info(f"Injecting Kafka trigger data for listener {listener_id}")
-            # Inject as a node output so it can be referenced via templating
-            init_state.set_node_output(listener_id, kafka_data)
+        
+        # Pre-inject trigger node outputs so they are available in node_outputs (and downstream nodes)
+        from app.nodes.base import NodeType
+        for node_id, gnode in self.nodes.items():
+            node_type_val = None
+            try:
+                node_type_val = gnode.node_instance.metadata.node_type
+            except Exception:
+                pass
+                
+            is_trigger = False
+            if gnode.type in ("StartNode", "WebhookTrigger", "KafkaConsumer", "KafkaTrigger", "TimerStartNode", "ErrorTriggerNode"):
+                is_trigger = True
+            elif node_type_val == NodeType.TERMINATOR and gnode.type not in ("EndNode", "RespondToWebhook"):
+                is_trigger = True
+                
+            if is_trigger:
+                try:
+                    # 1. Webhook Trigger Node
+                    if "webhook" in gnode.type.lower() or gnode.node_instance.__class__.__name__ == "WebhookTriggerNode":
+                        if webhook_data:
+                            payload = webhook_data.get("data", webhook_data)
+                            gnode.node_instance.user_data["webhook_payload"] = payload
+                            output_dict = gnode.node_instance._execute(init_state)
+                        else:
+                            output_dict = gnode.node_instance.execute()
+                            if isinstance(output_dict, dict) and "webhook_data" not in output_dict:
+                                output_dict["webhook_data"] = {
+                                    "payload": {},
+                                    "timestamp": datetime.now().isoformat(),
+                                    "webhook_id": getattr(gnode.node_instance, "webhook_id", "mock"),
+                                    "source": "mock",
+                                    "event_type": "webhook.received"
+                                }
+                                
+                        from app.core.json_utils import format_standard_node_output
+                        standard_output = format_standard_node_output(
+                            node_id=node_id,
+                            node_type=gnode.type,
+                            success=True,
+                            status_code=200,
+                            execution_time_ms=0.0,
+                            inputs=gnode.user_data,
+                            output=output_dict,
+                            node_instance=gnode.node_instance
+                        )
+                        init_state.set_node_output(node_id, standard_output)
+                        logger.info(f"[TRIGGER] Pre-injected standardized output for webhook: {node_id}")
+                        
+                    # 2. Kafka Trigger Node
+                    elif "kafka" in gnode.type.lower() or gnode.node_instance.__class__.__name__ == "KafkaTriggerNode":
+                        k_data = kafka_data or inputs.get("kafka_data") or {}
+                        output_dict = {
+                            "kafka_data": k_data,
+                            "output": k_data.get("value", "Kafka trigger message")
+                        }
+                        from app.core.json_utils import format_standard_node_output
+                        standard_output = format_standard_node_output(
+                            node_id=node_id,
+                            node_type=gnode.type,
+                            success=True,
+                            status_code=200,
+                            execution_time_ms=0.0,
+                            inputs=gnode.user_data,
+                            output=output_dict,
+                            node_instance=gnode.node_instance
+                        )
+                        init_state.set_node_output(node_id, standard_output)
+                        logger.info(f"[TRIGGER] Pre-injected standardized output for kafka: {node_id}")
+                        
+                    # 3. Start Node
+                    elif gnode.type == "StartNode" or gnode.node_instance.__class__.__name__ == "StartNode":
+                        output_dict = {
+                            "output": initial_input or "Workflow started"
+                        }
+                        from app.core.json_utils import format_standard_node_output
+                        standard_output = format_standard_node_output(
+                            node_id=node_id,
+                            node_type=gnode.type,
+                            success=True,
+                            status_code=200,
+                            execution_time_ms=0.0,
+                            inputs=gnode.user_data,
+                            output=output_dict,
+                            node_instance=gnode.node_instance
+                        )
+                        init_state.set_node_output(node_id, standard_output)
+                        logger.info(f"[TRIGGER] Pre-injected standardized output for start node: {node_id}")
+                except Exception as trigger_err:
+                    logger.warning(f"Failed to pre-inject trigger output for {node_id}: {trigger_err}")
 
         config: RunnableConfig = {"configurable": {"thread_id": init_state.session_id}}
 
@@ -939,7 +1094,7 @@ class GraphBuilder:
             
             logger.info(f"Final result output: {str(result_output)[:100] if result_output else '(empty)'}")
             
-            return {
+            result = {
                 "success": True,
                 "result": result_output,
                 "state": state_dict,
@@ -947,8 +1102,17 @@ class GraphBuilder:
                 "session_id": state_dict.get("session_id", init_state.session_id),
             }
             
+            # Cleanup session-scoped registry to prevent memory leak
+            from app.core.templating import unregister_global_registry
+            unregister_global_registry(init_state.session_id)
+            
+            return result
+            
         except Exception as e:
             logger.error(f"Workflow execution failed in _execute_sync: {e}", exc_info=True)
+            # Cleanup session-scoped registry even on failure
+            from app.core.templating import unregister_global_registry
+            unregister_global_registry(init_state.session_id)
             # Re-raise so workflow_executor can properly mark execution as "failed"
             raise
 
@@ -993,8 +1157,12 @@ class GraphBuilder:
                     # Try to extract meaningful output from various formats
                     output_data = {}
                     if isinstance(node_output, dict):
+                        standard_key = f"output_{node_name}"
+                        # Check if standardized output is present first
+                        if standard_key in node_output:
+                            output_data = node_output.get(standard_key)
                         # Check for common output keys
-                        if "last_output" in node_output:
+                        elif "last_output" in node_output:
                             output_data["output"] = node_output.get("last_output")
                         elif "output" in node_output:
                             output_data["output"] = node_output.get("output")
@@ -1046,13 +1214,46 @@ class GraphBuilder:
                 "session_id": init_state.session_id,
             }
             
+            # Cleanup session-scoped registry to prevent memory leak
+            from app.core.templating import unregister_global_registry
+            unregister_global_registry(init_state.session_id)
+            
         except Exception as e:
+            # Extract state data from exception context first, fallback to checkpointer
+            node_outputs = {}
+            executed_nodes = []
+            
+            # Recursively traverse exception chain to find context
+            curr_e = e
+            while curr_e:
+                if hasattr(curr_e, "context") and isinstance(curr_e.context, dict):
+                    node_outputs = curr_e.context.get("node_outputs") or {}
+                    executed_nodes = curr_e.context.get("executed_nodes") or []
+                    if node_outputs:
+                        break
+                curr_e = getattr(curr_e, "__cause__", None) or getattr(curr_e, "__context__", None)
+                
+            if not node_outputs:
+                try:
+                    final_state = await self.graph.aget_state(config)
+                    if hasattr(final_state, 'values') and final_state.values:
+                        node_outputs = final_state.values.get('node_outputs', {})
+                        executed_nodes = final_state.values.get('executed_nodes', [])
+                except Exception as state_err:
+                    logger.warning(f"Failed to get graph state on streaming error: {state_err}")
+                
             yield {
                 "type": "error", 
                 "error": str(e), 
                 "error_type": type(e).__name__, 
-                "session_id": init_state.session_id
+                "session_id": init_state.session_id,
+                "node_outputs": node_outputs,
+                "executed_nodes": executed_nodes
             }
+            
+            # Cleanup session-scoped registry even on error
+            from app.core.templating import unregister_global_registry
+            unregister_global_registry(init_state.session_id)
 
     async def execute_with_monitoring(
             self,
@@ -1076,5 +1277,4 @@ class GraphBuilder:
         except Exception as e:
             execution_duration = time.time() - execution_start
             logger.error(f"Enhanced execution failed after {execution_duration:.3f}s: {e}")
-            raise
             raise

--- a/backend/app/core/graph_builder/node_executor.py
+++ b/backend/app/core/graph_builder/node_executor.py
@@ -137,6 +137,7 @@ class NodeExecutor:
         """
         try:
             logger.info(f"[PROCESSING] Executing processor node: {node_id} ({gnode.type})")
+            start_time = datetime.datetime.now()
             
             # Extract user inputs for processor
             user_inputs = self.extract_user_inputs_for_processor(gnode, state)
@@ -146,9 +147,27 @@ class NodeExecutor:
             user_inputs = apply_jinja_to_inputs(user_inputs, state, node_id, self._nodes_registry)
             logger.debug(f"Templated user inputs: {list(user_inputs.keys()) if user_inputs else 'None'}")
             
+            # Inject kafka_data if the node is a Kafka consumer trigger
+            if gnode.type in ("KafkaConsumer", "KafkaTrigger") or gnode.node_instance.__class__.__name__ == "KafkaTriggerNode":
+                kafka_data = None
+                state_variables = state.get("variables") if isinstance(state, dict) else getattr(state, "variables", None)
+                if isinstance(state_variables, dict):
+                    kafka_data = state_variables.get("kafka_data")
+                state_node_outputs = state.get("node_outputs") if isinstance(state, dict) else getattr(state, "node_outputs", None)
+                if not kafka_data and isinstance(state_node_outputs, dict):
+                    kafka_node_out = state_node_outputs.get(node_id)
+                    if isinstance(kafka_node_out, dict):
+                        kafka_data = kafka_node_out.get("kafka_data") or kafka_node_out.get("value")
+                if kafka_data:
+                    user_inputs["kafka_data"] = kafka_data
+                    logger.info(f"[KAFKA] Successfully injected kafka_data into inputs for node: {node_id}")
+
             # Extract connected node instances
             connected_nodes = self.extract_connected_node_instances(gnode, state)
             logger.debug(f"Connected nodes extracted: {list(connected_nodes.keys())}")
+            
+            # Build resolved inputs representation for standard logging
+            resolved_inputs = {**user_inputs, **{k: make_json_serializable_with_langchain(v) if not isinstance(v, (str, dict, list, int, float, bool)) else v for k, v in connected_nodes.items()}}
             
             # Call execute with proper async handling
             execute_method = gnode.node_instance.execute
@@ -161,7 +180,15 @@ class NodeExecutor:
             except Exception:
                 pass  # If we can't determine node type, use default processor pattern
             
-            if is_terminator:
+            # Check if trigger node defines a custom _execute method taking state
+            if hasattr(gnode.node_instance, "_execute") and callable(getattr(gnode.node_instance, "_execute")):
+                logger.info(f"[TRIGGER] Executing custom _execute with state for node: {node_id}")
+                execute_method_trigger = gnode.node_instance._execute
+                if inspect.iscoroutinefunction(execute_method_trigger):
+                    result = self._execute_async_trigger(execute_method_trigger, state, node_id)
+                else:
+                    result = execute_method_trigger(state)
+            elif is_terminator:
                 # TERMINATOR nodes expect (previous_node, inputs) signature
                 # Extract the primary connected input as previous_node
                 previous_node = None
@@ -210,20 +237,35 @@ class NodeExecutor:
                 last_output = str(processed_result)
             # Update the state directly
             state.last_output = last_output
-            state.executed_nodes = updated_executed_nodes                       # Filter out complex objects before storing in state
-            if gnode.type in PROCESSOR_NODE_TYPES:
-                serializable_result = make_json_serializable_with_langchain(processed_result, filter_complex=True)
-                serializable_output = last_output
-                logger.debug(f"Agent serializable output: {type(serializable_output)} - '{str(serializable_output)[:100]}...'")
+            state.executed_nodes = updated_executed_nodes
+            
+            # Calculate execution duration
+            execution_time_ms = round((datetime.datetime.now() - start_time).total_seconds() * 1000, 2)
+            
+            # Format standard output
+            from app.core.json_utils import format_standard_node_output
+            standard_output = format_standard_node_output(
+                node_id=node_id,
+                node_type=gnode.type,
+                success=True,
+                status_code=200,
+                execution_time_ms=execution_time_ms,
+                inputs=resolved_inputs,
+                output=processed_result,
+                node_instance=gnode.node_instance
+            )
+            
+            if isinstance(state, dict):
+                if 'node_outputs' not in state or not isinstance(state['node_outputs'], dict):
+                    state['node_outputs'] = {}
+                state['node_outputs'][node_id] = standard_output
             else:
-                serializable_result = make_json_serializable_with_langchain(processed_result, filter_complex=False)
-                serializable_output = serializable_result            # Store only serializable data in state for connected nodes to access
-            if not hasattr(state, 'node_outputs'):
-                state.node_outputs = {}
-            state.node_outputs[node_id] = serializable_result
+                if not hasattr(state, 'node_outputs') or not isinstance(state.node_outputs, dict):
+                    state.node_outputs = {}
+                state.node_outputs[node_id] = standard_output
             
             result_dict = {
-                f"output_{node_id}": serializable_output,
+                f"output_{node_id}": standard_output,
                 "executed_nodes": updated_executed_nodes,
                 "last_output": last_output,
                 "node_outputs": state.node_outputs
@@ -235,6 +277,40 @@ class NodeExecutor:
             return result_dict
             
         except Exception as e:
+            try:
+                execution_time_ms = round((datetime.datetime.now() - start_time).total_seconds() * 1000, 2)
+                error_details = {
+                    "node_id": node_id,
+                    "node_type": gnode.type,
+                    "error_type": type(e).__name__,
+                    "error_message": str(e),
+                    "timestamp": datetime.datetime.now().isoformat(),
+                    "stack_trace": traceback.format_exc()
+                }
+                from app.core.json_utils import format_standard_node_output
+                local_resolved_inputs = locals().get('resolved_inputs', {})
+                standard_error_output = format_standard_node_output(
+                    node_id=node_id,
+                    node_type=gnode.type,
+                    success=False,
+                    status_code=500,
+                    execution_time_ms=execution_time_ms,
+                    inputs=local_resolved_inputs,
+                    output=None,
+                    error=error_details,
+                    node_instance=gnode.node_instance
+                )
+                if isinstance(state, dict):
+                    if 'node_outputs' not in state or not isinstance(state['node_outputs'], dict):
+                        state['node_outputs'] = {}
+                    state['node_outputs'][node_id] = standard_error_output
+                else:
+                    if not hasattr(state, 'node_outputs') or not isinstance(state.node_outputs, dict):
+                        state.node_outputs = {}
+                    state.node_outputs[node_id] = standard_error_output
+            except Exception as formatting_err:
+                logger.warning(f"Failed to record standardized error in execute_processor_node: {formatting_err}")
+
             raise NodeExecutionError(
                 node_id=node_id,
                 node_type=gnode.type,
@@ -272,9 +348,14 @@ class NodeExecutor:
                     output_key = f"output_{node_id}"
                     if output_key in result:
                         primary_raw = result[output_key]
-                        if not hasattr(state, "node_outputs"):
-                            state.node_outputs = {}
-                        state.node_outputs[node_id] = primary_raw
+                        if isinstance(state, dict):
+                            if 'node_outputs' not in state or not isinstance(state['node_outputs'], dict):
+                                state['node_outputs'] = {}
+                            state['node_outputs'][node_id] = primary_raw
+                        else:
+                            if not hasattr(state, "node_outputs") or not isinstance(state.node_outputs, dict):
+                                state.node_outputs = {}
+                            state.node_outputs[node_id] = primary_raw
                         logger.debug(
                             f"[TEMPLATE] Standard node {node_id} stored in state.node_outputs "
                             f"with type={type(primary_raw)}"
@@ -282,7 +363,7 @@ class NodeExecutor:
                         # CRITICAL: Ensure the returned result dict also has the updated node_outputs
                         # to prevent LangGraph's merge from overwriting the in-place change with an old version
                         if isinstance(result, dict):
-                            result["node_outputs"] = state.node_outputs
+                            result["node_outputs"] = state.get("node_outputs", {}) if isinstance(state, dict) else getattr(state, "node_outputs", {})
             except Exception as e:
                 logger.warning(f"[TEMPLATE] Failed to store standard node output for {node_id}: {e}")
             
@@ -572,6 +653,24 @@ class NodeExecutor:
         except Exception as e:
             logger.error(f"Failed to execute async terminator method for {node_id}: {e}")
             raise
+            
+    def _execute_async_trigger(self, execute_method, state, node_id: str) -> Any:
+        """Execute async trigger method with proper event loop handling."""
+        try:
+            try:
+                loop = asyncio.get_event_loop()
+                if loop.is_running():
+                    with concurrent.futures.ThreadPoolExecutor() as executor:
+                        future = executor.submit(asyncio.run, execute_method(state))
+                        result = future.result()
+                else:
+                    result = asyncio.run(execute_method(state))
+            except RuntimeError:
+                result = asyncio.run(execute_method(state))
+            return result
+        except Exception as e:
+            logger.error(f"Failed to execute async trigger for {node_id}: {e}")
+            raise
     
     def _has_pool_connections(self, gnode: GraphNodeInstance) -> bool:
         """
@@ -671,8 +770,9 @@ class NodeExecutor:
                 return None
             
             # Check if we have cached output for this node
-            if hasattr(state, 'node_outputs') and source_node_id in state.node_outputs:
-                stored_result = state.node_outputs[source_node_id]
+            state_node_outputs = state.get("node_outputs") if isinstance(state, dict) else getattr(state, "node_outputs", None)
+            if isinstance(state_node_outputs, dict) and source_node_id in state_node_outputs:
+                stored_result = state_node_outputs[source_node_id]
                 
                 # Try to extract specific handle output
                 if isinstance(stored_result, dict) and source_handle in stored_result:

--- a/backend/app/core/json_utils.py
+++ b/backend/app/core/json_utils.py
@@ -38,7 +38,7 @@ Usage:
     serializable = make_json_serializable_with_langchain(agent_result, filter_complex=True)
 """
 
-from typing import Any, Optional
+from typing import Any, Optional, Dict
 from datetime import datetime, date
 from decimal import Decimal
 import uuid
@@ -102,6 +102,17 @@ def json_serializer_default(obj: Any) -> Any:
         return str(obj)
     elif isinstance(obj, Decimal):
         return float(obj)
+    # LangChain LLMs, ChatModels, Embeddings
+    class_name = obj.__class__.__name__
+    module_name = obj.__class__.__module__.lower()
+    if "langchain" in module_name:
+        is_llm_or_embed = any(kw in module_name for kw in ("language_models", "chat_models", "llms", "embeddings")) or class_name.endswith("Embeddings")
+        if is_llm_or_embed:
+            if hasattr(obj, 'model_name') and getattr(obj, 'model_name'):
+                return f"<{class_name} model={getattr(obj, 'model_name')}>"
+            if hasattr(obj, 'model') and getattr(obj, 'model'):
+                return f"<{class_name} model={getattr(obj, 'model')}>"
+            return f"<{class_name}>"
     # LangChain objects (if available)
     elif _LANGCHAIN_AVAILABLE and (_BaseTool and isinstance(obj, _BaseTool) or 
                                    _Runnable and isinstance(obj, _Runnable)):
@@ -194,6 +205,18 @@ def make_json_serializable(obj: Any, filter_langchain_complex: bool = False) -> 
     elif isinstance(obj, (list, tuple)):
         return [make_json_serializable(item, filter_langchain_complex) 
                 for item in obj]
+    # LangChain LLMs, ChatModels, Embeddings
+    class_name = obj.__class__.__name__
+    module_name = obj.__class__.__module__.lower()
+    if "langchain" in module_name:
+        is_llm_or_embed = any(kw in module_name for kw in ("language_models", "chat_models", "llms", "embeddings")) or class_name.endswith("Embeddings")
+        if is_llm_or_embed:
+            if hasattr(obj, 'model_name') and getattr(obj, 'model_name'):
+                return f"<{class_name} model={getattr(obj, 'model_name')}>"
+            if hasattr(obj, 'model') and getattr(obj, 'model'):
+                return f"<{class_name} model={getattr(obj, 'model')}>"
+            return f"<{class_name}>"
+
     # LangChain complex objects (BaseTool, Runnable, callable) - convert to string representation
     # Note: We use 'if' here instead of 'elif' to allow fallthrough to Pydantic handling for other LangChain objects like Document
     if _LANGCHAIN_AVAILABLE:
@@ -300,6 +323,152 @@ def make_json_serializable_with_langchain(obj: Any, filter_complex: bool = True)
         >>> # tools and memory are filtered out, output is preserved
     """
     return make_json_serializable(obj, filter_langchain_complex=filter_complex)
+
+
+def format_standard_node_output(
+    node_id: str,
+    node_type: str,
+    success: bool,
+    status_code: int,
+    execution_time_ms: float,
+    inputs: Any,
+    output: Any,
+    error: Optional[Dict[str, Any]] = None,
+    node_instance: Optional[Any] = None
+) -> Dict[str, Any]:
+    """
+    Format node execution result into a standardized JSON structure.
+    Also copies keys from the output payload to the top-level (if output is a dict)
+    to maintain backward compatibility with routing and direct key access.
+    
+    If node_instance is provided, metadata.outputs definitions are dynamically inspected
+    and mapped to the root of the output dictionary.
+    """
+    serializable_inputs = make_json_serializable_with_langchain(inputs, filter_complex=True)
+    serializable_output = make_json_serializable_with_langchain(output, filter_complex=False)
+    
+    # Dynamically resolve success status and status code from the output payload if present
+    dynamic_success = success
+    dynamic_status_code = status_code
+    
+    if isinstance(serializable_output, dict):
+        # Resolve dynamic success
+        if "success" in serializable_output:
+            val = serializable_output["success"]
+            if isinstance(val, bool):
+                dynamic_success = val
+            elif str(val).lower() in ("true", "1"):
+                dynamic_success = True
+            elif str(val).lower() in ("false", "0"):
+                dynamic_success = False
+                
+        # Resolve dynamic status code (supports both status_code and statusCode)
+        if "status_code" in serializable_output:
+            try:
+                dynamic_status_code = int(serializable_output["status_code"])
+            except (ValueError, TypeError):
+                pass
+        elif "statusCode" in serializable_output:
+            try:
+                dynamic_status_code = int(serializable_output["statusCode"])
+            except (ValueError, TypeError):
+                pass
+                
+    result = {
+        "success": dynamic_success,
+        "statusCode": dynamic_status_code,
+        "nodeId": node_id,
+        "nodeType": node_type,
+        "timestamp": datetime.now().isoformat(),
+        "executionTimeMs": execution_time_ms,
+        "inputs": serializable_inputs,
+        "output": serializable_output,
+        "error": error
+    }
+    
+    if isinstance(serializable_output, dict):
+        reserved_keys = set(result.keys())
+        for k, v in serializable_output.items():
+            if k not in reserved_keys:
+                result[k] = v
+                
+    # Dynamic metadata-based mapping if node_instance or its outputs metadata is available
+    mapped_dynamically = False
+    outputs_list = []
+    if node_instance is not None:
+        if hasattr(node_instance, "metadata") and node_instance.metadata is not None:
+            outputs_list = getattr(node_instance.metadata, "outputs", [])
+        elif hasattr(node_instance, "outputs") and node_instance.outputs is not None:
+            outputs_list = node_instance.outputs
+        elif isinstance(node_instance, dict):
+            outputs_list = node_instance.get("outputs") or node_instance.get("metadata", {}).get("outputs", [])
+            
+    if outputs_list:
+        output_names = []
+        connection_outputs = []
+        for out in outputs_list:
+            if isinstance(out, dict):
+                name = out.get("name")
+                is_conn = out.get("is_connection", False)
+            else:
+                name = getattr(out, "name", None)
+                is_conn = getattr(out, "is_connection", False)
+            if name:
+                output_names.append(name)
+                if is_conn:
+                    connection_outputs.append(name)
+                    
+        # 1. If output is a dict, copy matching keys from output to result
+        if isinstance(serializable_output, dict):
+            for name in output_names:
+                if name in serializable_output:
+                    result[name] = serializable_output[name]
+                    mapped_dynamically = True
+                    
+        # 2. If output is not mapped, and there is exactly one output defined in metadata
+        if not mapped_dynamically and len(output_names) == 1:
+            name = output_names[0]
+            result[name] = serializable_output
+            mapped_dynamically = True
+            
+        # 3. If output is not mapped, and there is exactly one connection output defined in metadata
+        if not mapped_dynamically and len(connection_outputs) == 1:
+            result[connection_outputs[0]] = serializable_output
+            mapped_dynamically = True
+
+    # Fallback to static mapping for legacy/backward compatibility
+    if not mapped_dynamically:
+        node_type_lower = node_type.lower()
+        if "openai" in node_type_lower or "openrouter" in node_type_lower or "llm" in node_type_lower:
+            result["llm"] = serializable_output
+        elif "embeddings" in node_type_lower or "embedder" in node_type_lower:
+            result["embedder"] = serializable_output
+        elif "reranker" in node_type_lower or "cohere" in node_type_lower:
+            result["reranker"] = serializable_output
+        elif "memory" in node_type_lower:
+            result["memory"] = serializable_output
+        elif "tavily" in node_type_lower or "search" in node_type_lower:
+            result["search_tool"] = serializable_output
+        elif "retriever" in node_type_lower:
+            result["retriever_tool"] = serializable_output
+        elif "loader" in node_type_lower or "scraper" in node_type_lower or "crawler" in node_type_lower:
+            result["documents"] = serializable_output
+        elif "webhook" in node_type_lower:
+            if isinstance(serializable_output, dict):
+                result["webhook_data"] = serializable_output.get("webhook_data")
+                result["webhook_endpoint"] = serializable_output.get("webhook_endpoint")
+                result["webhook_config"] = serializable_output.get("webhook_config")
+        elif "kafka" in node_type_lower or "consumer" in node_type_lower:
+            if isinstance(serializable_output, dict):
+                result["kafka_data"] = serializable_output.get("kafka_data")
+        elif "timer" in node_type_lower:
+            if isinstance(serializable_output, dict):
+                result["timer_data"] = serializable_output.get("timer_data")
+        elif "errortrigger" in node_type_lower:
+            if isinstance(serializable_output, dict):
+                result["error_data"] = serializable_output.get("error_data")
+
+    return result
 
 
 def safe_json_dumps(obj: Any, **kwargs) -> str:

--- a/backend/app/core/templating.py
+++ b/backend/app/core/templating.py
@@ -31,6 +31,158 @@ _jinja_env = Environment()
 _jinja_env.filters['tojson'] = _tojson_unicode
 
 
+class TemplateValue:
+    """A custom value wrapper that behaves like the primary resolved output value (which can be a string,
+    list, or dict) but also delegates attribute and item lookups to the full node output dictionary 
+    or nested collections to allow path-based access (like node.property or node.0.property).
+    """
+    def __init__(self, value, dict_data=None):
+        self.raw_value = value
+        self.dict_data = dict_data or {}
+
+    def __getattr__(self, name):
+        # 1. Try to find the attribute in self.dict_data (wrapper envelope)
+        if name in self.dict_data:
+            return wrap_template_value(self.dict_data[name])
+        
+        # 2. Try to find the attribute on raw_value if it's a dictionary
+        if isinstance(self.raw_value, dict) and name in self.raw_value:
+            return wrap_template_value(self.raw_value[name])
+
+        # 2b. Backward compatibility lookup for webhook payloads/data
+        if isinstance(self.dict_data, dict):
+            # Check in dict_data["webhook_data"]["payload"]
+            web_data = self.dict_data.get("webhook_data")
+            if isinstance(web_data, dict):
+                payload = web_data.get("payload")
+                if isinstance(payload, dict) and name in payload:
+                    return wrap_template_value(payload[name])
+                if name in web_data:
+                    return wrap_template_value(web_data[name])
+            
+            # Check dict_data["payload"]
+            payload = self.dict_data.get("payload")
+            if isinstance(payload, dict) and name in payload:
+                return wrap_template_value(payload[name])
+
+        # 3. If raw_value is a list/tuple, check if name is a digit/index
+        if isinstance(self.raw_value, (list, tuple)) and name.isdigit():
+            idx = int(name)
+            if 0 <= idx < len(self.raw_value):
+                return wrap_template_value(self.raw_value[idx])
+
+        # 4. If name is a common document content property and raw_value is a string, return the string itself.
+        if name in ("page_content", "text", "content", "output") and isinstance(self.raw_value, str):
+            return self.raw_value
+
+        # 5. If self.dict_data contains a "documents" or "chunks" list, and the attribute is page_content or metadata
+        for list_key in ("documents", "chunks"):
+            if list_key in self.dict_data and isinstance(self.dict_data[list_key], list) and self.dict_data[list_key]:
+                first_item = self.dict_data[list_key][0]
+                if isinstance(first_item, dict) and name in first_item:
+                    return wrap_template_value(first_item[name])
+                elif hasattr(first_item, name):
+                    return wrap_template_value(getattr(first_item, name))
+
+        # 6. Delegate to raw_value's attributes if it has them
+        if hasattr(self.raw_value, name):
+            return wrap_template_value(getattr(self.raw_value, name))
+            
+        raise AttributeError(f"'TemplateValue' object has no attribute '{name}'")
+
+    def __getitem__(self, key):
+        # 1. Try to look up in self.dict_data
+        if isinstance(key, str) and key in self.dict_data:
+            return wrap_template_value(self.dict_data[key])
+            
+        # 2. Try to look up in raw_value if it's a dict or list
+        try:
+            if isinstance(self.raw_value, (dict, list, tuple)):
+                lookup_key = int(key) if (isinstance(key, str) and key.isdigit() and isinstance(self.raw_value, (list, tuple))) else key
+                return wrap_template_value(self.raw_value[lookup_key])
+        except (KeyError, IndexError, TypeError, ValueError):
+            pass
+
+        # 3. If key is a digit/index string (like "0"), and self.dict_data has a "documents" or "chunks" list:
+        if isinstance(key, (int, str)):
+            try:
+                idx = int(key)
+                for list_key in ("documents", "chunks"):
+                    if list_key in self.dict_data and isinstance(self.dict_data[list_key], list):
+                        list_val = self.dict_data[list_key]
+                        if 0 <= idx < len(list_val):
+                            return wrap_template_value(list_val[idx])
+            except (ValueError, TypeError):
+                pass
+
+        # 4. Fallback to dictionary key lookups in self.dict_data if key is string
+        if isinstance(key, str):
+            if isinstance(self.raw_value, dict) and key in self.raw_value:
+                return wrap_template_value(self.raw_value[key])
+
+        # 4b. Backward compatibility lookup for webhook payloads/data
+        if isinstance(key, str) and isinstance(self.dict_data, dict):
+            web_data = self.dict_data.get("webhook_data")
+            if isinstance(web_data, dict):
+                payload = web_data.get("payload")
+                if isinstance(payload, dict) and key in payload:
+                    return wrap_template_value(payload[key])
+                if key in web_data:
+                    return wrap_template_value(web_data[key])
+            
+            payload = self.dict_data.get("payload")
+            if isinstance(payload, dict) and key in payload:
+                return wrap_template_value(payload[key])
+
+        raise KeyError(f"'TemplateValue' object has no key/index '{key}'")
+
+    def get(self, key, default=None):
+        try:
+            return self[key]
+        except (KeyError, IndexError):
+            return default
+
+    def __str__(self):
+        return str(self.raw_value)
+
+    def __repr__(self):
+        return repr(self.raw_value)
+
+    def __eq__(self, other):
+        if isinstance(other, TemplateValue):
+            return self.raw_value == other.raw_value
+        return self.raw_value == other
+
+    def __len__(self):
+        try:
+            return len(self.raw_value)
+        except TypeError:
+            return 0
+
+    def __iter__(self):
+        if isinstance(self.raw_value, (list, tuple, dict)):
+            for item in self.raw_value:
+                yield wrap_template_value(item)
+        else:
+            yield self
+
+    def __add__(self, other):
+        return str(self) + str(other)
+
+    def __radd__(self, other):
+        return str(other) + str(self)
+
+
+def wrap_template_value(val):
+    if isinstance(val, TemplateValue):
+        return val
+    if isinstance(val, dict):
+        return TemplateValue(val.get("output", val), val)
+    if isinstance(val, (list, tuple)):
+        return TemplateValue(val, None)
+    return val
+
+
 def normalize_display_name(name: str) -> str:
     """Normalize a display name to a Jinja-safe identifier.
     
@@ -40,7 +192,7 @@ def normalize_display_name(name: str) -> str:
     if not name:
         return ""
     
-    normalized = re.sub(r"[^0-9a-zA-Z_]+", "_", name).strip("_")
+    normalized = re.sub(r"[^0-9a-zA-Z_]+", "_", name.lower()).strip("_")
     if not normalized:
         return ""
     
@@ -51,11 +203,32 @@ def normalize_display_name(name: str) -> str:
     return normalized
 
 
+_global_registries = {}
+_MAX_GLOBAL_REGISTRIES = 100
+
+
+def register_global_registry(key: str, registry: Dict[str, Any]) -> None:
+    """Register a workflow's nodes registry globally so it is accessible as fallback during execution."""
+    if key and registry:
+        _global_registries[str(key)] = registry
+        # Evict oldest entries when the cap is exceeded to prevent unbounded memory growth
+        if len(_global_registries) > _MAX_GLOBAL_REGISTRIES:
+            keys_to_remove = list(_global_registries.keys())[: len(_global_registries) - _MAX_GLOBAL_REGISTRIES]
+            for k in keys_to_remove:
+                del _global_registries[k]
+
+
+def unregister_global_registry(key: str) -> None:
+    """Remove a registry entry when execution completes."""
+    _global_registries.pop(str(key), None)
+
+
 def get_primary_output(node_id: str, state: FlowState) -> Any:
     """Determine the primary output value for a given node from FlowState.
 
     Heuristic:
     - If node_outputs[node_id] is a dict:
+      - Peel off the standardized wrapper (which has success, nodeId, output, etc.)
       - Prefer 'output'
       - Then 'content'
       - If only one key, return that single value
@@ -68,6 +241,10 @@ def get_primary_output(node_id: str, state: FlowState) -> Any:
     node_output = state.node_outputs.get(node_id)
     if node_output is None:
         return None
+        
+    # Check if this is the standardized node output wrapper and unwrap it
+    if isinstance(node_output, dict) and "success" in node_output and "output" in node_output and "nodeId" in node_output:
+        node_output = node_output["output"]
     
     if isinstance(node_output, dict):
         if "output" in node_output:
@@ -83,73 +260,56 @@ def get_primary_output(node_id: str, state: FlowState) -> Any:
 
 def build_template_context(state: FlowState, nodes_registry: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     """Build the templating context from state, inputs, webhook data, and node outputs."""
+    # Fallback to globally registered registries if none provided
+    if not nodes_registry:
+        session_id = getattr(state, "session_id", None)
+        workflow_id = getattr(state, "workflow_id", None)
+        if session_id:
+            nodes_registry = _global_registries.get(str(session_id))
+        if not nodes_registry and workflow_id:
+            nodes_registry = _global_registries.get(str(workflow_id))
+            
     context: Dict[str, Any] = {}
     
     # 1. Add current_input as 'input' (allows {{input}} to work like a chat system)
     if hasattr(state, 'current_input') and state.current_input is not None:
         context['input'] = state.current_input
         
-    # 2. Add webhook data for webhook-triggered workflows
+    # 2. Add webhook data for webhook-triggered workflows as fallback (only if not already in node_outputs to avoid collisions)
     if hasattr(state, 'webhook_data') and state.webhook_data:
         context['webhook_data'] = state.webhook_data
-        webhook_payload = state.webhook_data.get('data', state.webhook_data)
-        context['webhook_trigger'] = webhook_payload
-        logger.debug(f"[TEMPLATE] Added webhook_trigger to context keys: {list(webhook_payload.keys()) if isinstance(webhook_payload, dict) else type(webhook_payload)}")
+        
+        # Only add webhook_trigger fallback if it won't be added in step 3 from node_outputs
+        has_webhook_output = any("webhook" in nid.lower() for nid in getattr(state, "node_outputs", {}).keys())
+        if not has_webhook_output:
+            webhook_payload = state.webhook_data.get('data', state.webhook_data)
+            primary_val = webhook_payload
+            if isinstance(webhook_payload, dict):
+                primary_val = webhook_payload.get('input', webhook_payload.get('message', webhook_payload))
+            
+            # Wrap in TemplateValue so it supports both simple values and nested path lookups
+            dict_data = {
+                "webhook_data": state.webhook_data,
+                "output": state.webhook_data,
+            }
+            if isinstance(state.webhook_data, dict):
+                dict_data.update(state.webhook_data)
+                
+            context['webhook_trigger'] = TemplateValue(primary_val, dict_data)
+            logger.debug("[TEMPLATE] Added fallback webhook_trigger TemplateValue to context")
 
     # 3. Add executed node outputs with friendly aliases
     has_node_outputs = hasattr(state, "node_outputs") and bool(state.node_outputs)
     
     if has_node_outputs:
         for other_node_id in state.node_outputs.keys():
-            alias_candidates: List[tuple[str, str]] = []
-            
-            # Lookup node definition from registry if available
-            graph_node = None
-            if nodes_registry:
-                graph_node = nodes_registry.get(other_node_id)
-                
-            if graph_node:
-                # UI Name (user_data["name"]) - highest priority
-                ui_name = None
-                try:
-                    user_data = getattr(graph_node, "user_data", {}) or {}
-                    if isinstance(user_data, dict):
-                        ui_name = user_data.get("name")
-                except Exception:
-                    pass
-                if ui_name:
-                    alias_candidates.append(("ui_name", str(ui_name)))
-                
-                # Pydantic NodeMetadata from node instance
-                node_meta_model = None
-                try:
-                    node_meta_model = getattr(graph_node.node_instance, "metadata", None)
-                except Exception:
-                    pass
-                if node_meta_model is not None:
-                    display_name = getattr(node_meta_model, "display_name", None)
-                    meta_name = getattr(node_meta_model, "name", None)
-                    if display_name:
-                        alias_candidates.append(("display_name", str(display_name)))
-                    if meta_name and meta_name != display_name:
-                        alias_candidates.append(("meta_name", str(meta_name)))
-                        
-                # GraphNodeInstance metadata dict fallback
-                metadata_dict = getattr(graph_node, "metadata", {}) or {}
-                if isinstance(metadata_dict, dict):
-                    md_display = metadata_dict.get("display_name")
-                    md_name = metadata_dict.get("name")
-                    if md_display:
-                        alias_candidates.append(("graph_display_name", str(md_display)))
-                    if md_name and md_name != md_display:
-                        alias_candidates.append(("graph_name", str(md_name)))
-            
-            # Final fallback: node_id
-            alias_candidates.append(("node_id", str(other_node_id)))
-            
             primary_value = get_primary_output(other_node_id, state)
             if primary_value is None:
                 continue
+                
+            graph_node = None
+            if nodes_registry:
+                graph_node = nodes_registry.get(other_node_id)
                 
             # If the node is a StartNode, also allow {{input}} fallback mapping
             try:
@@ -159,14 +319,34 @@ def build_template_context(state: FlowState, nodes_registry: Optional[Dict[str, 
             except Exception:
                 pass
                 
+            # Extract ui_name (highest priority)
+            ui_name = None
+            if graph_node:
+                try:
+                    user_data = getattr(graph_node, "user_data", {}) or {}
+                    if isinstance(user_data, dict):
+                        ui_name = user_data.get("name")
+                except Exception:
+                    pass
+
+            alias_candidates: List[tuple[str, str]] = []
+            if ui_name:
+                alias_candidates.append(("ui_name", str(ui_name)))
+            
+            # Always append the unique node_id as fallback
+            alias_candidates.append(("node_id", str(other_node_id)))
+            
             # Normalize and assign aliases without overwriting existing keys
+            node_output = state.node_outputs.get(other_node_id)
             for source_type, raw_name in alias_candidates:
                 normalized = normalize_display_name(raw_name)
                 if not normalized:
                     continue
                 if normalized in context:
                     continue
-                context[normalized] = primary_value
+                
+                # Wrap primary value with full output dictionary for nested property access (e.g. ${{node.property}})
+                context[normalized] = TemplateValue(primary_value, node_output if isinstance(node_output, dict) else {})
                 logger.debug(f"[TEMPLATE] Added alias '{normalized}' ({source_type}) into context")
                 
     return context

--- a/backend/app/nodes/base.py
+++ b/backend/app/nodes/base.py
@@ -710,6 +710,15 @@ class BaseNode(ABC):
         This method transforms the node into a function that takes and returns FlowState
         """
         def graph_node_function(state: FlowState) -> Dict[str, Any]:  # noqa: D401
+            import time
+            import traceback
+            import datetime
+            from app.core.json_utils import format_standard_node_output
+
+            start_time = time.time()
+            resolved_inputs = {}
+            node_id = getattr(self, 'node_id', f"{self.__class__.__name__}_{id(self)}")
+
             try:
                 # Merge user configuration into state variables
                 for key, value in self.user_data.items():
@@ -717,7 +726,6 @@ class BaseNode(ABC):
                 
                 # Get node metadata for input processing
                 metadata = self.metadata
-                node_id = getattr(self, 'node_id', f"{self.__class__.__name__}_{id(self)}")
                 
                 from app.core.templating import apply_jinja_to_inputs
                 nodes_registry = getattr(state, "nodes_registry", None)
@@ -727,6 +735,7 @@ class BaseNode(ABC):
                     # Provider nodes create objects from user inputs only
                     inputs = self._extract_user_inputs(state, metadata.inputs)
                     inputs = apply_jinja_to_inputs(inputs, state, node_id, nodes_registry)
+                    resolved_inputs = inputs
                     result = self.execute(**inputs)
                     
                 elif self.metadata.node_type == NodeType.PROCESSOR:
@@ -739,6 +748,7 @@ class BaseNode(ABC):
                     logger.debug(f"Processor {node_id} - User inputs: {list(user_inputs.keys())}")
                     logger.debug(f"Processor {node_id} - Connected inputs: {list(connected_nodes.keys())}")
                     
+                    resolved_inputs = {**user_inputs, **{k: make_json_serializable_with_langchain(v) if not isinstance(v, (str, dict, list, int, float, bool)) else v for k, v in connected_nodes.items()}}
                     result = self.execute(inputs=user_inputs, connected_nodes=connected_nodes)
                     
                 elif self.metadata.node_type == NodeType.TERMINATOR:
@@ -753,16 +763,32 @@ class BaseNode(ABC):
                         # Get the first connected input as the primary input
                         previous_node = list(connected_inputs.values())[0]
                     
+                    resolved_inputs = {**user_inputs, "previous_node": previous_node}
                     result = self.execute(previous_node=previous_node, inputs=user_inputs)
                     
                 else:
                     # Fallback for unknown node types
                     inputs = self._extract_all_inputs(state, metadata.inputs)
                     inputs = apply_jinja_to_inputs(inputs, state, node_id, nodes_registry)
+                    resolved_inputs = inputs
                     result = self.execute(**inputs)
                 
                 # Handle different result types
                 processed_result = self._process_execution_result(result, state)
+                
+                execution_time_ms = round((time.time() - start_time) * 1000, 2)
+                
+                # Format standard output
+                standard_output = format_standard_node_output(
+                    node_id=node_id,
+                    node_type=self.__class__.__name__,
+                    success=True,
+                    status_code=200,
+                    execution_time_ms=execution_time_ms,
+                    inputs=resolved_inputs,
+                    output=processed_result,
+                    node_instance=self
+                )
                 
                 # Store the result in state using unique key
                 unique_output_key = f"output_{node_id}"
@@ -776,27 +802,53 @@ class BaseNode(ABC):
                 if not hasattr(state, "node_outputs"):
                     state.node_outputs = {}
                 
-                try:
-                    serializable_result = make_json_serializable_with_langchain(processed_result, filter_complex=False)
-                    state.node_outputs[node_id] = serializable_result
-                except Exception as e:
-                    logger.warning(f"Failed to store node output in node_outputs for {node_id}: {e}")
+                state.node_outputs[node_id] = standard_output
 
                 return {
-                    unique_output_key: processed_result,
+                    unique_output_key: standard_output,
                     "executed_nodes": updated_executed_nodes,
                     "last_output": str(processed_result),
                     "node_outputs": state.node_outputs
                 }
                 
             except Exception as e:
+                execution_time_ms = round((time.time() - start_time) * 1000, 2)
+                
                 # Handle errors gracefully
                 error_msg = f"Error in {self.__class__.__name__} ({node_id}): {str(e)}"
                 logger.error(f"{error_msg}")
                 state.add_error(error_msg)
+                
+                error_details = {
+                    "node_id": node_id,
+                    "node_type": self.__class__.__name__,
+                    "error_type": type(e).__name__,
+                    "error_message": str(e),
+                    "timestamp": datetime.datetime.now().isoformat(),
+                    "stack_trace": traceback.format_exc()
+                }
+                
+                # Standardize error output
+                standard_error_output = format_standard_node_output(
+                    node_id=node_id,
+                    node_type=self.__class__.__name__,
+                    success=False,
+                    status_code=500,
+                    execution_time_ms=execution_time_ms,
+                    inputs=resolved_inputs,
+                    output=None,
+                    error=error_details,
+                    node_instance=self
+                )
+                
+                if not hasattr(state, "node_outputs"):
+                    state.node_outputs = {}
+                state.node_outputs[node_id] = standard_error_output
+                
                 return {
                     "errors": state.errors,
-                    "last_output": f"ERROR: {error_msg}"
+                    "last_output": f"ERROR: {error_msg}",
+                    "node_outputs": state.node_outputs
                 }
         
         return graph_node_function

--- a/backend/app/nodes/processing/condition_node.py
+++ b/backend/app/nodes/processing/condition_node.py
@@ -304,6 +304,10 @@ class ConditionNode(ProcessorNode):
         """
         if input_data is None:
             return None
+            
+        # Peel off the standardized wrapper if present
+        if isinstance(input_data, dict) and "success" in input_data and "output" in input_data and "nodeId" in input_data:
+            input_data = input_data["output"]
         
         # Handle LangChain Document objects directly
         if hasattr(input_data, 'page_content'):

--- a/backend/app/services/error_handler_service.py
+++ b/backend/app/services/error_handler_service.py
@@ -1,12 +1,13 @@
 """Trigger a configured error-handling workflow when a source workflow fails."""
 
+import asyncio
 import copy
 import logging
 import re
 import traceback
 import uuid
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, List
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -25,6 +26,29 @@ def _clean_error_message(message: str) -> str:
     text = re.sub(node_prefix_pattern, "", text, flags=re.IGNORECASE).strip()
     text = re.sub(r"^:\s*", "", text).strip()
     return text
+
+
+error_trigger_subscribers: Dict[str, List[asyncio.Queue]] = {}
+
+async def broadcast_error_trigger_event(workflow_id: str, event: Dict[str, Any]) -> None:
+    """Broadcast Error Trigger-triggered workflow execution events to canvas subscribers."""
+    subscribers = error_trigger_subscribers.get(workflow_id, [])
+    if not subscribers:
+        return
+
+    stale_subscribers = []
+    for queue in subscribers.copy():
+        try:
+            if queue.qsize() >= 100:
+                stale_subscribers.append(queue)
+                continue
+            queue.put_nowait(event)
+        except Exception:
+            stale_subscribers.append(queue)
+
+    for queue in stale_subscribers:
+        if queue in subscribers:
+            subscribers.remove(queue)
 
 
 class ErrorHandlerService:
@@ -140,7 +164,19 @@ class ErrorHandlerService:
                 user=owner,
                 is_webhook=False,
             )
-            await executor.execute_workflow(ctx=ctx, db=db, stream=False)
+            result_stream = await executor.execute_workflow(ctx=ctx, db=db, stream=True)
+            if hasattr(result_stream, "__aiter__"):
+                async for event_chunk in result_stream:
+                    if isinstance(event_chunk, dict):
+                        ui_event = {
+                            "type": "error_trigger_execution_event",
+                            "workflow_id": error_workflow_id,
+                            "execution_id": str(ctx.execution_id) if ctx.execution_id else None,
+                            "event": event_chunk,
+                            "error_payload": error_data,
+                            "timestamp": datetime.now(timezone.utc).isoformat(),
+                        }
+                        await broadcast_error_trigger_event(error_workflow_id, ui_event)
             return True
         except Exception as e:
             logger.error("[ErrorHandler] Failed to trigger error workflow: %s", e, exc_info=True)

--- a/backend/app/services/workflow_executor.py
+++ b/backend/app/services/workflow_executor.py
@@ -546,12 +546,45 @@ class WorkflowExecutor:
                         logger.error(f"Workflow streaming execution crashed: {e}", exc_info=True)
                         try:
                             err_text = str(e) or f"Streaming crash: {type(e).__name__}"
+                            
+                            # Extract state data from exception context first, fallback to checkpointer
+                            node_outputs = {}
+                            executed_nodes = []
+                            
+                            curr_e = e
+                            while curr_e:
+                                if hasattr(curr_e, "context") and isinstance(curr_e.context, dict):
+                                    node_outputs = curr_e.context.get("node_outputs") or {}
+                                    executed_nodes = curr_e.context.get("executed_nodes") or []
+                                    if node_outputs:
+                                        break
+                                curr_e = getattr(curr_e, "__cause__", None) or getattr(curr_e, "__context__", None)
+                                
+                            if not node_outputs:
+                                try:
+                                    if build_result and len(build_result) > 1:
+                                        compiled_graph = build_result[1]
+                                        config = {"configurable": {"thread_id": ctx.session_id}}
+                                        final_state = await compiled_graph.aget_state(config)
+                                        if hasattr(final_state, 'values') and final_state.values:
+                                            node_outputs = final_state.values.get('node_outputs', {})
+                                            executed_nodes = final_state.values.get('executed_nodes', [])
+                                except Exception as state_err:
+                                    logger.warning(f"Failed to get graph state on streaming crash: {state_err}")
+                                
+                            outputs = {
+                                "error": err_text,
+                                "status": "failed",
+                                "node_outputs": make_json_serializable(node_outputs),
+                                "executed_nodes": executed_nodes
+                            }
+                            
                             await self.update_execution_status(
                                 db,
                                 execution_id,
                                 status="failed",
                                 error_message=err_text,
-                                outputs={"error": err_text, "status": "failed"},
+                                outputs=outputs,
                                 completed_at=datetime.now(timezone.utc),
                             )
                             await self._trigger_error_workflow_if_configured(db, ctx, execution_id, e)
@@ -629,12 +662,44 @@ class WorkflowExecutor:
                 if not error_msg:
                     error_msg = f"Execution failed with error: {type(e).__name__}"
                 
+                # Extract state data from exception context first, fallback to checkpointer
+                node_outputs = {}
+                executed_nodes = []
+                
+                curr_e = e
+                while curr_e:
+                    if hasattr(curr_e, "context") and isinstance(curr_e.context, dict):
+                        node_outputs = curr_e.context.get("node_outputs") or {}
+                        executed_nodes = curr_e.context.get("executed_nodes") or []
+                        if node_outputs:
+                            break
+                    curr_e = getattr(curr_e, "__cause__", None) or getattr(curr_e, "__context__", None)
+                    
+                if not node_outputs:
+                    try:
+                        if build_result and len(build_result) > 1:
+                            compiled_graph = build_result[1]
+                            config = {"configurable": {"thread_id": ctx.session_id}}
+                            final_state = await compiled_graph.aget_state(config)
+                            if hasattr(final_state, 'values') and final_state.values:
+                                node_outputs = final_state.values.get('node_outputs', {})
+                                executed_nodes = final_state.values.get('executed_nodes', [])
+                    except Exception as state_err:
+                        logger.warning(f"Failed to get graph state on workflow execution fail: {state_err}")
+                    
+                outputs = {
+                    "error": error_msg,
+                    "status": "failed",
+                    "node_outputs": make_json_serializable(node_outputs),
+                    "executed_nodes": executed_nodes
+                }
+                
                 await self.update_execution_status(
                     db,
                     execution_id,
                     status="failed",
                     error_message=error_msg,
-                    outputs={"error": error_msg, "status": "failed"},
+                    outputs=outputs,
                     completed_at=datetime.now(timezone.utc),
                 )
                 await self._trigger_error_workflow_if_configured(db, ctx, execution_id, e)

--- a/client/app/components/canvas/FlowCanvas.tsx
+++ b/client/app/components/canvas/FlowCanvas.tsx
@@ -367,6 +367,34 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
     ? getCurrentExecutionForWorkflow(currentWorkflow.id)
     : null;
 
+  // Clear execution data when workflow structure changes (nodes or edges added/removed/reconnected)
+  const previousStructureRef = useRef<{ nodeIds: string[]; edgeConnections: string[] }>({
+    nodeIds: [],
+    edgeConnections: [],
+  });
+
+  useEffect(() => {
+    const nodeIds = nodes.map(n => n.id).sort();
+    const edgeConnections = edges.map(e => `${e.source}-${e.target}-${e.sourceHandle || ''}-${e.targetHandle || ''}`).sort();
+
+    const structureChanged =
+      previousStructureRef.current.nodeIds.length > 0 && // Only after initial load
+      (JSON.stringify(previousStructureRef.current.nodeIds) !== JSON.stringify(nodeIds) ||
+       JSON.stringify(previousStructureRef.current.edgeConnections) !== JSON.stringify(edgeConnections));
+
+    if (structureChanged && currentWorkflow?.id) {
+      console.log("Workflow structure changed. Keeping current execution data intact.");
+      // Disabled clearing to persist states until next run as requested
+      // setCurrentExecutionForWorkflow(currentWorkflow.id, null);
+      // setNodeStatus({});
+      // setEdgeStatus({});
+      // setActiveEdges([]);
+      // setActiveNodes([]);
+    }
+
+    previousStructureRef.current = { nodeIds, edgeConnections };
+  }, [nodes, edges, currentWorkflow?.id, setCurrentExecutionForWorkflow, setNodeStatus, setEdgeStatus, setActiveEdges, setActiveNodes]);
+
   // Listen for webhook execution events to update node status
   // Must be called after currentWorkflow and setCurrentExecutionForWorkflow are defined
   useWebhookExecutionListener(
@@ -382,6 +410,17 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
   );
 
   useKafkaExecutionListener(
+    nodes,
+    setNodeStatus,
+    edges,
+    setEdgeStatus,
+    setActiveEdges,
+    setActiveNodes,
+    currentWorkflow?.id,
+    setCurrentExecutionForWorkflow
+  );
+
+  useErrorTriggerExecutionListener(
     nodes,
     setNodeStatus,
     edges,
@@ -1123,6 +1162,25 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
                   };
 
                   setDetailedExecutionError(errorDetails);
+
+                  // Store the failed execution result in the store so that nodes reflect the current failed state outputs
+                  const executionResult = {
+                    id: evt.execution_id || Date.now().toString(),
+                    workflow_id: currentWorkflow.id,
+                    input_text: executionData.input_text,
+                    result: {
+                      result: `ERROR: ${evt.error || "Workflow execution failed"}`,
+                      executed_nodes: evt.executed_nodes || [],
+                      node_outputs: evt.node_outputs || {},
+                      session_id: evt.session_id,
+                      status: "failed" as const,
+                    },
+                    started_at: new Date().toISOString(),
+                    completed_at: new Date().toISOString(),
+                    status: "failed" as const,
+                  };
+
+                  setCurrentExecutionForWorkflow(currentWorkflow.id, executionResult);
                 } else if (t === "complete") {
                   // Store the execution result in the store
                   const executionResult = {
@@ -1702,6 +1760,7 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
         fullscreenModal.nodeMetadata &&
         fullscreenModal.configComponent && (
           <FullscreenNodeModal
+            key={fullscreenModal.nodeData?.id}
             isOpen={fullscreenModal.isOpen}
             onClose={handleFullscreenModalClose}
             nodeMetadata={fullscreenModal.nodeMetadata}
@@ -1715,20 +1774,16 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
               nodeId: fullscreenModal.nodeData?.id || "",
               inputs: (() => {
                 const nodeId = fullscreenModal.nodeData?.id;
-                if (!nodeId || !currentExecution?.result?.node_outputs)
-                  return {};
+                if (!nodeId) return {};
 
-                // First try to get tracked inputs from execution data
-                const nodeExecutionData =
-                  currentExecution?.result?.node_outputs?.[nodeId];
-                if (
-                  nodeExecutionData?.inputs &&
-                  Object.keys(nodeExecutionData.inputs).length > 0
-                ) {
-                  return nodeExecutionData.inputs;
+                // If no execution exists or this node hasn't run in this execution, do not show inputs (returns undefined)
+                const hasRun = currentExecution?.result?.node_outputs?.[nodeId] !== undefined;
+                console.log(`[DEBUG inputs] nodeId: ${nodeId}, hasRun: ${hasRun}, node_outputs keys:`, currentExecution?.result?.node_outputs ? Object.keys(currentExecution.result.node_outputs) : []);
+                if (!currentExecution || !hasRun) {
+                  return undefined;
                 }
 
-                // Fallback to edge-based input construction for nodes without tracked inputs
+                // ALWAYS build inputs dynamically from connected edges only, to exclude local node config parameters
                 const inputEdges = edges.filter(
                   (edge) => edge.target === nodeId
                 );
@@ -1736,50 +1791,56 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
                   return {};
                 }
 
-                const inputs: Record<string, any[]> = {};
+                const inputs: Record<string, any> = {};
+                const edgeGroups: Record<string, Edge[]> = {};
 
                 inputEdges.forEach((edge) => {
-                  const sourceNodeOutput =
-                    currentExecution?.result?.node_outputs?.[edge.source];
                   const inputKey = edge.targetHandle || "input";
-                  const sourceNodeId = edge.source;
-                  const sourceNode = nodes.find((n) => n.id === sourceNodeId);
+                  if (!edgeGroups[inputKey]) {
+                    edgeGroups[inputKey] = [];
+                  }
+                  edgeGroups[inputKey].push(edge);
+                });
 
-                  // Extract actual output value if it's wrapped in execution data structure
-                  let value: any;
-                  if (sourceNodeOutput !== undefined) {
-                    // Check for wrapped output fields in order of priority
-                    const OUTPUT_FIELDS = ['output', 'outputs'];
-                    const isObject = sourceNodeOutput && typeof sourceNodeOutput === "object";
-                    const outputField = isObject
-                      ? OUTPUT_FIELDS.find(field => sourceNodeOutput[field] !== undefined)
-                      : null;
+                Object.entries(edgeGroups).forEach(([inputKey, groupEdges]) => {
+                  const getEdgeInputValue = (edge: Edge) => {
+                    const sourceNodeOutput =
+                      currentExecution?.result?.node_outputs?.[edge.source];
+                    const sourceNode = nodes.find((n) => n.id === edge.source);
 
-                    value = outputField ? sourceNodeOutput[outputField] : sourceNodeOutput;
-                  } else {
-                    // Try to get default value from source node config
-                    const sourceData = (sourceNode?.data as any) || {};
-
-                    // List of fallback fields to check in order of priority
-                    const FALLBACK_FIELDS = ['text_input', 'text', 'content', 'value', 'query', 'prompt'];
-                    const fallbackField = FALLBACK_FIELDS.find(field => sourceData[field] !== undefined);
-
-                    if (fallbackField) {
-                      value = sourceData[fallbackField];
+                    if (sourceNodeOutput !== undefined) {
+                      // Show standardized output from source node, but strip its own 'inputs' field
+                      // (which contains that node's upstream data and would leak irrelevant info)
+                      if (sourceNodeOutput && typeof sourceNodeOutput === "object") {
+                        const { inputs: _srcInputs, ...cleanOutput } = sourceNodeOutput;
+                        return cleanOutput;
+                      }
+                      return sourceNodeOutput;
                     } else {
-                      // Placeholder for nodes that haven't executed yet and have no default value
-                      value = {
-                        _placeholder: true,
-                        message: "No default value available",
-                        sourceNodeId: edge.source
-                      };
-                    }
-                  }
+                      // Try to get default value from source node config
+                      const sourceData = (sourceNode?.data as any) || {};
+                      const FALLBACK_FIELDS = ['text_input', 'text', 'content', 'value', 'query', 'prompt'];
+                      const fallbackField = FALLBACK_FIELDS.find(field => sourceData[field] !== undefined);
 
-                  if (!Array.isArray(inputs[inputKey])) {
-                    inputs[inputKey] = [];
+                      if (fallbackField) {
+                        return sourceData[fallbackField];
+                      } else {
+                        // Descriptive placeholder for provider/unexecuted nodes
+                        const sourceDisplayName = sourceData?.metadata?.display_name || sourceData?.displayName || sourceNode?.type || "Unknown";
+                        return {
+                          _placeholder: true,
+                          message: `${sourceDisplayName} — provider node (no serializable output)`,
+                          sourceNodeId: edge.source
+                        };
+                      }
+                    }
+                  };
+
+                  if (groupEdges.length === 1) {
+                    inputs[inputKey] = getEdgeInputValue(groupEdges[0]);
+                  } else {
+                    inputs[inputKey] = groupEdges.map(getEdgeInputValue);
                   }
-                  inputs[inputKey].push(value);
                 });
 
                 return inputs;
@@ -1788,6 +1849,12 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
                 const nodeId = fullscreenModal.nodeData?.id;
                 if (!nodeId || !currentExecution?.result?.node_outputs)
                   return undefined;
+
+                // If this node hasn't run in this execution, do not show inputs_meta (returns undefined)
+                const hasRun = currentExecution?.result?.node_outputs?.[nodeId] !== undefined;
+                if (!hasRun) {
+                  return undefined;
+                }
 
                 // 1) If engine already tracked inputs_meta explicitly (e.g., from chat), use it
                 const nodeExecutionData =
@@ -1853,32 +1920,12 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
 
                 // 1. If execution output exists, use it
                 const executionOutput = currentExecution?.result?.node_outputs?.[nodeId];
+                console.log(`[DEBUG outputs] nodeId: ${nodeId}, executionOutput exists: ${executionOutput !== undefined}`);
                 if (executionOutput) {
                   return executionOutput;
                 }
 
-                // 2. Only show fallback/placeholder if a workflow execution exists but this node hasn't run
-                if (currentExecution?.result?.node_outputs) {
-                  // Check node config data for fallback fields
-                  const nodeData = (fullscreenModal.nodeData?.data as any) || {};
-                  const OUTPUT_FALLBACK_FIELDS = ['output', 'text_input', 'text', 'content', 'value', 'result', 'response', 'query', 'prompt'];
-                  const fallbackField = OUTPUT_FALLBACK_FIELDS.find(field => nodeData[field] !== undefined);
-
-                  if (fallbackField) {
-                    return { output: nodeData[fallbackField] };
-                  }
-
-                  // No fallback fields found, return placeholder
-                  return {
-                    output: {
-                      _placeholder: true,
-                      message: "No default value available",
-                      nodeId: nodeId
-                    }
-                  };
-                }
-
-                // 3. No execution exists at all - return undefined (shows "No Output Data Yet")
+                // If this node has not run in this execution, do not show outputs (returns undefined)
                 return undefined;
               })(),
               status:
@@ -2323,15 +2370,16 @@ function useWebhookExecutionListener(
 
                   // Handle error for snackbar notification
                   if (isError) {
+                    const ev = executionEvent as any;
                     window.dispatchEvent(
                       new CustomEvent("chat-execution-error", {
                         detail: {
-                          error: executionEvent.error || `Node ${node_id} failed`,
-                          message: executionEvent.error || `Node ${node_id} failed`,
-                          type: executionEvent.error_type || "execution",
+                          error: ev.error || `Node ${node_id} failed`,
+                          message: ev.error || `Node ${node_id} failed`,
+                          type: ev.error_type || "execution",
                           nodeId: actualNode.id,
                           nodeType: actualNode.type,
-                          stackTrace: executionEvent.stack_trace,
+                          stackTrace: ev.stack_trace,
                         },
                       })
                     );
@@ -2366,18 +2414,55 @@ function useWebhookExecutionListener(
               }
 
               // Handle general execution error event
-              if (eventType === "error" || eventType === "workflow_error") {
+              if ((eventType as string) === "error" || (eventType as string) === "workflow_error") {
+                const ev = executionEvent as any;
                 window.dispatchEvent(
                   new CustomEvent("chat-execution-error", {
                     detail: {
-                      error: executionEvent.error || "Workflow execution failed",
-                      message: executionEvent.error || "Workflow execution failed",
-                      type: executionEvent.error_type || "execution",
-                      nodeId: executionEvent.node_id,
-                      stackTrace: executionEvent.stack_trace,
+                      error: ev.error || "Workflow execution failed",
+                      message: ev.error || "Workflow execution failed",
+                      type: ev.error_type || "execution",
+                      nodeId: ev.node_id,
+                      stackTrace: ev.stack_trace,
                     },
                   })
                 );
+
+                // Save failed execution to store so canvas updates correctly
+                execData.status = "failed";
+                execData.completedAt = data.timestamp || new Date().toISOString();
+                if (ev.node_outputs) {
+                  execData.nodeOutputs = {
+                    ...execData.nodeOutputs,
+                    ...ev.node_outputs,
+                  };
+                }
+                if (ev.executed_nodes) {
+                  execData.executedNodes = ev.executed_nodes;
+                }
+                if (ev.session_id) {
+                  execData.sessionId = ev.session_id;
+                }
+
+                if (currentWorkflowId && setCurrentExecutionForWorkflow) {
+                  const executionResult = {
+                    id: executionId,
+                    workflow_id: currentWorkflowId,
+                    input_text: data.webhook_payload ? JSON.stringify(data.webhook_payload) : "",
+                    result: {
+                      result: `ERROR: ${ev.error || "Workflow execution failed"}`,
+                      executed_nodes: execData.executedNodes,
+                      node_outputs: execData.nodeOutputs,
+                      session_id: execData.sessionId,
+                      status: "failed" as const,
+                    },
+                    started_at: execData.startedAt,
+                    completed_at: execData.completedAt,
+                    status: "failed" as const,
+                  };
+
+                  setCurrentExecutionForWorkflow(currentWorkflowId, executionResult);
+                }
               }
             }
           } catch (error) {
@@ -2522,18 +2607,46 @@ function useKafkaExecutionListener(
           }
 
           // Handle general execution error event
-          if (eventType === "error" || eventType === "workflow_error") {
+          if ((eventType as string) === "error" || (eventType as string) === "workflow_error") {
+            const ev = executionEvent as any;
             window.dispatchEvent(
               new CustomEvent("chat-execution-error", {
                 detail: {
-                  error: executionEvent.error || "Workflow execution failed",
-                  message: executionEvent.error || "Workflow execution failed",
-                  type: executionEvent.error_type || "execution",
-                  nodeId: executionEvent.node_id,
-                  stackTrace: executionEvent.stack_trace,
+                  error: ev.error || "Workflow execution failed",
+                  message: ev.error || "Workflow execution failed",
+                  type: ev.error_type || "execution",
+                  nodeId: ev.node_id,
+                  stackTrace: ev.stack_trace,
                 },
               })
             );
+
+            // Save failed execution to store so canvas updates correctly
+            execData.completedAt = data.timestamp || new Date().toISOString();
+            execData.nodeOutputs = {
+              ...execData.nodeOutputs,
+              ...(ev.node_outputs || {}),
+            };
+            execData.executedNodes = ev.executed_nodes || execData.executedNodes;
+            execData.sessionId = ev.session_id;
+
+            if (currentWorkflowId && setCurrentExecutionForWorkflow) {
+              setCurrentExecutionForWorkflow(currentWorkflowId, {
+                id: executionId,
+                workflow_id: currentWorkflowId,
+                input_text: data.kafka_payload ? JSON.stringify(data.kafka_payload) : "",
+                result: {
+                  result: `ERROR: ${ev.error || "Workflow execution failed"}`,
+                  executed_nodes: execData.executedNodes,
+                  node_outputs: execData.nodeOutputs,
+                  session_id: ev.session_id,
+                  status: "failed" as const,
+                },
+                started_at: execData.startedAt,
+                completed_at: execData.completedAt,
+                status: "failed" as const,
+              });
+            }
           }
 
           if (eventType === "complete" || eventType === "workflow_complete") {
@@ -2577,11 +2690,224 @@ function useKafkaExecutionListener(
       eventSources.push(eventSource);
     });
 
+    // Cleanup: close all event sources when component unmounts or dependencies change
     return () => {
-      eventSources.forEach((source) => source.close());
+      eventSources.forEach((es) => {
+        try {
+          es.close();
+        } catch (error) {
+          console.warn("Error closing Kafka EventSource:", error);
+        }
+      });
       executionData.clear();
     };
   }, [nodes, edges, currentWorkflowId, setCurrentExecutionForWorkflow, setNodeStatus, setEdgeStatus, setActiveEdges, setActiveNodes]);
+}
+
+function useErrorTriggerExecutionListener(
+  nodes: Node[],
+  setNodeStatus: React.Dispatch<
+    React.SetStateAction<Record<string, NodeStatus>>
+  >,
+  edges: Edge[],
+  setEdgeStatus: React.Dispatch<
+    React.SetStateAction<Record<string, NodeStatus>>
+  >,
+  setActiveEdges: React.Dispatch<React.SetStateAction<string[]>>,
+  setActiveNodes: React.Dispatch<React.SetStateAction<string[]>>,
+  currentWorkflowId?: string,
+  setCurrentExecutionForWorkflow?: (workflowId: string, execution: any) => void
+) {
+  useEffect(() => {
+    // Find if there is an ErrorTrigger node in the workflow
+    const errorTriggerNode = nodes.find(
+      (node) => node.type === "ErrorTrigger" || node.type === "ErrorTriggerNode"
+    );
+
+    if (!errorTriggerNode || !currentWorkflowId) {
+      return; // No error trigger node or workflow ID, nothing to listen to
+    }
+
+    const baseUrl = config.API_BASE_URL;
+    const streamUrl = `${baseUrl}/${config.API_START}/${config.API_VERSION_ONLY}/workflows/error-trigger/${currentWorkflowId}/stream`;
+    const eventSource = new EventSource(streamUrl);
+    const executionData = new Map<string, {
+      executionId: string;
+      nodeOutputs: Record<string, any>;
+      executedNodes: string[];
+      sessionId?: string;
+      result?: any;
+      startedAt: string;
+      completedAt?: string;
+    }>();
+
+    eventSource.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (data.type === "connected" || data.type === "ping") return;
+        if (data.type !== "error_trigger_execution_event" || !data.event) return;
+
+        const executionEvent = data.event;
+        const eventType = executionEvent.type || executionEvent.event;
+        const nodeId = executionEvent.node_id;
+        const executionId = data.execution_id || "unknown";
+
+        if (!executionData.has(executionId)) {
+          executionData.set(executionId, {
+            executionId,
+            nodeOutputs: {},
+            executedNodes: [],
+            startedAt: data.timestamp || new Date().toISOString(),
+          });
+        }
+
+        const execData = executionData.get(executionId)!;
+
+        if (eventType === "node_start" && nodeId) {
+          if (!execData.executedNodes.includes(nodeId)) {
+            execData.executedNodes.push(nodeId);
+          }
+
+          const actualNode = findCanvasNode(nodes, nodeId);
+          if (actualNode) {
+            const activeFlowEdges = resolveExecutionEdges(executionEvent, actualNode, nodes, edges);
+            setActiveNodes([actualNode.id]);
+            setNodeStatus((prev) => ({ ...prev, [actualNode.id]: "pending" }));
+            setActiveEdges(activeFlowEdges.map((edge) => edge.id));
+            setEdgeStatus((prev) => ({
+              ...prev,
+              ...Object.fromEntries(activeFlowEdges.map((edge) => [edge.id, "pending" as const])),
+            }));
+          }
+        }
+
+        if (eventType === "node_end" && nodeId) {
+          execData.nodeOutputs[nodeId] = {
+            ...(execData.nodeOutputs[nodeId] || {}),
+            output: executionEvent.output || executionEvent.result,
+            outputs: executionEvent.output || executionEvent.result,
+            status: executionEvent.error ? "failed" : "completed",
+          };
+
+          const actualNode = findCanvasNode(nodes, nodeId);
+          if (actualNode) {
+            const isError = executionEvent.error || executionEvent.status === "error";
+
+            // Handle error for snackbar notification
+            if (isError) {
+              window.dispatchEvent(
+                new CustomEvent("chat-execution-error", {
+                  detail: {
+                    error: executionEvent.error || `Node ${nodeId} failed`,
+                    message: executionEvent.error || `Node ${nodeId} failed`,
+                    type: executionEvent.error_type || "execution",
+                    nodeId: actualNode.id,
+                    nodeType: actualNode.type,
+                    stackTrace: executionEvent.stack_trace,
+                  },
+                })
+              );
+            }
+
+            const activeFlowEdges = resolveExecutionEdges(executionEvent, actualNode, nodes, edges);
+            setNodeStatus((prev) => ({ ...prev, [actualNode.id]: isError ? "failed" : "success" }));
+            setEdgeStatus((prev) => ({
+              ...prev,
+              ...Object.fromEntries(activeFlowEdges.map((edge) => [edge.id, isError ? "failed" as const : "success" as const])),
+            }));
+          }
+        }
+
+        // Handle general execution error event
+        if ((eventType as string) === "error" || (eventType as string) === "workflow_error") {
+          const ev = executionEvent as any;
+          window.dispatchEvent(
+            new CustomEvent("chat-execution-error", {
+              detail: {
+                error: ev.error || "Workflow execution failed",
+                message: ev.error || "Workflow execution failed",
+                type: ev.error_type || "execution",
+                nodeId: ev.node_id,
+                stackTrace: ev.stack_trace,
+              },
+            })
+          );
+
+          // Save failed execution to store so canvas updates correctly
+          execData.completedAt = data.timestamp || new Date().toISOString();
+          execData.nodeOutputs = {
+            ...execData.nodeOutputs,
+            ...(ev.node_outputs || {}),
+          };
+          execData.executedNodes = ev.executed_nodes || execData.executedNodes;
+          execData.sessionId = ev.session_id;
+
+          if (currentWorkflowId && setCurrentExecutionForWorkflow) {
+            setCurrentExecutionForWorkflow(currentWorkflowId, {
+              id: executionId,
+              workflow_id: currentWorkflowId,
+              input_text: data.error_payload ? JSON.stringify(data.error_payload) : "",
+              result: {
+                result: `ERROR: ${ev.error || "Workflow execution failed"}`,
+                executed_nodes: execData.executedNodes,
+                node_outputs: execData.nodeOutputs,
+                session_id: ev.session_id,
+                status: "failed" as const,
+              },
+              started_at: execData.startedAt,
+              completed_at: execData.completedAt,
+              status: "failed" as const,
+            });
+          }
+        }
+
+        if (eventType === "complete" || eventType === "workflow_complete") {
+          execData.completedAt = data.timestamp || new Date().toISOString();
+          execData.result = executionEvent.result;
+          execData.nodeOutputs = {
+            ...execData.nodeOutputs,
+            ...(executionEvent.node_outputs || {}),
+          };
+          execData.executedNodes = executionEvent.executed_nodes || execData.executedNodes;
+          execData.sessionId = executionEvent.session_id;
+
+          if (currentWorkflowId && setCurrentExecutionForWorkflow) {
+            setCurrentExecutionForWorkflow(currentWorkflowId, {
+              id: executionId,
+              workflow_id: currentWorkflowId,
+              input_text: data.error_payload ? JSON.stringify(data.error_payload) : "",
+              result: {
+                result: executionEvent.result,
+                executed_nodes: execData.executedNodes,
+                node_outputs: execData.nodeOutputs,
+                session_id: execData.sessionId,
+                status: "completed" as const,
+              },
+              started_at: execData.startedAt,
+              completed_at: execData.completedAt,
+              status: "completed" as const,
+            });
+          }
+        }
+      } catch (err) {
+        console.error("Error processing error trigger execution event:", err);
+      }
+    };
+
+    return () => {
+      eventSource.close();
+      executionData.clear();
+    };
+  }, [
+    nodes,
+    edges,
+    currentWorkflowId,
+    setCurrentExecutionForWorkflow,
+    setNodeStatus,
+    setEdgeStatus,
+    setActiveEdges,
+    setActiveNodes,
+  ]);
 }
 
 interface FlowCanvasWrapperProps {

--- a/client/app/components/common/DataDisplayModes.tsx
+++ b/client/app/components/common/DataDisplayModes.tsx
@@ -1,53 +1,336 @@
 import React, { useState } from 'react';
-import { Code, Table, FileText, ChevronDown, Copy, Check } from 'lucide-react';
-
-export type DisplayMode = 'schema' | 'table' | 'json';
+import { ChevronDown, ChevronRight, Copy, Check } from 'lucide-react';
 
 interface DataDisplayModesProps {
   data: any;
   className?: string;
-  defaultMode?: DisplayMode;
+  isInputPanel?: boolean;
+  inputsMeta?: any;
+  currentNodeName?: string;
+  defaultMode?: string; // Kept for backward compatibility signatures
 }
 
-interface DisplayModeOption {
-  id: DisplayMode;
-  label: string;
-  icon: React.ComponentType<{ className?: string }>;
-  description: string;
+const DataTreeContext = React.createContext<{
+  isInputPanel?: boolean;
+  inputsMeta?: any;
+  currentNodeName?: string;
+} | null>(null);
+
+function RenderPrimitiveValue({ val }: { val: any }) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  if (val === null || val === undefined) {
+    return <span className="text-gray-500 italic font-mono select-all">null</span>;
+  }
+  
+  if (typeof val === 'string') {
+    const threshold = 150;
+    const isLong = val.length > threshold;
+    
+    if (isLong && !isExpanded) {
+      const truncated = val.slice(0, threshold) + "...";
+      return (
+        <span 
+          onClick={() => setIsExpanded(true)}
+          className="text-emerald-400 font-mono break-all select-all cursor-pointer hover:underline hover:text-emerald-300"
+          title="Click to expand"
+        >
+          "{truncated}"
+        </span>
+      );
+    }
+    
+    return (
+      <span 
+        onClick={() => { if (isLong) setIsExpanded(false); }}
+        className={`text-emerald-400 font-mono break-all select-all ${isLong ? 'cursor-pointer hover:underline hover:text-emerald-300' : ''}`}
+        title={isLong ? "Click to collapse" : undefined}
+      >
+        "{val}"
+      </span>
+    );
+  }
+  
+  if (typeof val === 'number') {
+    return <span className="text-amber-400 font-mono select-all">{val}</span>;
+  }
+  
+  if (typeof val === 'boolean') {
+    return <span className="text-purple-400 font-semibold font-mono select-all">{val ? 'true' : 'false'}</span>;
+  }
+  
+  const stringVal = String(val);
+  const threshold = 150;
+  const isLong = stringVal.length > threshold;
+  
+  if (isLong && !isExpanded) {
+    const truncated = stringVal.slice(0, threshold) + "...";
+    return (
+      <span 
+        onClick={() => setIsExpanded(true)}
+        className="text-gray-300 font-mono select-all cursor-pointer hover:underline hover:text-gray-200"
+        title="Click to expand"
+      >
+        {truncated}
+      </span>
+    );
+  }
+  
+  return (
+    <span 
+      onClick={() => { if (isLong) setIsExpanded(false); }}
+      className={`text-gray-300 font-mono select-all ${isLong ? 'cursor-pointer hover:underline hover:text-gray-200' : ''}`}
+      title={isLong ? "Click to collapse" : undefined}
+    >
+      {stringVal}
+    </span>
+  );
 }
 
-const displayModes: DisplayModeOption[] = [
-  {
-    id: 'schema',
-    label: 'Schema',
-    icon: FileText,
-    description: 'Structured overview with data types',
-  },
-  {
-    id: 'table', 
-    label: 'Table',
-    icon: Table,
-    description: 'Tabular view for arrays and objects',
-  },
-  {
-    id: 'json',
-    label: 'JSON',
-    icon: Code,
-    description: 'Raw JSON with syntax highlighting',
-  },
-];
+function calculateJinjaExpression(path: string[], context: any) {
+  if (!path || path.length === 0) return '';
+
+  const normalizeForJinja = (name: string): string => {
+    let normalized = name
+      .toLowerCase()
+      .replace(/[^a-z0-9_]/g, "_")
+      .replace(/_+/g, "_")
+      .replace(/^_+|_+$/g, "");
+    if (/^[0-9]/.test(normalized)) {
+      normalized = "n_" + normalized;
+    }
+    return normalized || "node";
+  };
+
+  const buildPathString = (base: string, parts: string[]): string => {
+    let resultPath = base;
+    for (const part of parts) {
+      const trimmedPart = String(part).trim();
+      if (/^\d+$/.test(trimmedPart)) {
+        resultPath += `[${trimmedPart}]`;
+      } else {
+        resultPath += `.${trimmedPart}`;
+      }
+    }
+    return resultPath;
+  };
+
+  if (context?.isInputPanel) {
+    const [rootKey, ...restPath] = path;
+    const metaArray = context.inputsMeta?.[rootKey];
+    if (metaArray && metaArray.length > 0) {
+      const connection = metaArray[0];
+      const sourceAlias = connection.sourceNodeAlias || connection.sourceNodeName;
+      if (sourceAlias) {
+        const normalizedAlias = normalizeForJinja(sourceAlias);
+        const jinjaPath = buildPathString(normalizedAlias, restPath);
+        return `\${{${jinjaPath}}}`;
+      }
+    }
+    return `\${{${buildPathString(rootKey, restPath)}}}`;
+  } else {
+    const currentNodeAlias = context?.currentNodeName || 'node';
+    const normalizedCurrentNode = normalizeForJinja(currentNodeAlias);
+    const [rootKey, ...restPath] = path;
+    if (rootKey === 'output') {
+      return `\${{${buildPathString(normalizedCurrentNode, restPath)}}}`;
+    } else {
+      return `\${{${buildPathString(normalizedCurrentNode, path)}}}`;
+    }
+  }
+}
+
+interface JsonTreeItemProps {
+  keyName?: string;
+  value: any;
+  isLast?: boolean;
+  depth: number;
+  path: string[];
+}
+
+function JsonTreeItem({ keyName, value, isLast = false, depth, path }: JsonTreeItemProps) {
+  const [isOpen, setIsOpen] = useState(true);
+  const [copied, setCopied] = useState(false);
+  const context = React.useContext(DataTreeContext);
+
+  const isObject = value !== null && typeof value === 'object';
+  const isArray = Array.isArray(value);
+
+  const handleCopy = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    try {
+      const text = typeof value === 'object' ? JSON.stringify(value, null, 2) : String(value);
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch (err) {
+      console.error('Failed to copy', err);
+    }
+  };
+
+  const handleDragStart = (e: React.DragEvent) => {
+    const jinjaExpr = calculateJinjaExpression(path, context);
+    e.dataTransfer.setData("text/plain", jinjaExpr);
+    e.dataTransfer.effectAllowed = "copy";
+  };
+
+  if (isObject) {
+    const keys = isArray ? value : Object.keys(value);
+    const size = isArray ? value.length : keys.length;
+
+    if (size === 0) {
+      return (
+        <div className="flex items-center py-1 pl-4 font-mono text-sm">
+          {keyName && <span className="text-sky-400 font-medium mr-1">{keyName}:</span>}
+          <span className="text-gray-500">{isArray ? '[]' : '{}'}</span>
+        </div>
+      );
+    }
+
+    return (
+      <div className="flex flex-col font-mono text-sm">
+        {/* Header */}
+        <div className="flex items-center group py-0.5 hover:bg-gray-800/20 rounded cursor-pointer" onClick={() => setIsOpen(!isOpen)}>
+          <span className="p-0.5 mr-0.5 text-gray-500 hover:text-gray-300" onClick={(e) => e.stopPropagation()}>
+            {isOpen ? (
+              <ChevronDown className="w-3.5 h-3.5" onClick={() => setIsOpen(false)} />
+            ) : (
+              <ChevronRight className="w-3.5 h-3.5" onClick={() => setIsOpen(true)} />
+            )}
+          </span>
+          {keyName && (
+            context?.isInputPanel ? (
+              <span
+                draggable
+                onDragStart={handleDragStart}
+                onClick={(e) => e.stopPropagation()}
+                className="border border-gray-800 bg-gray-900/50 rounded px-1.5 py-0.5 text-xs text-sky-400 font-mono font-medium cursor-grab active:cursor-grabbing hover:bg-gray-800 transition-colors select-none flex items-center gap-1"
+                title="Drag to drop Jinja variable"
+              >
+                <span className="text-[10px] text-gray-500 font-mono">☰</span>
+                {keyName}
+              </span>
+            ) : (
+              <span
+                onClick={(e) => e.stopPropagation()}
+                className="border border-gray-800 bg-gray-950/40 rounded px-1.5 py-0.5 text-xs text-sky-300 font-mono font-medium select-none flex items-center gap-1"
+                title="Output key"
+              >
+                {keyName}
+              </span>
+            )
+          )}
+          {keyName && <span className="text-gray-500 mr-1.5">:</span>}
+          <span className="text-gray-400 mr-2">{isArray ? '[' : '{'}</span>
+          
+          {!isOpen && (
+            <>
+              <span className="text-gray-500 text-xs italic mr-2">
+                {isArray ? `${size} items` : `${size} keys`}
+              </span>
+              <span className="text-gray-400 mr-2">{isArray ? ']' : '}'}</span>
+            </>
+          )}
+
+          {/* Copy node button */}
+          <button
+            onClick={handleCopy}
+            className="opacity-0 group-hover:opacity-100 ml-2 p-1 text-gray-500 hover:text-gray-300 rounded transition-opacity"
+            title={isArray ? "Copy array" : "Copy object"}
+          >
+            {copied ? <Check className="w-3 h-3 text-green-400" /> : <Copy className="w-3 h-3" />}
+          </button>
+        </div>
+
+        {/* Children */}
+        {isOpen && (
+          <div className="border-l border-gray-800/80 ml-2 pl-4 flex flex-col">
+            {isArray
+              ? value.map((item: any, idx: number) => (
+                  <JsonTreeItem
+                    key={idx}
+                    keyName={String(idx)}
+                    value={item}
+                    isLast={idx === value.length - 1}
+                    depth={depth + 1}
+                    path={[...path, String(idx)]}
+                  />
+                ))
+              : Object.entries(value).map(([childKey, childValue], idx, arr) => (
+                  <JsonTreeItem
+                    key={childKey}
+                    keyName={childKey}
+                    value={childValue}
+                    isLast={idx === arr.length - 1}
+                    depth={depth + 1}
+                    path={[...path, childKey]}
+                  />
+                ))}
+          </div>
+        )}
+
+        {/* Footer */}
+        {isOpen && (
+          <div className="text-gray-400 py-0.5 pl-4">
+            {isArray ? ']' : '}'}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // Primitive value
+  return (
+    <div className="flex items-center group py-0.5 pl-4 hover:bg-gray-800/20 rounded font-mono text-sm">
+      {keyName && (
+        context?.isInputPanel ? (
+          <span
+            draggable
+            onDragStart={handleDragStart}
+            className="border border-gray-800 bg-gray-900/50 rounded px-1.5 py-0.5 text-xs text-sky-400 font-mono font-medium cursor-grab active:cursor-grabbing hover:bg-gray-800 transition-colors select-none flex items-center gap-1 mr-1 flex-shrink-0"
+            title="Drag to drop Jinja variable"
+          >
+            <span className="text-[10px] text-gray-500 font-mono">☰</span>
+            {keyName}
+          </span>
+        ) : (
+          <span
+            className="border border-gray-800 bg-gray-950/40 rounded px-1.5 py-0.5 text-xs text-sky-300 font-mono font-medium select-none flex items-center gap-1 mr-1 flex-shrink-0"
+            title="Output key"
+          >
+            {keyName}
+          </span>
+        )
+      )}
+      {keyName && <span className="text-gray-500 mr-1.5 flex-shrink-0">:</span>}
+      <div className="flex-1 min-w-0">
+        <RenderPrimitiveValue val={value} />
+      </div>
+      
+      {/* Copy primitive button */}
+      <button
+        onClick={handleCopy}
+        className="opacity-0 group-hover:opacity-100 ml-2 p-1 text-gray-500 hover:text-gray-300 rounded transition-opacity flex-shrink-0"
+        title="Copy value"
+      >
+        {copied ? <Check className="w-3.5 h-3.5 text-green-400" /> : <Copy className="w-3 h-3" />}
+      </button>
+    </div>
+  );
+}
 
 export default function DataDisplayModes({
   data,
   className = '',
-  defaultMode = 'schema',
+  isInputPanel = false,
+  inputsMeta,
+  currentNodeName,
 }: DataDisplayModesProps) {
-  const [selectedMode, setSelectedMode] = useState<DisplayMode>(defaultMode);
   const [copied, setCopied] = useState(false);
 
-  const handleCopy = async () => {
+  const handleCopyAll = async () => {
     try {
-      const textToCopy = typeof data === 'object' 
+      const textToCopy = typeof data === 'object' && data !== null
         ? JSON.stringify(data, null, 2)
         : String(data);
       await navigator.clipboard.writeText(textToCopy);
@@ -58,278 +341,47 @@ export default function DataDisplayModes({
     }
   };
 
-  const renderSchemaView = (obj: any, depth: number = 0): React.ReactNode => {
-    if (obj === null || obj === undefined) {
-      return <span className="text-gray-500 italic">null</span>;
-    }
-
-    if (Array.isArray(obj)) {
-      return (
-        <div className={`${depth > 0 ? 'ml-4' : ''}`}>
-          <div className="text-blue-400 text-sm font-medium mb-2">
-            Array ({obj.length} items)
-          </div>
-          {obj.length > 0 && (
-            <div className="border-l-2 border-gray-600 pl-3">
-              <div className="text-gray-400 text-xs mb-2">Item structure:</div>
-              {renderSchemaView(obj[0], depth + 1)}
-            </div>
-          )}
-        </div>
-      );
-    }
-
-    if (typeof obj === 'object') {
-      const entries = Object.entries(obj);
-      return (
-        <div className={`${depth > 0 ? 'ml-4' : ''} space-y-2`}>
-          {entries.map(([key, value]) => (
-            <div key={key} className="flex items-start gap-3">
-              <div className="text-green-400 font-medium text-sm min-w-0 flex-shrink-0">
-                {key}
-              </div>
-              <div className="text-gray-400 text-xs self-center">:</div>
-              <div className="min-w-0 flex-1">
-                {typeof value === 'object' ? (
-                  renderSchemaView(value, depth + 1)
-                ) : (
-                  <div className="flex items-center gap-2">
-                    {typeof value === 'string' && value.length > 50 ? (
-                      <span className="text-gray-300 text-sm">
-                        {value.substring(0, 50)}...
-                      </span>
-                    ) : (
-                      <span className="text-gray-300 text-sm">
-                        {String(value)}
-                      </span>
-                    )}
-                  </div>
-                )}
-              </div>
-            </div>
-          ))}
-        </div>
-      );
-    }
-
-    return (
-      <div className="flex items-center gap-2">
-        <span className="text-gray-300">{String(obj)}</span>
-      </div>
-    );
-  };
-
-  const renderTableView = (obj: any): React.ReactNode => {
-    // Handle array data
-    if (Array.isArray(obj)) {
-      if (obj.length === 0) {
-        return (
-          <div className="text-gray-400 text-center py-8">
-            <Table className="w-8 h-8 mx-auto mb-2 opacity-50" />
-            <p>No data to display</p>
-          </div>
-        );
-      }
-
-      // Get all unique keys from all objects in array
-      const allKeys = new Set<string>();
-      obj.forEach(item => {
-        if (typeof item === 'object' && item !== null) {
-          Object.keys(item).forEach(key => allKeys.add(key));
-        }
-      });
-
-      const keys = Array.from(allKeys);
-
-      if (keys.length === 0) {
-        return (
-          <div className="text-gray-400 text-center py-8">
-            <Table className="w-8 h-8 mx-auto mb-2 opacity-50" />
-            <p>Array contains primitive values, not objects</p>
-          </div>
-        );
-      }
-
-      return (
-        <div className="overflow-x-auto">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-gray-600">
-                {keys.map(key => (
-                  <th key={key} className="text-left p-3 text-green-400 font-medium">
-                    {key}
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {obj.map((item, index) => (
-                <tr key={index} className="border-b border-gray-700/50 hover:bg-gray-800/30">
-                  {keys.map(key => (
-                    <td key={key} className="p-3 text-gray-300 max-w-xs">
-                      {item && typeof item === 'object' ? (
-                        typeof item[key] === 'object' ? (
-                          <span className="text-gray-500 italic">
-                            {Array.isArray(item[key]) 
-                              ? `[${item[key].length} items]`
-                              : '{object}'}
-                          </span>
-                        ) : (
-                          <span className="break-words">
-                            {String(item[key] || '—')}
-                          </span>
-                        )
-                      ) : (
-                        <span className="text-gray-500 italic">—</span>
-                      )}
-                    </td>
-                  ))}
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      );
-    }
-
-    // Handle object data as key-value table
-    if (typeof obj === 'object' && obj !== null) {
-      const entries = Object.entries(obj);
-      
-      if (entries.length === 0) {
-        return (
-          <div className="text-gray-400 text-center py-8">
-            <Table className="w-8 h-8 mx-auto mb-2 opacity-50" />
-            <p>No data to display</p>
-          </div>
-        );
-      }
-
-      return (
-        <div className="overflow-x-auto">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-gray-600">
-                <th className="text-left p-3 text-green-400 font-medium w-1/3">
-                  Property
-                </th>
-                <th className="text-left p-3 text-green-400 font-medium w-1/6">
-                  Type
-                </th>
-                <th className="text-left p-3 text-green-400 font-medium">
-                  Value
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {entries.map(([key, value]) => (
-                <tr key={key} className="border-b border-gray-700/50 hover:bg-gray-800/30">
-                  <td className="p-3 text-blue-300 font-medium">
-                    {key}
-                  </td>
-                  <td className="p-3 text-purple-400 text-xs">
-                    {Array.isArray(value) ? `array[${value.length}]` : typeof value}
-                  </td>
-                  <td className="p-3 text-gray-300 max-w-xs">
-                    {typeof value === 'object' && value !== null ? (
-                      <span className="text-gray-500 italic">
-                        {Array.isArray(value) 
-                          ? `[${value.length} items]`
-                          : `{${Object.keys(value).length} properties}`}
-                      </span>
-                    ) : (
-                      <span className="break-words">
-                        {String(value)}
-                      </span>
-                    )}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      );
-    }
-
-    // Fallback for primitive values
-    return (
-      <div className="text-gray-400 text-center py-8">
-        <Table className="w-8 h-8 mx-auto mb-2 opacity-50" />
-        <p>Table view is not available for primitive values</p>
-      </div>
-    );
-  };
-
-  const renderJsonView = (obj: any): React.ReactNode => {
-    const jsonString = JSON.stringify(obj, null, 2);
-    return (
-      <pre className="text-sm text-gray-300 whitespace-pre-wrap break-words">
-        {jsonString}
-      </pre>
-    );
-  };
-
-  const renderContent = (): React.ReactNode => {
-    switch (selectedMode) {
-      case 'schema':
-        return renderSchemaView(data);
-      case 'table':
-        return renderTableView(data);
-      case 'json':
-        return renderJsonView(data);
-      default:
-        return renderJsonView(data);
-    }
-  };
+  const isEmpty = data === null || data === undefined || (typeof data === 'object' && Object.keys(data).length === 0);
 
   return (
-    <div className={`w-full ${className}`}>
-      {/* Mode Selector */}
-      <div className="flex items-center justify-between mb-4 pb-3 border-b border-gray-700/50">
-        <div className="flex items-center gap-2">
-          {displayModes.map((mode) => {
-            const Icon = mode.icon;
-            return (
-              <button
-                key={mode.id}
-                onClick={() => setSelectedMode(mode.id)}
-                className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
-                  selectedMode === mode.id
-                    ? 'bg-blue-600 text-white'
-                    : 'bg-gray-700/50 text-gray-300 hover:bg-gray-600/50 hover:text-white'
-                }`}
-                title={mode.description}
-              >
-                <Icon className="w-4 h-4" />
-                {mode.label}
-              </button>
-            );
-          })}
+    <DataTreeContext.Provider value={{ isInputPanel, inputsMeta, currentNodeName }}>
+      <div className={`w-full flex flex-col bg-gray-950/40 border border-gray-850 rounded-xl overflow-hidden ${className}`}>
+        {/* Header bar */}
+        <div className="flex items-center justify-between px-4 py-2 bg-gray-900/60 border-b border-gray-850">
+          <span className="text-xs font-semibold text-gray-400 tracking-wider uppercase">
+            Data Tree
+          </span>
+
+          <button
+            onClick={handleCopyAll}
+            className="flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium bg-gray-800/60 hover:bg-gray-700/60 text-gray-300 hover:text-white border border-gray-700/50 transition-all cursor-pointer"
+            title="Copy full JSON"
+          >
+            {copied ? (
+              <>
+                <Check className="w-3.5 h-3.5 text-green-400" />
+                <span className="text-green-400">Copied</span>
+              </>
+            ) : (
+              <>
+                <Copy className="w-3.5 h-3.5" />
+                <span>Copy Full JSON</span>
+              </>
+            )}
+          </button>
         </div>
 
-        <button
-          onClick={handleCopy}
-          className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm bg-gray-700/50 text-gray-300 hover:bg-gray-600/50 hover:text-white transition-colors"
-          title="Copy data to clipboard"
-        >
-          {copied ? (
-            <>
-              <Check className="w-4 h-4 text-green-400" />
-              <span className="text-green-400">Copied</span>
-            </>
+        {/* Main tree display area */}
+        <div className="p-4 overflow-auto max-h-[500px] bg-gray-900/10">
+          {isEmpty ? (
+            <div className="text-gray-500 italic py-4 pl-4 text-sm font-mono">
+              {"{ empty }"}
+            </div>
           ) : (
-            <>
-              <Copy className="w-4 h-4" />
-              Copy
-            </>
+            <JsonTreeItem value={data} depth={0} path={[]} />
           )}
-        </button>
+        </div>
       </div>
-
-      {/* Content Display */}
-      <div className="bg-gray-900/50 rounded-lg p-4 border border-gray-700/30 max-h-96 overflow-auto">
-        {renderContent()}
-      </div>
-    </div>
+    </DataTreeContext.Provider>
   );
 }

--- a/client/app/components/common/FullscreenNodeModal.tsx
+++ b/client/app/components/common/FullscreenNodeModal.tsx
@@ -106,6 +106,8 @@ export default function FullscreenNodeModal({
   );
   const [nodeAliasError, setNodeAliasError] = useState<string | null>(null);
 
+  const inputDataToDisplay = executionData?.inputs;
+
   // Validate node alias for Jinja template compatibility
   // Rules: letters, numbers, and underscores only; must start with a letter; cannot be reserved keywords
   // Note: Uppercase letters are allowed but will be auto-converted to lowercase when saving
@@ -700,130 +702,24 @@ export default function FullscreenNodeModal({
                   </h2>
                 </div>
 
-                {/* Execution Data Section */}
-                {executionData?.inputs &&
-                  Object.keys(executionData.inputs).length > 0 ? (
+                {/* Standardized JSON Input View */}
+                {inputDataToDisplay &&
+                  Object.keys(inputDataToDisplay).length > 0 ? (
                   <div className="space-y-4">
                     <div className="flex items-center gap-2 text-sm mb-4">
-                      <div className="w-2 h-2 bg-green-400 rounded-full animate-pulse"></div>
-                      <span className="text-green-400 font-medium">
-                        Live Data
+                      <div className="w-2 h-2 bg-blue-400 rounded-full animate-pulse"></div>
+                      <span className="text-blue-300 font-medium">
+                        Standardized JSON Input
                       </span>
-                      <div className="text-xs text-gray-500">
-                        • Real-time workflow data
-                      </div>
                     </div>
-
-                    <div className="space-y-4">
-                      {Object.entries(executionData.inputs).flatMap(
-                        ([key, rawValue]) => {
-                          const valuesArray = Array.isArray(rawValue)
-                            ? rawValue
-                            : [rawValue];
-                          const rawMeta = executionData.inputs_meta?.[key];
-                          const metaArray = Array.isArray(rawMeta)
-                            ? rawMeta
-                            : rawMeta
-                              ? [rawMeta]
-                              : [];
-
-                          return valuesArray.map((value, index) => {
-                            const sourceMeta = metaArray[index] || metaArray[0];
-                            const label =
-                              valuesArray.length > 1
-                                ? `${getDataLabel(key)} [${index + 1}]`
-                                : getDataLabel(key);
-
-                            return (
-                              <div
-                                key={`${key}-${index}`}
-                                className="bg-gradient-to-r from-gray-800 to-gray-800/50 rounded-xl p-4 border border-gray-700/50"
-                              >
-                                {/* Header with icon and user-friendly label */}
-                                <div className="flex items-center gap-3 mb-3">
-                                  <div className="p-2 bg-blue-600/20 text-blue-400 rounded-lg">
-                                    {getDataIcon(key, value)}
-                                  </div>
-                                  <div className="flex-1">
-                                    <div className="text-sm font-medium text-blue-300">
-                                      {label}
-                                    </div>
-                                    <div className="text-xs text-gray-400">
-                                      {getDataDescription(key, value)}
-                                    </div>
-                                    {sourceMeta && (
-                                      <div className="mt-1 text-[10px] text-gray-500">
-                                        From:{" "}
-                                        {sourceMeta.sourceNodeAlias ||
-                                          sourceMeta.sourceNodeName ||
-                                          sourceMeta.sourceNodeId}
-                                        {sourceMeta.sourceHandle && (
-                                          <>
-                                            {" "}
-                                            · handle: {sourceMeta.sourceHandle}
-                                          </>
-                                        )}
-                                      </div>
-                                    )}
-                                  </div>
-                                  <div className="text-xs text-gray-500 bg-gray-700/50 px-2 py-1 rounded">
-                                    input
-                                  </div>
-                                </div>
-
-                                {/* Value display */}
-                                {value && typeof value === "object" && value._placeholder ? (
-                                  <div className="bg-yellow-900/20 rounded-lg p-3 border border-yellow-500/30">
-                                    <div className="flex items-center gap-2">
-                                      <div className="w-2 h-2 bg-yellow-400 rounded-full animate-pulse"></div>
-                                      <div className="text-sm text-yellow-200">
-                                        {value.message || "Waiting for execution"}
-                                      </div>
-                                    </div>
-                                  </div>
-                                ) : typeof value === "object" && value !== null ? (
-                                  <DataDisplayModes
-                                    data={maskSensitiveValue(key, value)}
-                                    className="mt-2"
-                                    defaultMode="schema"
-                                  />
-                                ) : (
-                                  <div className="bg-gray-900/80 rounded-lg p-3 border border-gray-700/30">
-                                    <div className="text-sm text-gray-100 break-words">
-                                      {formatValue(value, key)}
-                                    </div>
-                                  </div>
-                                )}
-                              </div>
-                            );
-                          });
-                        }
-                      )}
-                    </div>
-
-                    {/* Context Variables */}
-                    <div className="bg-gray-800/30 rounded-lg p-4 border border-gray-600/30">
-                      <div className="flex items-center gap-2 mb-3">
-                        <Info className="w-4 h-4 text-blue-400" />
-                        <div className="text-sm font-medium text-gray-300">
-                          Execution Info
-                        </div>
-                      </div>
-                      <div className="space-y-2 text-sm">
-                        <div className="flex justify-between items-center">
-                          <span className="text-gray-400">Execution Time:</span>
-                          <span className="text-blue-400 font-mono text-xs">
-                            {new Date().toLocaleString("en-US")}
-                          </span>
-                        </div>
-                        <div className="flex justify-between items-center">
-                          <span className="text-gray-400">Mode:</span>
-                          <span className="text-blue-400 bg-blue-400/10 px-2 py-1 rounded text-xs">
-                            Development
-                          </span>
-                        </div>
-                      </div>
-                    </div>
+ 
+                    <DataDisplayModes
+                      data={inputDataToDisplay}
+                      className="mt-2"
+                      isInputPanel={true}
+                      inputsMeta={executionData?.inputs_meta}
+                      currentNodeName={nodeAlias}
+                    />
                   </div>
                 ) : (
                   <div className="text-center py-12">
@@ -844,7 +740,7 @@ export default function FullscreenNodeModal({
                 )}
               </div>
             </motion.div>
-
+ 
             {/* Center Column - Configuration */}
             <motion.div
               initial={{ scale: 0.95, opacity: 0 }}
@@ -870,7 +766,7 @@ export default function FullscreenNodeModal({
                 </div>
               </div>
             </motion.div>
-
+ 
             {/* Right Column - Output Data */}
             <motion.div
               initial={{ x: 50, opacity: 0 }}
@@ -885,139 +781,31 @@ export default function FullscreenNodeModal({
                     Output Data
                   </h2>
                 </div>
-
-                {/* Execution Output Section */}
+ 
+                {/* Standardized JSON Output View */}
                 {executionData?.outputs ? (
                   <div className="space-y-4">
                     <div className="flex items-center gap-2 text-sm mb-4">
-                      <div className="w-2 h-2 bg-purple-400 rounded-full animate-pulse"></div>
-                      <span className="text-purple-400 font-medium">
-                        Generated
+                      <div className={`w-2 h-2 rounded-full animate-pulse ${
+                        executionData.outputs.success === false ? "bg-red-500" : "bg-purple-500"
+                      }`}></div>
+                      <span className={`${
+                        executionData.outputs.success === false ? "text-red-400" : "text-purple-300"
+                      } font-medium`}>
+                        {executionData.outputs.success === false ? "Execution Failed" : "Standardized JSON Output"}
                       </span>
-                      <div className="text-xs text-gray-500">
-                        • Processing completed, result ready
-                      </div>
                     </div>
-
-                    <div className="space-y-4">
-                      {typeof executionData.outputs === "object" &&
-                        executionData.outputs !== null ? (
-                        Object.entries(
-                          filterNodeData(executionData.outputs, true)
-                        ).map(([key, value]) => (
-                          <div
-                            key={key}
-                            className="bg-gradient-to-r from-purple-900/20 to-blue-900/20 rounded-xl p-4 border border-purple-500/30"
-                          >
-                            {/* Header with icon and user-friendly label */}
-                            <div className="flex items-center gap-3 mb-3">
-                              <div className="p-2 bg-purple-600/20 text-purple-400 rounded-lg">
-                                {getDataIcon(key, value)}
-                              </div>
-                              <div className="flex-1">
-                                <div className="text-sm font-medium text-purple-300">
-                                  {getDataLabel(key)}
-                                </div>
-                                <div className="text-xs text-gray-400">
-                                  {getDataDescription(key, value)}
-                                </div>
-                              </div>
-                              <div className="text-xs text-gray-500 bg-gray-700/50 px-2 py-1 rounded">
-                                çıkış
-                              </div>
-                            </div>
-
-                            {/* Value display */}
-                            {value && typeof value === "object" && value._placeholder ? (
-                              <div className="bg-yellow-900/20 rounded-lg p-3 border border-yellow-500/30">
-                                <div className="flex items-center gap-2">
-                                  <div className="w-2 h-2 bg-yellow-400 rounded-full animate-pulse"></div>
-                                  <div className="text-sm text-yellow-200">
-                                    {value.message || "Waiting for execution"}
-                                  </div>
-                                </div>
-                              </div>
-                            ) : typeof value === "object" && value !== null ? (
-                              <DataDisplayModes
-                                data={maskSensitiveValue(key, value)}
-                                className="mt-2"
-                                defaultMode="schema"
-                              />
-                            ) : (
-                              <div className="bg-gray-900/80 rounded-lg p-3 border border-gray-700/30">
-                                <div className="text-sm text-gray-100 break-words">
-                                  {formatValue(value, key)}
-                                </div>
-                                <button
-                                  onClick={() =>
-                                    navigator.clipboard.writeText(
-                                      String(maskSensitiveValue(key, value))
-                                    )
-                                  }
-                                  className="mt-2 text-xs text-purple-400 hover:text-purple-300 transition-colors bg-purple-600/10 px-2 py-1 rounded"
-                                >
-                                  Copy
-                                </button>
-                              </div>
-                            )}
-                          </div>
-                        ))
-                      ) : (
-                        // Single output value
-                        <div className="bg-gradient-to-r from-purple-900/20 to-blue-900/20 rounded-xl p-4 border border-purple-500/30">
-                          {/* Header with icon and user-friendly label */}
-                          <div className="flex items-center gap-3 mb-3">
-                            <div className="p-2 bg-purple-600/20 text-purple-400 rounded-lg">
-                              {getDataIcon("result", executionData.outputs)}
-                            </div>
-                            <div className="flex-1">
-                              <div className="text-sm font-medium text-purple-300">
-                                {getDataLabel("result")}
-                              </div>
-                              <div className="text-xs text-gray-400">
-                                {getDataDescription(
-                                  "result",
-                                  executionData.outputs
-                                )}
-                              </div>
-                            </div>
-                            <div className="text-xs text-gray-500 bg-gray-700/50 px-2 py-1 rounded">
-                              output
-                            </div>
-                          </div>
-
-                          {/* Value display */}
-                          {typeof executionData.outputs === "object" && executionData.outputs !== null ? (
-                            <DataDisplayModes
-                              data={maskSensitiveValue("result", executionData.outputs)}
-                              className="mt-2"
-                              defaultMode="schema"
-                            />
-                          ) : (
-                            <div className="bg-gray-900/80 rounded-lg p-3 border border-gray-700/30">
-                              <div className="text-sm text-gray-100 break-words">
-                                {formatValue(executionData.outputs, "result")}
-                              </div>
-                              <button
-                                onClick={() =>
-                                  navigator.clipboard.writeText(
-                                    String(
-                                      maskSensitiveValue(
-                                        "result",
-                                        executionData.outputs
-                                      )
-                                    )
-                                  )
-                                }
-                                className="mt-2 text-xs text-purple-400 hover:text-purple-300 transition-colors bg-purple-600/10 px-2 py-1 rounded"
-                              >
-                                Copy
-                              </button>
-                            </div>
-                          )}
-                        </div>
-                      )}
-                    </div>
+ 
+                    <DataDisplayModes
+                      data={(() => {
+                        if (!executionData?.outputs) return null;
+                        const { inputs, ...rest } = executionData.outputs;
+                        return rest;
+                      })()}
+                      className="mt-2"
+                      isInputPanel={false}
+                      currentNodeName={nodeAlias}
+                    />
                   </div>
                 ) : (
                   <div className="text-center py-12">

--- a/client/app/components/node/fields/NodeCodeEditor.tsx
+++ b/client/app/components/node/fields/NodeCodeEditor.tsx
@@ -123,6 +123,40 @@ export const NodeCodeEditor = ({ property, values }: NodeCodeEditorProps) => {
         monacoRef.current = monacoInstance;
         registerCompletions(monacoInstance);
 
+        // Custom drag & drop handler to prevent Monaco snippet formatting bug
+        const domNode = editorInstance.getDomNode();
+        if (domNode) {
+            const handleDragOver = (e: DragEvent) => {
+                e.preventDefault();
+            };
+            const handleDrop = (e: DragEvent) => {
+                const text = e.dataTransfer?.getData("text/plain");
+                if (text) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    const target = editorInstance.getTargetAtClientPoint(e.clientX, e.clientY);
+                    if (target && target.position) {
+                        const { lineNumber, column } = target.position;
+                        editorInstance.executeEdits("drag-drop", [
+                            {
+                                range: new monacoInstance.Range(lineNumber, column, lineNumber, column),
+                                text: text,
+                                forceMoveMarkers: true,
+                            }
+                        ]);
+                        editorInstance.setPosition({ lineNumber, column: column + text.length });
+                        editorInstance.focus();
+                    }
+                }
+            };
+            domNode.addEventListener("dragover", handleDragOver);
+            domNode.addEventListener("drop", handleDrop);
+            (editorInstance as any)._dropCleanup = () => {
+                domNode.removeEventListener("dragover", handleDragOver);
+                domNode.removeEventListener("drop", handleDrop);
+            };
+        }
+
         // Ctrl+S: save & close
         editorInstance.addCommand(
             monacoInstance.KeyMod.CtrlCmd | monacoInstance.KeyCode.KeyS,
@@ -214,6 +248,40 @@ export const NodeCodeEditor = ({ property, values }: NodeCodeEditorProps) => {
         registerCompletions(monacoInstance);
         editorInstance.focus();
 
+        // Custom drag & drop handler for fullscreen mode
+        const domNode = editorInstance.getDomNode();
+        if (domNode) {
+            const handleDragOver = (e: DragEvent) => {
+                e.preventDefault();
+            };
+            const handleDrop = (e: DragEvent) => {
+                const text = e.dataTransfer?.getData("text/plain");
+                if (text) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    const target = editorInstance.getTargetAtClientPoint(e.clientX, e.clientY);
+                    if (target && target.position) {
+                        const { lineNumber, column } = target.position;
+                        editorInstance.executeEdits("drag-drop", [
+                            {
+                                range: new monacoInstance.Range(lineNumber, column, lineNumber, column),
+                                text: text,
+                                forceMoveMarkers: true,
+                            }
+                        ]);
+                        editorInstance.setPosition({ lineNumber, column: column + text.length });
+                        editorInstance.focus();
+                    }
+                }
+            };
+            domNode.addEventListener("dragover", handleDragOver);
+            domNode.addEventListener("drop", handleDrop);
+            (editorInstance as any)._dropCleanup = () => {
+                domNode.removeEventListener("dragover", handleDragOver);
+                domNode.removeEventListener("drop", handleDrop);
+            };
+        }
+
         // Ctrl+S: save & close fullscreen + submit form
         editorInstance.addCommand(
             monacoInstance.KeyMod.CtrlCmd | monacoInstance.KeyCode.KeyS,
@@ -248,6 +316,12 @@ export const NodeCodeEditor = ({ property, values }: NodeCodeEditorProps) => {
         return () => {
             disposablesRef.current.forEach((d) => d.dispose());
             disposablesRef.current = [];
+            if (editorRef.current && (editorRef.current as any)._dropCleanup) {
+                (editorRef.current as any)._dropCleanup();
+            }
+            if (fullscreenEditorRef.current && (fullscreenEditorRef.current as any)._dropCleanup) {
+                (fullscreenEditorRef.current as any)._dropCleanup();
+            }
         };
     }, []);
 

--- a/client/app/stores/chat.ts
+++ b/client/app/stores/chat.ts
@@ -178,6 +178,31 @@ const executeWorkflowWithStreaming = async (
                   node_id: parsed.node_id
                 }
               }));
+
+              // Save failed execution to store so canvas updates correctly
+              const executionResult: WorkflowExecution = {
+                id: parsed.execution_id || Date.now().toString(),
+                workflow_id: workflow_id,
+                input_text: input_text,
+                result: {
+                  result: `ERROR: ${parsed.error || parsed.data || 'Unknown error'}`,
+                  executed_nodes: parsed.executed_nodes || [],
+                  node_outputs: parsed.node_outputs || {},
+                  session_id: parsed.session_id,
+                  status: 'failed' as const,
+                },
+                started_at: new Date().toISOString(),
+                completed_at: new Date().toISOString(),
+                status: 'failed' as const,
+              };
+
+              try {
+                const executionsModule = await import('./executions');
+                const executionsStore = executionsModule.useExecutionsStore.getState();
+                executionsStore.setCurrentExecutionForWorkflow(workflow_id, executionResult);
+              } catch (error) {
+                console.error('❌ Error setting failed execution result:', error);
+              }
             }
 
             // Handle complete event to capture execution data


### PR DESCRIPTION
- add TemplateValue wrapper to support nested path-based Jinja variable lookups
- standardize node outputs with a unified metadata and payload envelope structure
- cache trigger node outputs in FlowState for consistent downstream access
- integrate common output formatting in BaseNode for execution result tracking
- update graph builder and node executors to use standardized output schema
- redesign Data Tree to generate and drag nested Jinja expressions dynamically
- fix Monaco Editor drag-and-drop escaping issues for injected Jinja templates
- align frontend stores and canvas components with the new output data model