### PR TITLE
feat: enable standard exception handling within restricted python execution

### DIFF
--- a/backend/app/nodes/processing/code_node.py
+++ b/backend/app/nodes/processing/code_node.py
@@ -23,7 +23,6 @@ from ..base import (
 
 logger = logging.getLogger(__name__)
 
-# Safe built-in functions and modules for Python sandbox
 SAFE_PYTHON_BUILTINS = {
     "abs", "all", "any", "ascii", "bin", "bool", "bytes", "chr", "dict", "dir", "divmod", "enumerate", "filter", "float",
     "format", "frozenset", "hex", "int", "isinstance", "issubclass", "iter", "len", "list", "map", "max", "min", "next",
@@ -31,6 +30,28 @@ SAFE_PYTHON_BUILTINS = {
     "type", "zip", # Additional safe functions (note: broadens sandbox surface, kept for backward compatibility)
     "hasattr", "getattr", "setattr", "delattr", "hash", "id", "callable", "classmethod", "staticmethod", "property",
     "locals", "globals", "vars",
+
+    # Exceptions
+    "BaseException", "Exception", "ArithmeticError", "BufferError", "LookupError",
+    "AssertionError", "AttributeError", "EOFError", "FloatingPointError",
+    "GeneratorExit", "ImportError", "ModuleNotFoundError", "IndexError",
+    "KeyError", "KeyboardInterrupt", "MemoryError", "NameError", "NotImplementedError",
+    "OSError", "OverflowError", "RecursionError", "ReferenceError", "RuntimeError",
+    "StopIteration", "StopAsyncIteration", "SyntaxError", "IndentationError", "TabError",
+    "SystemError", "SystemExit", "TypeError", "UnboundLocalError", "UnicodeError",
+    "UnicodeEncodeError", "UnicodeDecodeError", "UnicodeTranslateError", "ValueError",
+    "ZeroDivisionError", "EnvironmentError", "IOError",
+
+    # OS Error subclasses
+    "BlockingIOError", "ChildProcessError", "ConnectionError", "BrokenPipeError",
+    "ConnectionAbortedError", "ConnectionRefusedError", "ConnectionResetError",
+    "FileExistsError", "FileNotFoundError", "InterruptedError", "IsADirectoryError",
+    "NotADirectoryError", "PermissionError", "ProcessLookupError", "TimeoutError",
+
+    # Warnings
+    "Warning", "UserWarning", "DeprecationWarning", "PendingDeprecationWarning",
+    "SyntaxWarning", "RuntimeWarning", "FutureWarning", "ImportWarning",
+    "UnicodeWarning", "BytesWarning", "ResourceWarning", "EncodingWarning",
 }
 
 SAFE_PYTHON_MODULES = {


### PR DESCRIPTION
- expose built-in exception types to sandboxed Python runtime through the safe builtins registry
- allow sandboxed code to raise, catch, and process standard Python exceptions
- support OSError hierarchies and warning classes during sandbox execution
- expand sandbox compatibility for libraries and user code that rely on native exception semantics