### PR TITLE
feat: improve field UX by replacing inline descriptions with tooltip-based help labels

### DIFF
--- a/client/app/components/node/GenericNodeForm.tsx
+++ b/client/app/components/node/GenericNodeForm.tsx
@@ -16,6 +16,7 @@ import {
   NodeCodeEditor,
   NodeSessionId,
 } from "./fields";
+import { FieldLabel, getFieldHelpText } from "./fields/FieldLabel";
 import TabNavigation from "../common/TabNavigation";
 import { useState, useRef, useEffect } from "react";
 import { Settings, Plus, X, ChevronDown } from "lucide-react";
@@ -255,12 +256,11 @@ export default function GenericNodeForm({
                 if (property.type === "checkbox") {
                   return (
                     <div key={property.name} className="col-span-2 flex items-center justify-between bg-slate-800/50 border border-slate-600 rounded-lg px-4 py-3">
-                      <div className="flex items-center gap-3">
-                        <span className="text-sm text-slate-200">{property.displayName}</span>
-                        {property.hint && (
-                          <span className="text-xs text-slate-400">({property.hint})</span>
-                        )}
-                      </div>
+                      <FieldLabel
+                        label={property.displayName}
+                        helpText={getFieldHelpText(property)}
+                        className="text-sm text-slate-200"
+                      />
                       <div className="flex items-center gap-3">
                         {/* Toggle Switch */}
                         <button
@@ -295,12 +295,11 @@ export default function GenericNodeForm({
                 if (property.type === "number") {
                   return (
                     <div key={property.name} className="col-span-2 flex items-center justify-between bg-slate-800/50 border border-slate-600 rounded-lg px-4 py-3">
-                      <div className="flex items-center gap-3">
-                        <span className="text-sm text-slate-200">{property.displayName}</span>
-                        {property.hint && (
-                          <span className="text-xs text-slate-400">({property.hint})</span>
-                        )}
-                      </div>
+                      <FieldLabel
+                        label={property.displayName}
+                        helpText={getFieldHelpText(property)}
+                        className="text-sm text-slate-200"
+                      />
                       <div className="flex items-center gap-3">
                         <input
                           type="number"

--- a/client/app/components/node/fields/FieldLabel.tsx
+++ b/client/app/components/node/fields/FieldLabel.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from "react";
+import { useId } from "react";
+import { CircleHelp } from "lucide-react";
+
+interface FieldLabelProps {
+  label: ReactNode;
+  helpText?: string;
+  className?: string;
+  children?: ReactNode;
+}
+
+export const getFieldHelpText = (property: Record<string, any>) => {
+  const helpText = property.hint ?? property.description;
+  return typeof helpText === "string" && helpText.trim() ? helpText : undefined;
+};
+
+export const FieldLabel = ({
+  label,
+  helpText,
+  className = "text-white text-sm font-medium mb-2",
+  children,
+}: FieldLabelProps) => {
+  const tooltipId = useId();
+
+  return (
+    <div className={`flex items-center gap-2 ${className}`}>
+      <span>{label}</span>
+      {helpText && (
+        <span className="relative inline-flex items-center group">
+          <button
+            type="button"
+            aria-label="Show field help"
+            aria-describedby={tooltipId}
+            className="inline-flex h-4 w-4 items-center justify-center text-slate-400 transition-colors hover:text-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+            onMouseDown={(e) => e.stopPropagation()}
+            onTouchStart={(e) => e.stopPropagation()}
+          >
+            <CircleHelp className="h-4 w-4" aria-hidden="true" />
+          </button>
+          <span
+            id={tooltipId}
+            role="tooltip"
+            className="pointer-events-none invisible absolute left-0 top-full z-50 mt-2 w-64 whitespace-normal break-words rounded-md border border-slate-600 bg-slate-950 px-3 py-2 text-left text-xs font-normal leading-relaxed text-slate-200 opacity-0 shadow-xl shadow-black/40 transition-opacity duration-150 group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100"
+          >
+            {helpText}
+          </span>
+        </span>
+      )}
+      {children}
+    </div>
+  );
+};

--- a/client/app/components/node/fields/NodeCheckbox.tsx
+++ b/client/app/components/node/fields/NodeCheckbox.tsx
@@ -1,6 +1,7 @@
 import { useField } from "formik";
 import type { NodeProperty } from "../types";
 import { ErrorMessage } from "formik";
+import { FieldLabel, getFieldHelpText } from "./FieldLabel";
 
 interface NodeCheckboxProps {
   property: NodeProperty;
@@ -26,12 +27,11 @@ export const NodeCheckbox = ({ property, values }: NodeCheckboxProps) => {
   return (
     <div className={`${property?.colSpan ? `col-span-${property?.colSpan}` : 'col-span-2'}`} key={property.name}>
       <div className="flex items-center justify-between">
-        <div className="flex flex-col">
-          <span className="text-sm text-slate-200">{property.displayName}</span>
-          {property.hint && (
-            <span className="text-xs text-slate-400">{property.hint}</span>
-          )}
-        </div>
+        <FieldLabel
+          label={property.displayName}
+          helpText={getFieldHelpText(property)}
+          className="text-sm text-slate-200"
+        />
         {/* Toggle Switch */}
         <button
           type="button"

--- a/client/app/components/node/fields/NodeCodeEditor.tsx
+++ b/client/app/components/node/fields/NodeCodeEditor.tsx
@@ -5,6 +5,7 @@ import { createPortal } from "react-dom";
 import { Maximize2, X } from "lucide-react";
 import Editor, { type OnMount } from "@monaco-editor/react";
 import type { editor, languages, IDisposable } from "monaco-editor";
+import { FieldLabel, getFieldHelpText } from "./FieldLabel";
 import { completionsByLanguage } from "./monaco/completions";
 import {
     getPythonDiagnostics,
@@ -360,9 +361,11 @@ export const NodeCodeEditor = ({ property, values }: NodeCodeEditorProps) => {
             key={property.name}
         >
             <div className="flex items-center justify-between mb-2">
-                <label className="text-white text-sm font-medium flex items-center gap-2">
-                    {property.displayName}
-                </label>
+                <FieldLabel
+                    label={property.displayName}
+                    helpText={getFieldHelpText(property)}
+                    className="text-white text-sm font-medium"
+                />
                 <VersionBadge />
             </div>
 
@@ -397,14 +400,6 @@ export const NodeCodeEditor = ({ property, values }: NodeCodeEditorProps) => {
                 component="div"
                 className="text-red-400 text-sm mt-1"
             />
-
-            {property.description && (
-                <p className="text-slate-400 text-xs mt-2">{property.description}</p>
-            )}
-
-            {property.hint && (
-                <p className="text-slate-400 text-sm mt-1">{property.hint}</p>
-            )}
 
             {property.maxLength && (
                 <div className="text-gray-400 text-xs mt-1">

--- a/client/app/components/node/fields/NodeCredentialSelect.tsx
+++ b/client/app/components/node/fields/NodeCredentialSelect.tsx
@@ -1,6 +1,7 @@
 import CredentialSelector from "../../credentials/CredentialSelector";
 import { getUserCredentialById } from "~/services/userCredentialService";
 import type { NodeProperty } from "../types";
+import { FieldLabel, getFieldHelpText } from "./FieldLabel";
 
 interface NodeCredentialSelectProps {
   property: NodeProperty;
@@ -49,9 +50,10 @@ export const NodeCredentialSelect = ({ property, values, setFieldValue }: NodeCr
 
   return (
     <div className={`${property?.colSpan ? `col-span-${property?.colSpan}` : 'col-span-2'}`} key={property.name}>
-      <label className="text-white text-sm font-medium mb-2 block">
-        {property.displayName}
-      </label>
+      <FieldLabel
+        label={property.displayName}
+        helpText={getFieldHelpText(property)}
+      />
       <CredentialSelector
         value={values[property.name] ?? values.credential_id}
         onChange={handleCredentialChange}

--- a/client/app/components/node/fields/NodeDateTime.tsx
+++ b/client/app/components/node/fields/NodeDateTime.tsx
@@ -1,6 +1,7 @@
 import { Field } from "formik";
 import type { NodeProperty } from "../types";
 import { CalendarDays } from "lucide-react";
+import { FieldLabel, getFieldHelpText } from "./FieldLabel";
 
 interface NodeDateTimeProps {
   property: NodeProperty;
@@ -24,18 +25,17 @@ export const NodeDateTime = ({ property, values }: NodeDateTimeProps) => {
     <div className={`${property?.colSpan ? `col-span-${property?.colSpan}` : 'col-span-2'}`} key={property.name}>
       <div className="flex items-center space-x-2 mb-2">
         <CalendarDays className="w-4 h-4 text-green-400" />
-        <label className="text-white text-sm font-medium">
-          {property.displayName}
-        </label>
+        <FieldLabel
+          label={property.displayName}
+          helpText={getFieldHelpText(property)}
+          className="text-white text-sm font-medium"
+        />
       </div>
       <Field
         className="w-full bg-slate-900/80 border border-slate-600/50 rounded-lg text-white placeholder-slate-400 px-3 py-2 text-sm focus:border-green-500 focus:ring-2 focus:ring-green-500/20 transition-all"
         type="datetime-local"
         name={property.name}
       />
-      {property.hint && (
-        <p className="text-slate-400 text-sm mt-1">{property.hint}</p>
-      )}
     </div>
   );
 };

--- a/client/app/components/node/fields/NodeJsonEditor.tsx
+++ b/client/app/components/node/fields/NodeJsonEditor.tsx
@@ -1,5 +1,6 @@
 import type { NodeProperty } from "../types";
 import JSONEditor from "../../common/JSONEditor";
+import { FieldLabel, getFieldHelpText } from "./FieldLabel";
 
 interface NodeJsonEditorProps {
   property: NodeProperty;
@@ -26,14 +27,14 @@ export const NodeJsonEditor = ({
 
   return (
     <div className={`${property?.colSpan ? `col-span-${property?.colSpan}` : 'col-span-2'}`} key={property.name}>
-      <label className="text-white text-sm font-medium mb-2 block">
-        {property.displayName}
-      </label>
+      <FieldLabel
+        label={property.displayName}
+        helpText={getFieldHelpText(property)}
+      />
       <JSONEditor
         value={values[property.name]}
         onChange={(value) => setFieldValue(property.name, value)}
         placeholder={property.placeholder}
-        description={property.hint}
       />
     </div>
   );

--- a/client/app/components/node/fields/NodeNumber.tsx
+++ b/client/app/components/node/fields/NodeNumber.tsx
@@ -1,5 +1,6 @@
 import { Field } from "formik";
 import type { NodeProperty } from "../types";
+import { FieldLabel, getFieldHelpText } from "./FieldLabel";
 
 interface NodeNumberProps {
   property: NodeProperty;
@@ -21,9 +22,10 @@ export const NodeNumber = ({ property, values }: NodeNumberProps) => {
 
   return (
     <div className={`${property?.colSpan ? `col-span-${property?.colSpan}` : 'col-span-2'}`} key={property.name}>
-      <label className="text-white text-sm font-medium mb-2 block">
-        {property.displayName}
-      </label>
+      <FieldLabel
+        label={property.displayName}
+        helpText={getFieldHelpText(property)}
+      />
       <Field
         type="number"
         defaultValue={property?.default}
@@ -32,9 +34,6 @@ export const NodeNumber = ({ property, values }: NodeNumberProps) => {
         min={property?.min}
         max={property?.max}
       />
-      {property.hint && (
-        <p className="text-slate-400 text-sm mt-1">{property.hint}</p>
-      )}
     </div>
   );
 };

--- a/client/app/components/node/fields/NodePassword.tsx
+++ b/client/app/components/node/fields/NodePassword.tsx
@@ -1,5 +1,6 @@
 import { Field } from "formik";
 import type { NodeProperty } from "../types";
+import { FieldLabel, getFieldHelpText } from "./FieldLabel";
 
 interface NodePasswordProps {
   property: NodeProperty;
@@ -21,18 +22,16 @@ export const NodePassword = ({ property, values }: NodePasswordProps) => {
 
   return (
     <div className={`${property?.colSpan ? `col-span-${property?.colSpan}` : 'col-span-2'}`} key={property.name}>
-      <label className="text-white text-sm font-medium mb-2 block">
-        {property.displayName}
-      </label>
+      <FieldLabel
+        label={property.displayName}
+        helpText={getFieldHelpText(property)}
+      />
       <Field
         type="password"
         name={property.name}
         className="input input-bordered w-full bg-[#10182c] text-white text-sm rounded-lg px-4 py-3 border border-slate-600 focus:border-blue-500 focus:ring-1 focus:ring-blue-500/20"
         placeholder={property.placeholder}
       />
-      {property.hint && (
-        <p className="text-slate-400 text-sm mt-1">{property.hint}</p>
-      )}
     </div>
   );
 };

--- a/client/app/components/node/fields/NodeRange.tsx
+++ b/client/app/components/node/fields/NodeRange.tsx
@@ -1,5 +1,6 @@
 import { ErrorMessage, Field } from "formik";
 import type { NodeProperty } from "../types";
+import { FieldLabel, getFieldHelpText } from "./FieldLabel";
 
 interface NodeRangeProps {
   property: NodeProperty;
@@ -21,15 +22,17 @@ export const NodeRange = ({ property, values }: NodeRangeProps) => {
 
   return (
     <div className={`${property?.colSpan ? `col-span-${property?.colSpan}` : 'col-span-2'}`} key={property.name}>
-      <label className="text-white text-sm font-medium mb-2 block">
-        {property.displayName}:{" "}
-        <span className={`text-${property.color || "blue-400"} font-mono`}>
-          {values[property.name]}
-        </span>
-      </label>
-      {property.hint && (
-        <p className="text-slate-400 text-sm mt-1">{property.hint}</p>
-      )}
+      <FieldLabel
+        label={(
+          <>
+            {property.displayName}:{" "}
+            <span className={`text-${property.color || "blue-400"} font-mono`}>
+              {values[property.name]}
+            </span>
+          </>
+        )}
+        helpText={getFieldHelpText(property)}
+      />
       <Field
         name={property.name}
         type="range"

--- a/client/app/components/node/fields/NodeReadonlyText.tsx
+++ b/client/app/components/node/fields/NodeReadonlyText.tsx
@@ -3,6 +3,7 @@ import { config } from "../../../lib/config";
 import type { NodeProperty } from "../types";
 import { getActiveSessionId } from "../../../services/chatService";
 import { useWorkflows } from "../../../stores/workflows";
+import { FieldLabel, getFieldHelpText } from "./FieldLabel";
 
 interface NodeReadonlyTextProps {
   property: NodeProperty;
@@ -88,9 +89,10 @@ export const NodeReadonlyText = ({ property, values, setFieldValue }: NodeReadon
         }`}
       key={property.name}
     >
-      <label className="text-white text-sm font-medium mb-2 block">
-        {property.displayName}
-      </label>
+      <FieldLabel
+        label={property.displayName}
+        helpText={getFieldHelpText(property)}
+      />
       <div className="flex items-center gap-2">
         <input
           type="text"
@@ -107,11 +109,6 @@ export const NodeReadonlyText = ({ property, values, setFieldValue }: NodeReadon
           Copy
         </button>
       </div>
-      {property.hint && (
-        <p className="text-slate-400 text-xs bg-slate-900/30 mt-1">
-          {property.hint}
-        </p>
-      )}
     </div>
   );
 };

--- a/client/app/components/node/fields/NodeSelect.tsx
+++ b/client/app/components/node/fields/NodeSelect.tsx
@@ -2,6 +2,7 @@ import { useField } from "formik";
 import { useState, useRef, useEffect } from "react";
 import { ChevronDown } from "lucide-react";
 import type { NodeProperty } from "../types";
+import { FieldLabel, getFieldHelpText } from "./FieldLabel";
 
 interface NodeSelectProps {
   property: NodeProperty;
@@ -49,9 +50,10 @@ export const NodeSelect = ({ property, values }: NodeSelectProps) => {
 
   return (
     <div className={`${property?.colSpan ? `col-span-${property?.colSpan}` : 'col-span-2'}`} key={property.name}>
-      <label className="text-white text-sm font-medium mb-2 block">
-        {property.displayName}
-      </label>
+      <FieldLabel
+        label={property.displayName}
+        helpText={getFieldHelpText(property)}
+      />
 
       {/* Custom Dropdown */}
       <div className="relative" ref={dropdownRef}>
@@ -92,9 +94,6 @@ export const NodeSelect = ({ property, values }: NodeSelectProps) => {
         )}
       </div>
 
-      {property.hint && (
-        <p className="text-slate-400 text-sm mt-1">{property.hint}</p>
-      )}
       {selectedOption?.hint && (
         <p className="text-slate-400 text-xs bg-slate-900/30 mt-1">{selectedOption.hint}</p>
       )}

--- a/client/app/components/node/fields/NodeSessionId.tsx
+++ b/client/app/components/node/fields/NodeSessionId.tsx
@@ -3,6 +3,7 @@ import { Field } from "formik";
 import type { NodeProperty } from "../types";
 import { getActiveSessionId } from "../../../services/chatService";
 import { useWorkflows } from "../../../stores/workflows";
+import { FieldLabel, getFieldHelpText } from "./FieldLabel";
 
 interface NodeSessionIdProps {
     property: NodeProperty;
@@ -43,9 +44,10 @@ export const NodeSessionId = ({ property, values, setFieldValue }: NodeSessionId
                 }`}
             key={property.name}
         >
-            <label className="text-white text-sm font-medium mb-2 block">
-                {property.displayName}
-            </label>
+            <FieldLabel
+                label={property.displayName}
+                helpText={getFieldHelpText(property)}
+            />
             <div className="flex items-center gap-2">
                 <Field
                     name={property.name}
@@ -65,16 +67,6 @@ export const NodeSessionId = ({ property, values, setFieldValue }: NodeSessionId
                     </button>
                 )}
             </div>
-            {property.description && (
-                <p className="text-slate-400 text-[11px] leading-relaxed mt-1.5 px-1 opacity-80">
-                    {property.description}
-                </p>
-            )}
-            {property.hint && (
-                <p className="text-slate-400 text-[11px] leading-relaxed mt-1 px-1 italic">
-                    {property.hint}
-                </p>
-            )}
         </div>
     );
 };

--- a/client/app/components/node/fields/NodeText.tsx
+++ b/client/app/components/node/fields/NodeText.tsx
@@ -1,5 +1,6 @@
 import { Field } from "formik";
 import type { NodeProperty } from "../types";
+import { FieldLabel, getFieldHelpText } from "./FieldLabel";
 
 interface NodeTextProps {
   property: NodeProperty;
@@ -21,18 +22,16 @@ export const NodeText = ({ property, values }: NodeTextProps) => {
 
   return (
     <div className={`${property?.colSpan ? `col-span-${property?.colSpan}` : 'col-span-2'}`} key={property.name}>
-      <label className="text-white text-sm font-medium mb-2 block">
-        {property.displayName}
-      </label>
+      <FieldLabel
+        label={property.displayName}
+        helpText={getFieldHelpText(property)}
+      />
       <Field
         type="text"
         name={property.name}
         className="input input-bordered w-full bg-[#10182c] text-white text-sm rounded-lg px-4 py-3 border border-slate-600 focus:border-blue-500 focus:ring-1 focus:ring-blue-500/20"
         placeholder={property.placeholder}
       />
-      {property.hint && (
-        <p className="text-slate-400 text-xs bg-slate-900/30 mt-1">{property.hint}</p>
-      )}
     </div>
   );
 };

--- a/client/app/components/node/fields/NodeTextArea.tsx
+++ b/client/app/components/node/fields/NodeTextArea.tsx
@@ -1,5 +1,6 @@
 import { Field, ErrorMessage } from "formik";
 import type { NodeProperty } from "../types";
+import { FieldLabel, getFieldHelpText } from "./FieldLabel";
 
 interface NodeTextAreaProps {
   property: NodeProperty;
@@ -21,9 +22,10 @@ export const NodeTextArea = ({ property, values }: NodeTextAreaProps) => {
 
   return (
     <div className={`${property?.colSpan ? `col-span-${property?.colSpan}` : 'col-span-2'}`} key={property.name}>
-      <label className="text-white text-sm font-medium mb-2 block flex items-center gap-2">
-        {property.displayName}
-      </label>
+      <FieldLabel
+        label={property.displayName}
+        helpText={getFieldHelpText(property)}
+      />
       <Field
         as="textarea"
         name={property.name}
@@ -38,9 +40,6 @@ export const NodeTextArea = ({ property, values }: NodeTextAreaProps) => {
         component="div"
         className="text-red-400 text-sm mt-1"
       />
-      {property.hint && (
-        <p className="text-slate-400 text-sm mt-1">{property.hint}</p>
-      )}
       {property.maxLength && (
         <div className="text-gray-400 text-xs mt-1">
           Characters: {property.value?.length.toLocaleString() || 0} /{" "}


### PR DESCRIPTION
- introduce FieldLabel component with accessible hover/focus help tooltip and icon support
- refactor dynamic node form fields to use FieldLabel instead of inline hint/description text
- remove legacy inline helper text to reduce visual clutter and form height
- enforce tooltip layout stability with wrapping and fixed-width constraints
- integrate FieldLabel into GenericNodeForm including custom option rendering flows