### PR TITLE
fix: resolve node gradient colors with inline styles

### DIFF
--- a/client/app/components/canvas/FlowCanvas.tsx
+++ b/client/app/components/canvas/FlowCanvas.tsx
@@ -253,6 +253,73 @@ const resolveExecutionEdges = (
   return edgesToAnimate;
 };
 
+type NodeRegistryEntry = {
+  name?: string;
+  id?: string;
+  colors?: string[];
+  icon?: unknown;
+  description?: string;
+  display_name?: string;
+  inputs?: unknown;
+  outputs?: unknown;
+};
+
+function findRegistryEntry(
+  node: Node,
+  registry: NodeRegistryEntry[]
+): NodeRegistryEntry | undefined {
+  return registry.find((n) => n.name === node.type || n.id === node.type);
+}
+
+function colorsMatch(saved?: string[], registry?: string[]): boolean {
+  if (!registry?.[0]) return true;
+  return (
+    saved?.[0] === registry[0] &&
+    (saved?.[1] ?? saved?.[0]) === (registry[1] ?? registry[0])
+  );
+}
+
+/** Merge registry metadata/colors into a canvas node (saved workflows, JSON import). */
+function enrichNodeFromRegistry(
+  node: Node,
+  registry: NodeRegistryEntry[]
+): Node {
+  if (!registry.length) return node;
+
+  const def = findRegistryEntry(node, registry);
+  if (!def) return node;
+
+  if (!node.data?.metadata) {
+    return {
+      ...node,
+      data: {
+        ...node.data,
+        metadata: def,
+        icon: def.icon,
+        description: def.description,
+        displayName: def.display_name,
+        inputs: def.inputs,
+        outputs: def.outputs,
+      },
+    };
+  }
+
+  if (def.colors && !colorsMatch(node.data.metadata.colors, def.colors)) {
+    return {
+      ...node,
+      data: {
+        ...node.data,
+        metadata: {
+          ...node.data.metadata,
+          colors: def.colors,
+        },
+      },
+    };
+  }
+
+  return node;
+}
+
 function FlowCanvas({ workflowId }: FlowCanvasProps) {
   const { enqueueSnackbar } = useSnackbar();
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
@@ -563,28 +630,9 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
 
       const combinedNodes = [...(availableNodes || []), ...(customNodes || [])];
 
-      // Inject missing metadata for nodes from availableNodes registry
-      const enrichedNodes = (rawNodes || []).map((node) => {
-        if (!node.data?.metadata && combinedNodes?.length > 0) {
-          const nodeDef = combinedNodes.find((n) => n.name === node.type || (n as any).id === node.type);
-          if (nodeDef) {
-            const def = nodeDef as any;
-            return {
-              ...node,
-              data: {
-                ...node.data,
-                metadata: def,
-                icon: def.icon,
-                description: def.description,
-                displayName: def.display_name,
-                inputs: def.inputs,
-                outputs: def.outputs
-              }
-            };
-          }
-        }
-        return node;
-      });
+      const enrichedNodes = (rawNodes || []).map((node) =>
+        enrichNodeFromRegistry(node, combinedNodes)
+      );
 
       setNodes(enrichedNodes);
 
@@ -604,7 +652,7 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
     }
     // Reset import flag after every useEffect run (self-healing)
     isImportingRef.current = false;
-  }, [currentWorkflow, availableNodes]);
+  }, [currentWorkflow, availableNodes, customNodes]);
 
   useEffect(() => {
     if (currentWorkflow) {

--- a/client/app/components/common/RecommendedNodes.tsx
+++ b/client/app/components/common/RecommendedNodes.tsx
@@ -40,7 +40,7 @@ const RecommendedNodes: React.FC<RecommendedNodesProps> = ({
       inputs: nodeMetadata.inputs,
       outputs: nodeMetadata.outputs,
       icon: nodeMetadata.icon,
-      color: nodeMetadata.color,
+      colors: nodeMetadata.colors,
     },
     info: nodeMetadata.description,
   });

--- a/client/app/components/common/Sidebar.tsx
+++ b/client/app/components/common/Sidebar.tsx
@@ -109,7 +109,7 @@ function Sidebar({ onClose }: SidebarProps) {
       inputs: nodeMetadata.inputs,
       outputs: nodeMetadata.outputs,
       icon: nodeMetadata.icon,
-      color: nodeMetadata.color,
+      colors: nodeMetadata.colors,
     },
     info: nodeMetadata.description,
   });

