### PR TITLE
feat: centralize OpenAI-compatible connection settings and inline credential management

### DIFF
--- a/backend/app/api/credentials.py
+++ b/backend/app/api/credentials.py
@@ -362,30 +362,17 @@ async def _test_openai_compatible(secret: Dict[str, Any]) -> CredentialTestRespo
 
         client = AsyncOpenAI(**client_kwargs)
         
-        # 1. Ensure the endpoint exists and responds to OpenAI format
-        await asyncio.wait_for(client.models.list(), timeout=10)
-        
-        # 2. Force an authentication check
-        # Some providers (like OpenRouter) have a completely public /models endpoint.
-        # Sending a dummy chat request with empty messages usually fails fast on Auth (401)
-        # BEFORE it fails on missing messages (400), letting us verify the API key!
-        try:
-            await asyncio.wait_for(
-                client.chat.completions.create(
-                    model="test-auth",
-                    messages=[],
-                    max_tokens=1
-                ),
-                timeout=10
-            )
-        except Exception as auth_test_e:
-            err_msg = str(auth_test_e).lower()
-            if "401" in err_msg or "unauthorized" in err_msg or "invalid" in err_msg:
-                return CredentialTestResponse(success=False, message="Invalid API Key or Unauthorized.")
-            # If it's a 400 Bad Request or 404 Model Not Found, it means authentication passed!
-            pass
-
-        msg = "Connected to OpenAI Compatible provider successfully."
+        # 1. First, test using chat/completions endpoint
+        model_name = secret.get("model_name", "")
+        await asyncio.wait_for(
+            client.chat.completions.create(
+                model=model_name,
+                messages=[{"role": "user", "content": "ping"}],
+                max_tokens=16
+            ),
+            timeout=10
+        )
+        msg = "Connected to OpenAI Compatible provider successfully via chat/completions."
         if skip_ssl:
             msg += " (SSL verification was skipped)"
         return CredentialTestResponse(success=True, message=msg)

