### PR TITLE
feat: enable connection validation before persisting workflow credentials

### DIFF
--- a/client/app/components/credentials/CredentialSelector.tsx
+++ b/client/app/components/credentials/CredentialSelector.tsx
@@ -2,9 +2,13 @@ import React, { useEffect, useState, useRef } from "react";
 import { createPortal } from "react-dom";
 import { Loader2, ChevronDown, Plus } from "lucide-react";
 import { useUserCredentialStore } from "~/stores/userCredential";
-import { getUserCredentialById } from "~/services/userCredentialService";
+import {
+  getUserCredentialById,
+  testCredentialRaw,
+} from "~/services/userCredentialService";
 import ServiceSelectionModal from "~/components/credentials/ServiceSelectionModal";
 import DynamicCredentialForm from "~/components/credentials/DynamicCredentialForm";
+import { getCredentialData } from "~/components/credentials/credentialPayload";
 import type { ServiceDefinition } from "~/types/credentials";
 import { getServiceDefinition } from "~/types/credentials";
 
@@ -112,7 +116,7 @@ const CredentialSelector: React.FC<CredentialSelectorProps> = ({
     try {
       const payload = {
         name: values.name || `${selectedService.name} Credential`,
-        data: values,
+        data: getCredentialData(values),
         service_type: selectedService.id,
       };
 
@@ -254,6 +258,13 @@ const CredentialSelector: React.FC<CredentialSelectorProps> = ({
                   service={selectedService}
                   onSubmit={handleCreateCredential}
                   onCancel={() => setSelectedService(null)}
+                  onTest={(values) =>
+                    testCredentialRaw(
+                      selectedService.id,
+                      getCredentialData(values)
+                    )
+                  }
+                  initialValues={{ name: `${selectedService.name} Credential` }}
                   isSubmitting={isSubmitting}
                 />
               </div>

--- a/client/app/components/credentials/DynamicCredentialForm.tsx
+++ b/client/app/components/credentials/DynamicCredentialForm.tsx
@@ -280,9 +280,9 @@ const DynamicCredentialForm: React.FC<DynamicCredentialFormProps> = ({
                       const result = await onTest(values);
                       setTestState(result.success ? "success" : "error");
                       setTestMessage(result.message);
-                    } catch {
+                    } catch (error: any) {
                       setTestState("error");
-                      setTestMessage("Unexpected error. Please try again.");
+                      setTestMessage(error?.message || "Unexpected error. Please try again.");
                     }
                     setTimeout(() => {
                       setTestState("idle");

--- a/client/app/components/credentials/credentialPayload.ts
+++ b/client/app/components/credentials/credentialPayload.ts
@@ -1,0 +1,14 @@
+const CREDENTIAL_META_FIELDS = new Set([
+  "id",
+  "name",
+  "service_type",
+  "created_at",
+  "updated_at",
+  "data",
+  "secret",
+]);
+
+export const getCredentialData = (values: Record<string, any>) =>
+  Object.fromEntries(
+    Object.entries(values).filter(([key]) => !CREDENTIAL_META_FIELDS.has(key))
+  );


### PR DESCRIPTION
- integrate backend credential connectivity checks into the credential creation workflow
- extract credential payload sanitization logic to remove metadata fields before validation or persistence
- surface backend API error responses in connection test results for actionable troubleshooting
- add loading, success, and failure states to provide real-time connection validation feedback