--- a/client/app/components/node/GenericVisual.tsx
+++ b/client/app/components/node/GenericVisual.tsx
@@ -6,6 +6,11 @@ import type { GenericData } from "./types";
 import type { NodeMetadata } from "../../types/api";
 import * as LucideIcons from "lucide-react";
 import { resolveIconPath } from "~/lib/iconUtils";
+import {
+  getNodeColorStops,
+  getNodeGradientClasses,
+  getNodeGradientStyle,
+} from "~/lib/nodeColors";
 
 interface GenericVisualProps {
   data: GenericData;
@@ -50,14 +55,11 @@ function GenericVisual({
   triggerNow,
   onToggleKafka,
 }: GenericVisualProps) {
-  const getNodeColor = () => {
-    const colors = data.metadata?.colors;
-    if (colors && colors[0] && colors[1]) {
-      return `from-${colors[0]} to-${colors[1]}`;
-    }
-    return "";
-    // return "from-blue-500 to-indigo-600";
-  };
+  const colorStops = getNodeColorStops(data);
+  const gradientStyle = getNodeGradientStyle(colorStops);
+  const gradientClasses = gradientStyle
+    ? ""
+    : getNodeGradientClasses(colorStops);
 
   const getGlowColor = () => {
     switch (data.validationStatus) {
@@ -176,10 +178,11 @@ function GenericVisual({
           ? `shadow-2xl ${getGlowColor()}`
           : "shadow-lg shadow-black/50"
         }
-        bg-gradient-to-br ${getNodeColor()}
+        ${gradientStyle ? "" : `bg-gradient-to-br ${gradientClasses}`}
 
         border border-white/20 backdrop-blur-sm
         hover:border-white/40`}
+      style={gradientStyle}
       onDoubleClick={onDoubleClick}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}

--- a/client/app/lib/nodeColors.ts
+++ b/client/app/lib/nodeColors.ts
@@ -1,0 +1,294 @@
+import type { CSSProperties } from "react";
+import colors from "tailwindcss/colors";
+
+type ColorScale = Record<string, string> | string;
+
+const DEPRECATED_PALETTES = new Set([
+  "lightBlue",
+  "warmGray",
+  "trueGray",
+  "coolGray",
+  "blueGray",
+]);
+
+/** CSS named colors not shipped as Tailwind palettes (olive, navy, …). */
+const CSS_NAMED_FALLBACK: Record<string, string> = {
+  aliceblue: "#f0f8ff",
+  antiquewhite: "#faebd7",
+  aqua: "#00ffff",
+  aquamarine: "#7fffd4",
+  azure: "#f0ffff",
+  beige: "#f5f5dc",
+  bisque: "#ffe4c4",
+  black: "#000000",
+  blanchedalmond: "#ffebcd",
+  blue: "#0000ff",
+  brown: "#a52a2a",
+  burlywood: "#deb887",
+  cadetblue: "#5f9ea0",
+  chartreuse: "#7fff00",
+  chocolate: "#d2691e",
+  coral: "#ff7f50",
+  cornflowerblue: "#6495ed",
+  cornsilk: "#fff8dc",
+  crimson: "#dc143c",
+  cyan: "#00ffff",
+  darkblue: "#00008b",
+  darkcyan: "#008b8b",
+  darkgoldenrod: "#b8860b",
+  darkgray: "#a9a9a9",
+  darkgreen: "#006400",
+  darkkhaki: "#bdb76b",
+  darkmagenta: "#8b008b",
+  darkolivegreen: "#556b2f",
+  darkorange: "#ff8c00",
+  darkorchid: "#9932cc",
+  darkred: "#8b0000",
+  darksalmon: "#e9967a",
+  darkseagreen: "#8fbc8f",
+  darkslateblue: "#483d8b",
+  darkslategray: "#2f4f4f",
+  darkturquoise: "#00ced1",
+  darkviolet: "#9400d3",
+  deeppink: "#ff1493",
+  deepskyblue: "#00bfff",
+  dimgray: "#696969",
+  dodgerblue: "#1e90ff",
+  firebrick: "#b22222",
+  floralwhite: "#fffaf0",
+  forestgreen: "#228b22",
+  fuchsia: "#ff00ff",
+  gainsboro: "#dcdcdc",
+  ghostwhite: "#f8f8ff",
+  gold: "#ffd700",
+  goldenrod: "#daa520",
+  gray: "#808080",
+  green: "#008000",
+  greenyellow: "#adff2f",
+  honeydew: "#f0fff0",
+  hotpink: "#ff69b4",
+  indianred: "#cd5c5c",
+  indigo: "#4b0082",
+  ivory: "#fffff0",
+  khaki: "#f0e68c",
+  lavender: "#e6e6fa",
+  lavenderblush: "#fff0f5",
+  lawngreen: "#7cfc00",
+  lemonchiffon: "#fffacd",
+  lightblue: "#add8e6",
+  lightcoral: "#f08080",
+  lightcyan: "#e0ffff",
+  lightgoldenrodyellow: "#fafad2",
+  lightgray: "#d3d3d3",
+  lightgreen: "#90ee90",
+  lightpink: "#ffb6c1",
+  lightsalmon: "#ffa07a",
+  lightseagreen: "#20b2aa",
+  lightskyblue: "#87cefa",
+  lightslategray: "#778899",
+  lightsteelblue: "#b0c4de",
+  lightyellow: "#ffffe0",
+  lime: "#00ff00",
+  limegreen: "#32cd32",
+  linen: "#faf0e6",
+  magenta: "#ff00ff",
+  maroon: "#800000",
+  mediumaquamarine: "#66cdaa",
+  mediumblue: "#0000cd",
+  mediumorchid: "#ba55d3",
+  mediumpurple: "#9370db",
+  mediumseagreen: "#3cb371",
+  mediumslateblue: "#7b68ee",
+  mediumspringgreen: "#00fa9a",
+  mediumturquoise: "#48d1cc",
+  mediumvioletred: "#c71585",
+  midnightblue: "#191970",
+  mintcream: "#f5fffa",
+  mistyrose: "#ffe4e1",
+  moccasin: "#ffe4b5",
+  navajowhite: "#ffdead",
+  navy: "#000080",
+  oldlace: "#fdf5e6",
+  olive: "#808000",
+  olivedrab: "#6b8e23",
+  orange: "#ffa500",
+  orangered: "#ff4500",
+  orchid: "#da70d6",
+  palegoldenrod: "#eee8aa",
+  palegreen: "#98fb98",
+  paleturquoise: "#afeeee",
+  palevioletred: "#db7093",
+  papayawhip: "#ffefd5",
+  peachpuff: "#ffdab9",
+  peru: "#cd853f",
+  pink: "#ffc0cb",
+  plum: "#dda0dd",
+  powderblue: "#b0e0e6",
+  purple: "#800080",
+  rebeccapurple: "#663399",
+  red: "#ff0000",
+  rosybrown: "#bc8f8f",
+  royalblue: "#4169e1",
+  saddlebrown: "#8b4513",
+  salmon: "#fa8072",
+  sandybrown: "#f4a460",
+  seagreen: "#2e8b57",
+  seashell: "#fff5ee",
+  sienna: "#a0522d",
+  silver: "#c0c0c0",
+  skyblue: "#87ceeb",
+  slateblue: "#6a5acd",
+  slategray: "#708090",
+  snow: "#fffafa",
+  springgreen: "#00ff7f",
+  steelblue: "#4682b4",
+  tan: "#d2b48c",
+  teal: "#008080",
+  thistle: "#d8bfd8",
+  tomato: "#ff6347",
+  turquoise: "#40e0d0",
+  violet: "#ee82ee",
+  wheat: "#f5deb3",
+  white: "#ffffff",
+  whitesmoke: "#f5f5f5",
+  yellow: "#ffff00",
+  yellowgreen: "#9acd32",
+};
+
+const cssColorCache = new Map<string, string>();
+
+function normalizeHex(value: string): string {
+  const raw = value.startsWith("#") ? value.slice(1) : value;
+  if (raw.length === 3) {
+    return `#${raw
+      .split("")
+      .map((c) => c + c)
+      .join("")}`;
+  }
+  return `#${raw}`;
+}
+
+function getTailwindScale(name: string): ColorScale | undefined {
+  if (DEPRECATED_PALETTES.has(name)) return undefined;
+  return (colors as Record<string, ColorScale | undefined>)[name];
+}
+
+function getTailwindShade(name: string, shade: string): string | null {
+  const scale = getTailwindScale(name);
+  if (!scale) return null;
+  if (typeof scale === "string") return scale;
+  const value = scale[shade];
+  return typeof value === "string" ? value : null;
+}
+
+/** Approximate Tailwind shade steps (50–950) from any base color. */
+export function applyShade(base: string, shade: number): string {
+  if (shade === 500) return base;
+  if (shade > 500) {
+    const amount = Math.round(((shade - 500) / 450) * 72);
+    return `color-mix(in oklch, ${base} ${100 - amount}%, black ${amount}%)`;
+  }
+  const amount = Math.round(((500 - shade) / 450) * 82);
+  return `color-mix(in oklch, ${base} ${100 - amount}%, white ${amount}%)`;
+}
+
+export function resolveCssNamedColor(name: string): string | null {
+  const key = name.toLowerCase();
+  if (CSS_NAMED_FALLBACK[key]) return CSS_NAMED_FALLBACK[key];
+
+  if (typeof document === "undefined") return null;
+
+  if (cssColorCache.has(key)) return cssColorCache.get(key)!;
+
+  const el = document.createElement("div");
+  el.style.color = key;
+  el.style.display = "none";
+  document.body.appendChild(el);
+  const computed = getComputedStyle(el).color;
+  document.body.removeChild(el);
+
+  if (!computed || computed === "rgba(0, 0, 0, 0)") return null;
+  cssColorCache.set(key, computed);
+  return computed;
+}
+
+/**
+ * Resolve any node color token:
+ * - Tailwind: "blue-700", "red-600"
+ * - CSS adları: "olive", "olive-700", "navy-500"
+ * - Hex: "#808000", "808000"
+ * - Fonksiyon: "rgb(...)", "hsl(...)", "oklch(...)"
+ */
+export function resolveNodeColorToken(token: string): string | null {
+  if (!token?.trim()) return null;
+
+  const normalized = token.replace(/^(from|to)-/, "").trim();
+
+  if (/^#?[0-9a-fA-F]{3,8}$/.test(normalized)) {
+    return normalizeHex(normalized);
+  }
+
+  if (/^(rgb|hsl|oklch|lab|color)\(/i.test(normalized)) {
+    return normalized;
+  }
+
+  const shadeMatch = normalized.match(/^([a-z][a-z0-9]*)-(\d{2,3})$/);
+  if (shadeMatch) {
+    const [, name, shadeStr] = shadeMatch;
+    const shade = parseInt(shadeStr, 10);
+
+    const tailwind = getTailwindShade(name, shadeStr);
+    if (tailwind) return tailwind;
+
+    const namedBase = resolveCssNamedColor(name);
+    if (namedBase) return applyShade(namedBase, shade);
+  }
+
+  const flatTailwind = getTailwindScale(normalized);
+  if (typeof flatTailwind === "string") return flatTailwind;
+
+  const named = resolveCssNamedColor(normalized);
+  if (named) return named;
+
+  return null;
+}
+
+/** @deprecated Use resolveNodeColorToken */
+export function resolveTailwindColorToken(token: string): string | null {
+  return resolveNodeColorToken(token);
+}
+
+/** Build an inline gradient style from node metadata `colors` (start + end). */
+export function getNodeGradientStyle(
+  colorStops?: string[]
+): CSSProperties | undefined {
+  if (!colorStops?.[0]) return undefined;
+
+  const from = resolveNodeColorToken(colorStops[0]);
+  const to = resolveNodeColorToken(colorStops[1] ?? colorStops[0]);
+  if (!from || !to) return undefined;
+
+  return {
+    backgroundImage: `linear-gradient(to bottom right, ${from}, ${to})`,
+  };
+}
+
+/** Tailwind gradient stop classes (fallback when inline resolution fails). */
+export function getNodeGradientClasses(colorStops?: string[]): string {
+  if (!colorStops?.[0]) return "";
+
+  const from = colorStops[0].startsWith("from-")
+    ? colorStops[0]
+    : `from-${colorStops[0]}`;
+  const rawTo = colorStops[1] ?? colorStops[0];
+  const to = rawTo.startsWith("to-") ? rawTo : `to-${rawTo}`;
+
+  return `${from} ${to}`;
+}
+
+export function getNodeColorStops(data: {
+  metadata?: { colors?: string[] };
+  colors?: string[];
+}): string[] | undefined {
+  return data.metadata?.colors ?? data.colors;
+}


### PR DESCRIPTION
Replace dynamic Tailwind gradient classes with inline CSS from metadata colors. Enrich saved workflows from the node registry and pass colors array when dropping nodes from the sidebar.