--- a/backend/app/nodes/llms/openai_compatible_node.py
+++ b/backend/app/nodes/llms/openai_compatible_node.py
@@ -39,16 +39,16 @@ class OpenAICompatibleNode(BaseNode):
                 NodeInput(
                     name="base_url",
                     type="str",
-                    description="API Base URL (e.g. https://api.groq.com/openai/v1)",
-                    default="https://openrouter.ai/api/v1",
-                    required=True,
+                    description="API Base URL (overrides credential Base URL if specified)",
+                    default="",
+                    required=False,
                 ),
                 NodeInput(
                     name="model_name",
                     type="str",
-                    description="Model identifier (e.g. llama3-70b-8192)",
-                    default="google/gemma-3n-e4b-it",
-                    required=True,
+                    description="Model identifier (overrides credential Model Name if specified)",
+                    default="",
+                    required=False,
                 ),
                 NodeInput(
                     name="temperature",
@@ -156,26 +156,6 @@ class OpenAICompatibleNode(BaseNode):
                     serviceType="openai_compatible",
                 ),
                 NodeProperty(
-                    name="base_url",
-                    displayName="Base URL",
-                    tabName="basic",
-                    type=NodePropertyType.TEXT,
-                    default="https://openrouter.ai/api/v1",
-                    placeholder="https://api.openai.com/v1",
-                    description="The API endpoint URL",
-                    required=True
-                ),
-                NodeProperty(
-                    name="model_name",
-                    displayName="Model Name",
-                    tabName="basic",
-                    type=NodePropertyType.TEXT,
-                    default="google/gemma-3n-e4b-it",
-                    placeholder="e.g. meta-llama/llama-3-70b-instruct",
-                    description="Enter the exact model ID from the provider",
-                    required=True
-                ),
-                NodeProperty(
                     name="temperature",
                     displayName="Temperature",
                     tabName="basic",
@@ -275,9 +255,40 @@ class OpenAICompatibleNode(BaseNode):
         """Execute Node to create the ChatOpenAI instance."""
         logger.info("\nOPENAI COMPATIBLE NODE SETUP")
         
-        # Get configuration from kwargs or user_data fallback
-        base_url = kwargs.get("base_url") or self.user_data.get("base_url", "https://openrouter.ai/api/v1")
-        model_name = kwargs.get("model_name") or self.user_data.get("model_name", "google/gemma-3n-e4b-it")
+        # Get API Key and config from credential
+        credential_id = kwargs.get("credential_id") or self.user_data.get("credential_id")
+        logger.info(f"[DEBUG][COMPATIBLE] credential_id: {credential_id}")
+        
+        api_key_value = ""
+        cred_base_url = None
+        cred_model_name = None
+        cred_verify_ssl = None
+        
+        if credential_id:
+            cred = self.get_credential(credential_id)
+            logger.info(f"[DEBUG][COMPATIBLE] cred found: {cred is not None}")
+            if cred and cred.get('secret'):
+                secret = cred.get('secret')
+                api_key_value = str(secret.get('api_key', '')).strip()
+                cred_base_url = secret.get('base_url')
+                cred_model_name = secret.get('model_name')
+                
+                # Check skip_ssl_verify in the credential
+                skip_ssl = secret.get('skip_ssl_verify', False)
+                if isinstance(skip_ssl, str):
+                    skip_ssl = skip_ssl.lower() in ("true", "1", "yes", "on")
+                cred_verify_ssl = not bool(skip_ssl)
+                logger.info(f"[DEBUG][COMPATIBLE] API key length: {len(api_key_value)}")
+
+        # Resolve base URL with priority: kwargs -> credential -> self.user_data
+        base_url = kwargs.get("base_url") or cred_base_url or self.user_data.get("base_url")
+        if not base_url:
+            raise ValueError("Base URL is required for OpenAI Compatible Node. Please configure it in the selected credential.")
+            
+        # Resolve model name with priority: kwargs -> credential -> self.user_data
+        model_name = kwargs.get("model_name") or cred_model_name or self.user_data.get("model_name")
+        if not model_name:
+            raise ValueError("Model Name is required for OpenAI Compatible Node. Please configure it in the selected credential.")
         
         temperature_val = kwargs.get("temperature")
         if temperature_val is None:
@@ -323,7 +334,11 @@ class OpenAICompatibleNode(BaseNode):
         # SSL verification - default to True (secure) unless explicitly disabled
         verify_ssl_val = kwargs.get("verify_ssl")
         if verify_ssl_val is None:
-            verify_ssl_val = self.user_data.get("verify_ssl", True)
+            verify_ssl_val = self.user_data.get("verify_ssl")
+        if verify_ssl_val is None and cred_verify_ssl is not None:
+            verify_ssl_val = cred_verify_ssl
+        if verify_ssl_val is None:
+            verify_ssl_val = True
         if isinstance(verify_ssl_val, str):
             verify_ssl = verify_ssl_val.lower() not in ("false", "0", "no")
         else:
@@ -332,18 +347,6 @@ class OpenAICompatibleNode(BaseNode):
         # OpenRouter specific params
         site_url = kwargs.get("site_url") or self.user_data.get("site_url", "")
         site_name = kwargs.get("site_name") or self.user_data.get("site_name", "KAI-Flow")
-        
-        # Get API Key
-        credential_id = kwargs.get("credential_id") or self.user_data.get("credential_id")
-        logger.info(f"[DEBUG][COMPATIBLE] credential_id: {credential_id}")
-        
-        api_key_value = ""
-        if credential_id:
-            cred = self.get_credential(credential_id)
-            logger.info(f"[DEBUG][COMPATIBLE] cred found: {cred is not None}")
-            if cred and cred.get('secret'):
-                api_key_value = str(cred.get('secret').get('api_key')).strip()
-                logger.info(f"[DEBUG][COMPATIBLE] API key length: {len(api_key_value)}")
         
         if not api_key_value:
              # Try environment variables as fallback

--- a/backend/app/nodes/tools/markitdown_tool.py
+++ b/backend/app/nodes/tools/markitdown_tool.py
@@ -258,7 +258,9 @@ class MarkItDownToolNode(ProviderNode):
         base_url = (self.user_data.get("llm_base_url") or "").strip()
         if not base_url:
             base_url = (secret.get("base_url") or "").strip()
-        model = (self.user_data.get("llm_model") or "gpt-4o").strip()
+        model = (self.user_data.get("llm_model") or "").strip()
+        if not model:
+            model = (secret.get("model_name") or "gpt-4o").strip()
         
         try:
             from openai import OpenAI

--- a/client/app/components/credentials/CredentialSelector.tsx
+++ b/client/app/components/credentials/CredentialSelector.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useRef } from "react";
 import { createPortal } from "react-dom";
