### PR TITLE
fix: prevent execution of deactivated workflows across webhook triggers

### DIFF
--- a/backend/app/api/webhooks.py
+++ b/backend/app/api/webhooks.py
@@ -511,6 +511,13 @@ async def trigger_webhook(
                 # Fetch the workflow data
                 workflow = await workflow_service.get_by_id(db=db, workflow_id=endpoint.workflow_id)
                 
+                # Check if workflow is active (is_public toggle)
+                if workflow and not workflow.is_public:
+                    raise HTTPException(
+                        status_code=status.HTTP_403_FORBIDDEN,
+                        detail="Workflow is currently deactivated"
+                    )
+                
                 if workflow and workflow.flow_data and workflow.flow_data.get('nodes'):
                     # Execute workflow via internal API
                     execution_payload = {

--- a/backend/app/nodes/triggers/respond_to_webhook.py
+++ b/backend/app/nodes/triggers/respond_to_webhook.py
@@ -212,10 +212,9 @@ class RespondToWebhookNode(TerminatorNode):
         """
         logger.info(f"Configuring RespondToWebhook node")
         
-        # Extract inputs from kwargs (inputs dict contains all node properties)
         inputs = kwargs.get("inputs", {})
-        connected_nodes = kwargs.get("connected_nodes", {})
-        previous_node_output = connected_nodes if connected_nodes else None
+        previous_node = kwargs.get("previous_node")
+        previous_node_output = previous_node if previous_node else None
         # Store user configuration (inputs dict'ini direkt user_data'ya kaydet)
         self.user_data.update(inputs)
         
@@ -227,8 +226,7 @@ class RespondToWebhookNode(TerminatorNode):
         
         # Determine response_body based on response_config
         if response_config == "all_incoming_items":
-            data = connected_nodes if connected_nodes else {}
-            # Convert Document objects to dicts first, then make JSON serializable
+            data = previous_node_output if previous_node_output else {}
             data = _convert_documents_to_dict(data)
             data = make_json_serializable(data)
             # Ensure JSON format: if string, wrap it; if already dict/list, use as is
@@ -247,10 +245,9 @@ class RespondToWebhookNode(TerminatorNode):
                 # Convert Document objects to dicts first, then make JSON serializable
                 response_body = _convert_documents_to_dict(previous_node_output)
                 response_body = make_json_serializable(response_body)
-            elif not response_body and connected_nodes:
-                logger.info(f"Using connected_nodes as response body: {connected_nodes}")
-                # Convert Document objects to dicts first, then make JSON serializable
-                response_body = _convert_documents_to_dict(connected_nodes)
+            elif not response_body and previous_node_output:
+                logger.info(f"Using previous_node output as response body: {previous_node_output}")
+                response_body = _convert_documents_to_dict(previous_node_output)
                 response_body = make_json_serializable(response_body)
         
         # Parse response_body if it's a JSON string and content_type is application/json
@@ -325,4 +322,3 @@ class RespondToWebhookNode(TerminatorNode):
 __all__ = [
     "RespondToWebhookNode",
 ]
-

--- a/backend/app/nodes/triggers/webhook_trigger.py
+++ b/backend/app/nodes/triggers/webhook_trigger.py
@@ -490,13 +490,20 @@ async def handle_webhook_request(
 
                 if not workflow:
                     logger.error(f"Workflow not found for webhook: {webhook_id}")
-                    # Return default response if workflow not found
-                    return WebhookResponse(
-                        success=False,
-                        message=f"Workflow not found for webhook: {webhook_id}",
-                        webhook_id=webhook_id,
-                        received_at=received_at.isoformat(),
-                        correlation_id=correlation_id
+                    raise HTTPException(
+                        status_code=status.HTTP_404_NOT_FOUND,
+                        detail=f"Workflow not found for webhook: {webhook_id}"
+                    )
+
+                # Check if workflow is active (is_public toggle)
+                if not workflow.is_public:
+                    logger.warning(
+                        f"Workflow {workflow.id} is deactivated (is_public=False), "
+                        f"rejecting webhook trigger: {webhook_id}"
+                    )
+                    raise HTTPException(
+                        status_code=status.HTTP_403_FORBIDDEN,
+                        detail="Workflow is currently deactivated"
                     )
 
                 # Create session ID


### PR DESCRIPTION
- reject webhook trigger requests for deactivated workflows through is_public validation
- return 404 Not Found when webhook identifiers do not match existing workflows
- enforce workflow activity checks in webhook API trigger endpoints before execution
- align trigger responses with workflow availability and HTTP status code semantics