-import { Loader2, ChevronDown, Plus } from "lucide-react";
+import { Loader2, ChevronDown, Plus, Edit, Trash2 } from "lucide-react";
 import { useUserCredentialStore } from "~/stores/userCredential";
 import {
   getUserCredentialById,
@@ -35,7 +35,7 @@ const CredentialSelector: React.FC<CredentialSelectorProps> = ({
   showCreateNew = true,
   includeGenericFallback = true,
 }) => {
-  const { userCredentials, addCredential, fetchCredentials, isLoading } =
+  const { userCredentials, addCredential, updateCredential, removeCredential, fetchCredentials, isLoading } =
     useUserCredentialStore();
   const [loadingCredential, setLoadingCredential] = useState(false);
   const [showServiceSelection, setShowServiceSelection] = useState(false);
@@ -43,6 +43,8 @@ const CredentialSelector: React.FC<CredentialSelectorProps> = ({
     useState<ServiceDefinition | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [editingCredential, setEditingCredential] = useState<any | null>(null);
+  const [editingInitialValues, setEditingInitialValues] = useState<Record<string, any>>({});
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   const predefinedService: ServiceDefinition | null = serviceType
@@ -146,6 +148,81 @@ const CredentialSelector: React.FC<CredentialSelectorProps> = ({
     }
   };
 
+  const handleEditClick = async () => {
+    if (!value) return;
+    const cred = userCredentials.find(c => c.id === value);
+    if (!cred) return;
+    
+    setLoadingCredential(true);
+    try {
+      const detail = await getUserCredentialById(value);
+      const serviceDef = getServiceDefinition(cred.service_type);
+      if (serviceDef) {
+        setSelectedService(serviceDef);
+        setEditingCredential(cred);
+        if (detail?.secret && typeof detail.secret === "object") {
+          setEditingInitialValues(detail.secret);
+        } else {
+          setEditingInitialValues({});
+        }
+      }
+    } catch (error) {
+      console.error("Failed to fetch credential for editing:", error);
+    } finally {
+      setLoadingCredential(false);
+    }
+  };
+
+  const handleUpdateCredential = async (values: Record<string, any>) => {
+    if (!editingCredential || !selectedService) return;
+
+    setIsSubmitting(true);
+    try {
+      const payload = {
+        name: values.name || editingCredential.name,
+        data: getCredentialData(values),
+        service_type: selectedService.id,
+      };
+
+      await updateCredential(editingCredential.id, payload);
+      await fetchCredentials();
+
+      // Refresh selection details
+      await handleCredentialSelect(editingCredential.id);
+
+      setSelectedService(null);
+      setEditingCredential(null);
+      setEditingInitialValues({});
+    } catch (error) {
+      console.error("Failed to update credential:", error);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleDeleteClick = async () => {
+    if (!value) return;
+    const cred = userCredentials.find(c => c.id === value);
+    if (!cred) return;
+    
+    const confirmDelete = window.confirm(`Are you sure you want to delete the credential "${cred.name}"?`);
+    if (!confirmDelete) return;
+
+    setLoadingCredential(true);
+    try {
+      await removeCredential(value);
+      await fetchCredentials();
+      onChange(""); // Clear selection
+      if (onCredentialLoad) {
+        onCredentialLoad(null);
+      }
+    } catch (error) {
+      console.error("Failed to delete credential:", error);
+    } finally {
+      setLoadingCredential(false);
+    }
+  };
+
   // Get selected credential name
   const selectedCredential = filteredCredentials.find(cred => cred.id === value);
   const displayText = selectedCredential
@@ -154,60 +231,83 @@ const CredentialSelector: React.FC<CredentialSelectorProps> = ({
 
   return (
     <div className="space-y-3">
-      {/* Custom Dropdown */}
-      <div className="relative" ref={dropdownRef}>
-        <button
-          type="button"
-          onClick={() => !disabled && setDropdownOpen(!dropdownOpen)}
-          disabled={disabled || loadingCredential}
-          className={`w-full flex items-center justify-between bg-[#10182c] border border-slate-600 rounded-lg px-4 py-3 text-left transition-all duration-200 ${
-            disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer hover:border-slate-500"
-          } ${dropdownOpen ? "border-blue-500" : ""} ${className}`}
-        >
-          <span className={`text-sm ${value ? "text-white" : "text-slate-400"}`}>
-            {displayText}
-          </span>
-          <div className="flex items-center gap-2">
-            {loadingCredential && (
-              <Loader2 className="w-4 h-4 animate-spin text-blue-400" />
-            )}
-            <ChevronDown
-              size={16}
-              className={`text-slate-400 transition-transform duration-200 ${dropdownOpen ? "rotate-180" : ""}`}
-            />
-          </div>
-        </button>
+      {/* Custom Dropdown and Edit Button Container */}
+      <div className="flex items-center gap-2">
+        <div className="relative flex-1" ref={dropdownRef}>
+          <button
+            type="button"
+            onClick={() => !disabled && setDropdownOpen(!dropdownOpen)}
+            disabled={disabled || loadingCredential}
+            className={`w-full flex items-center justify-between bg-[#10182c] border border-slate-600 rounded-lg px-4 py-3 text-left transition-all duration-200 ${
+              disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer hover:border-slate-500"
+            } ${dropdownOpen ? "border-blue-500" : ""} ${className}`}
+          >
+            <span className={`text-sm ${value ? "text-white" : "text-slate-400"}`}>
+              {displayText}
+            </span>
+            <div className="flex items-center gap-2">
+              {loadingCredential && (
+                <Loader2 className="w-4 h-4 animate-spin text-blue-400" />
+              )}
+              <ChevronDown
+                size={16}
+                className={`text-slate-400 transition-transform duration-200 ${dropdownOpen ? "rotate-180" : ""}`}
+              />
+            </div>
+          </button>
 
-        {/* Dropdown Menu */}
-        {dropdownOpen && (
-          <div className="absolute z-50 mt-1 left-0 right-0 bg-slate-900 border border-slate-700 rounded-lg shadow-lg shadow-black/40 overflow-hidden">
-            {/* Credential options */}
-            {filteredCredentials.map((cred) => (
-              <button
-                key={cred.id}
-                type="button"
-                onClick={() => handleCredentialSelect(cred.id)}
-                className={`w-full flex items-center gap-3 px-4 py-2.5 text-sm text-left transition-colors duration-150 ${
-                  value === cred.id ? "bg-blue-500/20 text-blue-300" : "text-slate-300 hover:bg-blue-500/20 hover:text-blue-300"
-                }`}
-              >
-                {cred.name} ({cred.service_type})
-              </button>
-            ))}
+          {/* Dropdown Menu */}
+          {dropdownOpen && (
+            <div className="absolute z-50 mt-1 left-0 right-0 bg-slate-900 border border-slate-700 rounded-lg shadow-lg shadow-black/40 overflow-hidden">
+              {/* Credential options */}
+              {filteredCredentials.map((cred) => (
+                <button
+                  key={cred.id}
+                  type="button"
+                  onClick={() => handleCredentialSelect(cred.id)}
+                  className={`w-full flex items-center gap-3 px-4 py-2.5 text-sm text-left transition-colors duration-150 ${
+                    value === cred.id ? "bg-blue-500/20 text-blue-300" : "text-slate-300 hover:bg-blue-500/20 hover:text-blue-300"
+                  }`}
+                >
+                  {cred.name} ({cred.service_type})
+                </button>
+              ))}
 
-            {/* Create new option */}
-            {showCreateNew && (
-              <button
-                type="button"
-                onClick={handleCreateNewClick}
-                className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-slate-300 hover:bg-blue-500/20 hover:text-blue-300 transition-colors duration-150 text-left border-t border-slate-700"
-              >
-                <Plus size={14} className="text-slate-500" />
-                {predefinedService
-                  ? `Create new ${predefinedService.name} credentials…`
-                  : "Create new credentials…"}
-              </button>
-            )}
+              {/* Create new option */}
+              {showCreateNew && (
+                <button
+                  type="button"
+                  onClick={handleCreateNewClick}
+                  className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-slate-300 hover:bg-blue-500/20 hover:text-blue-300 transition-colors duration-150 text-left border-t border-slate-700"
+                >
+                  <Plus size={14} className="text-slate-500" />
+                  {predefinedService
+                    ? `Create new ${predefinedService.name} credentials…`
+                    : "Create new credentials…"}
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+
+        {value && !disabled && (
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={handleEditClick}
+              className="p-3 bg-slate-800 border border-slate-600 hover:border-slate-500 rounded-lg text-slate-300 hover:text-white transition-all duration-200 shadow-md hover:shadow-lg flex items-center justify-center h-[46px] w-[46px]"
+              title="Edit selected credential"
+            >
+              <Edit size={16} />
+            </button>
+            <button
+              type="button"
+              onClick={handleDeleteClick}
+              className="p-3 bg-red-950/40 border border-red-900/60 hover:border-red-800 rounded-lg text-red-400 hover:text-red-300 transition-all duration-200 shadow-md hover:shadow-lg flex items-center justify-center h-[46px] w-[46px]"
+              title="Delete selected credential"
+            >
+              <Trash2 size={16} />
+            </button>
           </div>
         )}
       </div>
@@ -232,10 +332,16 @@ const CredentialSelector: React.FC<CredentialSelectorProps> = ({
               <div className="p-6">
                 <div className="flex items-center justify-between mb-4">
                   <h2 className="text-xl font-bold text-gray-900">
-                    Create New {selectedService.name} Credentials
+                    {editingCredential
+                      ? `Edit ${editingCredential.name}`
+                      : `Create New ${selectedService.name} Credentials`}
                   </h2>
                   <button
-                    onClick={() => setSelectedService(null)}
+                    onClick={() => {
+                      setSelectedService(null);
+                      setEditingCredential(null);
+                      setEditingInitialValues({});
+                    }}
                     className="text-gray-400 hover:text-gray-600 transition-colors"
                   >
                     <svg
@@ -256,15 +362,23 @@ const CredentialSelector: React.FC<CredentialSelectorProps> = ({
 
                 <DynamicCredentialForm
                   service={selectedService}
-                  onSubmit={handleCreateCredential}
-                  onCancel={() => setSelectedService(null)}
+                  onSubmit={editingCredential ? handleUpdateCredential : handleCreateCredential}
+                  onCancel={() => {
+                    setSelectedService(null);
+                    setEditingCredential(null);
+                    setEditingInitialValues({});
+                  }}
                   onTest={(values) =>
                     testCredentialRaw(
                       selectedService.id,
                       getCredentialData(values)
                     )
                   }
-                  initialValues={{ name: `${selectedService.name} Credential` }}
+                  initialValues={
+                    editingCredential
+                      ? { name: editingCredential.name, ...editingInitialValues }
+                      : { name: `${selectedService.name} Credential` }
+                  }
                   isSubmitting={isSubmitting}
                 />
               </div>

--- a/client/app/types/credentials.ts
+++ b/client/app/types/credentials.ts
@@ -74,6 +74,14 @@ export const SERVICE_DEFINITIONS: ServiceDefinition[] = [
         description: 'The endpoint URL for the compatible service'
       },
       {
+        name: 'model_name',
+        label: 'Model Name',
+        type: 'text',
+        required: true,
+        placeholder: 'google/gemma-3n-e4b-it',
+        description: 'The model name/identifier (e.g. llama3-70b-8192)'
+      },
+      {
         name: 'api_key',
         label: 'API Key',
         type: 'password',


### PR DESCRIPTION
- migrate base URL and model configuration from node properties to shared credential definitions
- extend OpenAI-compatible credential schema with model configuration support
- validate connections through chat/completions requests to support providers without models endpoints
- enforce fail-fast validation when required connection settings are missing during execution
- resolve model configuration from credentials when node-level values are not provided
- add inline credential edit and deletion actions within node settings panels
- support live credential updates and removal without leaving the node configuration workflow
- standardize OpenAI-compatible provider configuration across execution and management flows