### PR TITLE
fix: allow wrapped LLM runnables in ReactAgent validation

### DIFF
--- a/backend/app/nodes/agents/react_agent.py
+++ b/backend/app/nodes/agents/react_agent.py
@@ -514,9 +514,9 @@ class ReactAgentNode(ProcessorNode):
                 f"Make sure to connect an OpenAI Chat node to the 'llm' input of this Agent."
             )
 
-        if not isinstance(llm, BaseLanguageModel):
+        if not isinstance(llm, (BaseLanguageModel, Runnable)):
             raise ValueError(
-                f"Connected LLM must be a BaseLanguageModel instance, got {type(llm)}. "
+                f"Connected LLM must be a BaseLanguageModel or Runnable instance, got {type(llm)}. "
                 f"Ensure the OpenAI Chat node is properly configured and connected."
             )
 

--- a/backend/app/nodes/llms/openai_compatible_node.py
+++ b/backend/app/nodes/llms/openai_compatible_node.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from typing import Dict, Any, Optional, List
 import httpx
 from langchain_openai import ChatOpenAI
@@ -8,6 +9,108 @@ from pydantic import SecretStr
 from ..base import BaseNode, NodeType, NodeInput, NodeOutput, NodeProperty, NodePropertyType, NodePosition
 
 logger = logging.getLogger(__name__)
+
+class LLMReasoningFilterWrapper(Runnable):
+    def __init__(self, llm, strip_reasoning: bool):
+        self.llm = llm
+        self.strip_reasoning = strip_reasoning
+
+    def __getattr__(self, name):
+        return getattr(self.llm, name)
+
+    def invoke(self, *args, **kwargs):
+        resp = self.llm.invoke(*args, **kwargs)
+        return self._clean(resp)
+
+    async def ainvoke(self, *args, **kwargs):
+        resp = await self.llm.ainvoke(*args, **kwargs)
+        return self._clean(resp)
+
+    def with_structured_output(self, schema, **kwargs):
+        structured_model = self.llm.with_structured_output(schema, **kwargs)
+        return LLMReasoningFilterWrapper(structured_model, self.strip_reasoning)
+
+    def stream(self, *args, **kwargs):
+        if not self.strip_reasoning:
+            yield from self.llm.stream(*args, **kwargs)
+            return
+
+        buffer = ""
+        for chunk in self.llm.stream(*args, **kwargs):
+            content = chunk.content if hasattr(chunk, "content") else str(chunk)
+            buffer += content
+            
+            has_open_think = "<think" in buffer and "</think>" not in buffer
+            has_open_thought = "<thought" in buffer and "</thought>" not in buffer
+            
+            if not has_open_think and not has_open_thought:
+                cleaned = re.sub(r"<think>[\s\S]*?</think>", "", buffer)
+                cleaned = re.sub(r"<thought>[\s\S]*?</thought>", "", cleaned)
+                if cleaned:
+                    if hasattr(chunk, "content"):
+                        chunk.content = cleaned
+                        yield chunk
+                    else:
+                        yield cleaned
+                    buffer = ""
+        
+        if buffer:
+            cleaned = re.sub(r"<think>[\s\S]*?</think>", "", buffer)
+            cleaned = re.sub(r"<thought>[\s\S]*?</thought>", "", cleaned)
+            if cleaned:
+                yield cleaned
+
+    async def astream(self, *args, **kwargs):
+        if not self.strip_reasoning:
+            async for chunk in self.llm.astream(*args, **kwargs):
+                yield chunk
+            return
+
+        buffer = ""
+        async for chunk in self.llm.astream(*args, **kwargs):
+            content = chunk.content if hasattr(chunk, "content") else str(chunk)
+            buffer += content
+            
+            has_open_think = "<think" in buffer and "</think>" not in buffer
+            has_open_thought = "<thought" in buffer and "</thought>" not in buffer
+            
+            if not has_open_think and not has_open_thought:
+                cleaned = re.sub(r"<think>[\s\S]*?</think>", "", buffer)
+                cleaned = re.sub(r"<thought>[\s\S]*?</thought>", "", cleaned)
+                if cleaned:
+                    if hasattr(chunk, "content"):
+                        chunk.content = cleaned
+                        yield chunk
+                    else:
+                        yield cleaned
+                    buffer = ""
+                    
+        if buffer:
+            cleaned = re.sub(r"<think>[\s\S]*?</think>", "", buffer)
+            cleaned = re.sub(r"<thought>[\s\S]*?</thought>", "", cleaned)
+            if cleaned:
+                yield cleaned
+
+    def _clean(self, output):
+        if not self.strip_reasoning:
+            return output
+        from langchain_core.messages import AIMessage
+
+        def _clean_text(text: str) -> str:
+            text = re.sub(r"<think>[\s\S]*?</think>", "", text)
+            text = re.sub(r"<thought>[\s\S]*?</thought>", "", text)
+            return text.strip()
+
+        if isinstance(output, AIMessage):
+            if isinstance(output.content, str):
+                output.content = _clean_text(output.content)
+            return output
+        elif hasattr(output, "content") and isinstance(output.content, str):
+            output.content = _clean_text(output.content)
+            return output
+        elif isinstance(output, str):
+            return _clean_text(output)
+        return output
 
 class OpenAICompatibleNode(BaseNode):
     """
@@ -127,6 +230,20 @@ class OpenAICompatibleNode(BaseNode):
                     description="Enable SSL certificate verification (disable for self-signed certificates)",
                     default=True,
                     required=False,
+                ),
+                NodeInput(
+                    name="strip_reasoning",
+                    type="bool",
+                    description="Automatically remove <think>...</think> or <thought>...</thought> tags and their contents from the model's output.",
+                    default=False,
+                    required=False
+                ),
+                NodeInput(
+                    name="extra_body_params",
+                    type="str",
+                    description="Additional parameters to inject directly into the request body as a JSON string.",
+                    default="",
+                    required=False
                 )
             ],
             "outputs": [
@@ -240,6 +357,25 @@ class OpenAICompatibleNode(BaseNode):
                     type=NodePropertyType.CHECKBOX,
                     default=True,
                     description="Enable SSL certificate verification. Disable this only when connecting to servers with self-signed certificates (e.g. internal/local deployments)",
+                    required=False
+                ),
+                NodeProperty(
+                    name="strip_reasoning",
+                    displayName="Strip Reasoning/Thinking Tags",
+                    tabName="advanced",
+                    type=NodePropertyType.CHECKBOX,
+                    default=False,
+                    description="Automatically remove <think>...</think> or <thought>...</thought> tags and their contents from the model's output.",
+                    required=False
+                ),
+                NodeProperty(
+                    name="extra_body_params",
+                    displayName="Extra Body Parameters (JSON)",
+                    tabName="advanced",
+                    type=NodePropertyType.TEXT_AREA,
+                    default="",
+                    placeholder='{"thinking_mode": false}',
+                    description="Additional parameters to inject directly into the request body (e.g. for Groq thinking configuration).",
                     required=False
                 )
             ]
@@ -370,6 +506,27 @@ class OpenAICompatibleNode(BaseNode):
             if site_name:
                 extra_headers["X-Title"] = site_name
  
+        # Strip Reasoning/Thinking Tags
+        strip_reasoning_val = kwargs.get("strip_reasoning")
+        if strip_reasoning_val is None:
+            strip_reasoning_val = self.user_data.get("strip_reasoning", False)
+        if isinstance(strip_reasoning_val, str):
+            strip_reasoning = strip_reasoning_val.lower() in ("true", "1", "yes", "on")
+        else:
+            strip_reasoning = bool(strip_reasoning_val)
+
+        # Extra Body Parameters (JSON)
+        extra_body_json = kwargs.get("extra_body_params")
+        if extra_body_json is None:
+            extra_body_json = self.user_data.get("extra_body_params", "")
+        extra_body_data = {}
+        if extra_body_json:
+            import json
+            try:
+                extra_body_data = json.loads(extra_body_json)
+            except json.JSONDecodeError as e:
+                logger.error(f"Failed to parse extra_body_params JSON: {e}")
+
         # Build LLM Configuration
         llm_config = {
             "model": model_name,
@@ -390,8 +547,16 @@ class OpenAICompatibleNode(BaseNode):
         if timeout is not None:
             llm_config["timeout"] = timeout
  
+        # Build model_kwargs if extra headers exist
+        model_kwargs = {}
         if extra_headers:
-            llm_config["model_kwargs"] = {"extra_headers": extra_headers}
+            model_kwargs["extra_headers"] = extra_headers
+            
+        if model_kwargs:
+            llm_config["model_kwargs"] = model_kwargs
+
+        if extra_body_data:
+            llm_config["extra_body"] = extra_body_data
         
         # Create custom HTTP client for self-signed certificate support
         if not verify_ssl:
@@ -405,6 +570,9 @@ class OpenAICompatibleNode(BaseNode):
             logger.info(f"   Provider Base: {base_url}")
             logger.info(f"   Model: {model_name} | Temp: {temperature}")
             
+            if strip_reasoning:
+                logger.info("Applying LLMReasoningFilterWrapper to strip reasoning/thinking tags.")
+                return LLMReasoningFilterWrapper(llm, strip_reasoning=True)
             return llm
             
         except Exception as e:

--- a/backend/app/nodes/security/agentic_red_team_node.py
+++ b/backend/app/nodes/security/agentic_red_team_node.py
@@ -283,6 +283,25 @@ class AgenticRedTeamNode(ProcessorNode):
                 displayOptions={"show": {"enable_owasp_asi": True}},
                 required=False,
             ),
+            NodeProperty(
+                name="verify_ssl", displayName="SSL Certificate Verification",
+                type=NodePropertyType.CHECKBOX, default=True,
+                hint="Enable SSL certificate verification. Disable this only when connecting to servers with self-signed certificates.",
+                tabName="advanced", required=False,
+            ),
+            NodeProperty(
+                name="strip_reasoning", displayName="Strip Reasoning/Thinking Tags",
+                type=NodePropertyType.CHECKBOX, default=False,
+                hint="Automatically remove <think>...</think> or <thought>...</thought> tags and their contents from the target model's output.",
+                tabName="advanced", required=False,
+            ),
+            NodeProperty(
+                name="extra_body_params", displayName="Extra Body Parameters (JSON)",
+                type=NodePropertyType.TEXT_AREA, default="",
+                placeholder='{"thinking_mode": false}',
+                hint="Additional parameters to inject directly into the request body of target model (e.g. for Groq thinking configuration).",
+                tabName="advanced", required=False,
+            ),
         ]
 
     # ----------------------------------------------------------------
@@ -304,10 +323,36 @@ class AgenticRedTeamNode(ProcessorNode):
             "target_base_url", "target_model_name", "target_api_key",
             "target_purpose", "target_system_prompt", "vulnerabilities",
             "vulnerability_types", "attacks", "attacks_per_vuln_type",
-            "max_concurrent", "enable_owasp_asi", "owasp_asi_categories",
+            "max_concurrent", "enable_owasp_asi", "owasp_asi_categories", "verify_ssl",
+            "strip_reasoning", "extra_body_params",
         ]:
             if key not in inputs and isinstance(self.user_data, dict) and key in self.user_data:
                 inputs[key] = self.user_data[key]
+
+        # SSL verification
+        verify_ssl_val = inputs.get("verify_ssl", True)
+        if isinstance(verify_ssl_val, str):
+            verify_ssl = verify_ssl_val.lower() not in ("false", "0", "no")
+        else:
+            verify_ssl = bool(verify_ssl_val)
+
+        # Strip Reasoning/Thinking Tags
+        strip_reasoning_val = inputs.get("strip_reasoning")
+        if strip_reasoning_val is None:
+            strip_reasoning_val = False
+        if isinstance(strip_reasoning_val, str):
+            strip_reasoning = strip_reasoning_val.lower() in ("true", "1", "yes", "on")
+        else:
+            strip_reasoning = bool(strip_reasoning_val)
+
+        # Extra Body Parameters (JSON)
+        extra_body_json = inputs.get("extra_body_params") or ""
+        extra_body_data = {}
+        if extra_body_json:
+            try:
+                extra_body_data = json.loads(extra_body_json)
+            except json.JSONDecodeError as e:
+                logger.error(f"Failed to parse extra_body_params JSON: {e}")
 
         # ── Validate & extract target params ──
         target_base_url      = inputs.get("target_base_url", "").strip()
@@ -341,7 +386,16 @@ class AgenticRedTeamNode(ProcessorNode):
         logger.info(f"AgenticRedTeam: target={target_model_name} @ {target_base_url}")
 
         # ── Build raw OpenAI client for target ──
-        target_client = OpenAI(base_url=target_base_url, api_key=target_api_key)
+        import httpx
+        client_kwargs = {
+            "base_url": target_base_url,
+            "api_key": target_api_key,
+        }
+        if not verify_ssl:
+            logger.warning("SSL certificate verification is DISABLED for the target client. Use only for trusted internal endpoints.")
+            client_kwargs["http_client"] = httpx.Client(verify=False)
+
+        target_client = OpenAI(**client_kwargs)
 
         # ── model_callback — async function (official docs pattern) ──
         async def model_callback(input: str, turns=None) -> RTTurn:
@@ -360,12 +414,23 @@ class AgenticRedTeamNode(ProcessorNode):
             messages.append({"role": "user", "content": input})
 
             try:
-                resp = target_client.chat.completions.create(
-                    model=target_model_name,
-                    messages=messages,
-                    temperature=0.0,
-                )
+                create_kwargs = {
+                    "model": target_model_name,
+                    "messages": messages,
+                    "temperature": 0.0,
+                }
+                if extra_body_data:
+                    create_kwargs["extra_body"] = extra_body_data
+
+                resp = target_client.chat.completions.create(**create_kwargs)
                 content = resp.choices[0].message.content or "[ERROR] No content returned."
+                
+                # Apply reasoning strip if enabled
+                if strip_reasoning and isinstance(content, str):
+                    import re
+                    content = re.sub(r"<think>[\s\S]*?</think>", "", content)
+                    content = re.sub(r"<thought>[\s\S]*?</thought>", "", content)
+                    content = content.strip()
             except Exception as e:
                 logger.warning(f"AgenticRedTeam: target_callback error — {type(e).__name__}: {e}")
                 content = f"[ERROR] {e}"
@@ -384,16 +449,84 @@ class AgenticRedTeamNode(ProcessorNode):
                 def load_model(self):
                     return self.model
 
-                def generate(self, prompt: str) -> str:
-                    resp = self.model.invoke(prompt)
-                    return resp.content if hasattr(resp, "content") else str(resp)
+                def generate(self, prompt: str, schema: Any = None, *args, **kwargs) -> Any:
+                    if schema is not None:
+                        try:
+                            structured_model = self.model.with_structured_output(schema)
+                            return structured_model.invoke(prompt)
+                        except Exception as e:
+                            logger.warning(
+                                f"AgenticRedTeam: Failed to get structured output from {name_hint} model via langchain: {e}. "
+                                "Falling back to raw string generation and manual parsing."
+                            )
+                            resp = self.model.invoke(prompt)
+                            content = resp.content if hasattr(resp, "content") else str(resp)
+                            return _Wrapper.parse_json_to_schema(content, schema)
+                    else:
+                        resp = self.model.invoke(prompt)
+                        return resp.content if hasattr(resp, "content") else str(resp)
 
-                async def a_generate(self, prompt: str) -> str:
-                    resp = await self.model.ainvoke(prompt)
-                    return resp.content if hasattr(resp, "content") else str(resp)
+                async def a_generate(self, prompt: str, schema: Any = None, *args, **kwargs) -> Any:
+                    if schema is not None:
+                        try:
+                            structured_model = self.model.with_structured_output(schema)
+                            return await structured_model.ainvoke(prompt)
+                        except Exception as e:
+                            logger.warning(
+                                f"AgenticRedTeam: Failed to get structured output from {name_hint} model via langchain: {e}. "
+                                "Falling back to raw string generation and manual parsing."
+                            )
+                            resp = await self.model.ainvoke(prompt)
+                            content = resp.content if hasattr(resp, "content") else str(resp)
+                            return _Wrapper.parse_json_to_schema(content, schema)
+                    else:
+                        resp = await self.model.ainvoke(prompt)
+                        return resp.content if hasattr(resp, "content") else str(resp)
 
                 def get_model_name(self) -> str:
                     return getattr(self.model, "model_name", name_hint)
+
+                @staticmethod
+                def parse_json_to_schema(text: str, schema: Any) -> Any:
+                    import re
+                    text_str = text.strip()
+                    try:
+                        if hasattr(schema, "model_validate_json"):
+                            return schema.model_validate_json(text_str)
+                        else:
+                            return schema.parse_raw(text_str)
+                    except Exception:
+                        pass
+
+                    # Regex 1: Markdown kod bloklarının (```json ... ```) içerisindeki JSON kısmını yakalama
+                    json_block_match = re.search(r"```json\s*(.*?)\s*```", text_str, re.DOTALL)
+                    if json_block_match:
+                        try:
+                            clean_content = json_block_match.group(1).strip()
+                            if hasattr(schema, "model_validate_json"):
+                                return schema.model_validate_json(clean_content)
+                            else:
+                                return schema.parse_raw(clean_content)
+                        except Exception:
+                            pass
+
+                    # Regex 2: Metin içinde süslü parantezler { ... } arasına sıkışmış olan JSON'ı yakalama
+                    braces_match = re.search(r"(\{.*\})", text_str, re.DOTALL)
+                    if braces_match:
+                        try:
+                            clean_content = braces_match.group(1).strip()
+                            if hasattr(schema, "model_validate_json"):
+                                return schema.model_validate_json(clean_content)
+                            else:
+                                return schema.parse_raw(clean_content)
+                        except Exception:
+                            pass
+
+                    # Son çare
+                    if hasattr(schema, "model_validate_json"):
+                        return schema.model_validate_json(text_str)
+                    else:
+                        return schema.parse_raw(text_str)
 
             return _Wrapper()
 

--- a/backend/app/nodes/security/custom_red_team_node.py
+++ b/backend/app/nodes/security/custom_red_team_node.py
@@ -119,6 +119,31 @@ class CustomRedTeamNode(ProcessorNode):
                 hint="System prompt for target model",
                 required=False
             ),
+            NodeProperty(
+                name="verify_ssl",
+                displayName="SSL Certificate Verification",
+                type=NodePropertyType.CHECKBOX,
+                default=True,
+                hint="Enable SSL certificate verification. Disable this only when connecting to servers with self-signed certificates.",
+                required=False
+            ),
+            NodeProperty(
+                name="strip_reasoning",
+                displayName="Strip Reasoning/Thinking Tags",
+                type=NodePropertyType.CHECKBOX,
+                default=False,
+                hint="Automatically remove <think>...</think> or <thought>...</thought> tags and their contents from the target model's output.",
+                required=False
+            ),
+            NodeProperty(
+                name="extra_body_params",
+                displayName="Extra Body Parameters (JSON)",
+                type=NodePropertyType.TEXT_AREA,
+                default="",
+                placeholder='{"thinking_mode": false}',
+                hint="Additional parameters to inject directly into the request body of target model.",
+                required=False
+            ),
         ]
 
     def execute(self, inputs: Dict[str, Any], connected_nodes: Dict[str, Any]) -> Dict[str, Any]:
@@ -131,9 +156,35 @@ class CustomRedTeamNode(ProcessorNode):
 
             # Fallback to user_data
             for key in ["minio_credential", "minio_bucket", "minio_key", 
-                       "target_base_url", "target_model_name", "target_api_key", "target_system_prompt"]:
+                       "target_base_url", "target_model_name", "target_api_key", "target_system_prompt", "verify_ssl",
+                       "strip_reasoning", "extra_body_params"]:
                 if key not in inputs and isinstance(self.user_data, dict) and key in self.user_data:
                     inputs[key] = self.user_data[key]
+
+            # SSL verification
+            verify_ssl_val = inputs.get("verify_ssl", True)
+            if isinstance(verify_ssl_val, str):
+                verify_ssl = verify_ssl_val.lower() not in ("false", "0", "no")
+            else:
+                verify_ssl = bool(verify_ssl_val)
+
+            # Strip Reasoning
+            strip_reasoning_val = inputs.get("strip_reasoning")
+            if strip_reasoning_val is None:
+                strip_reasoning_val = False
+            if isinstance(strip_reasoning_val, str):
+                strip_reasoning = strip_reasoning_val.lower() in ("true", "1", "yes", "on")
+            else:
+                strip_reasoning = bool(strip_reasoning_val)
+
+            # Extra Body Params
+            extra_body_json = inputs.get("extra_body_params") or ""
+            extra_body_data = {}
+            if extra_body_json:
+                try:
+                    extra_body_data = json.loads(extra_body_json)
+                except json.JSONDecodeError as e:
+                    logger.error(f"Failed to parse extra_body_params JSON: {e}")
 
             # 1. Load prompts from MinIO
             prompts_data = self._load_prompts_from_minio(inputs)
@@ -152,7 +203,16 @@ class CustomRedTeamNode(ProcessorNode):
             if not target_base_url or not target_model_name or not target_api_key:
                 raise ValueError("Target LLM configuration is incomplete.")
 
-            target_client = OpenAI(base_url=target_base_url, api_key=target_api_key)
+            import httpx
+            client_kwargs = {
+                "base_url": target_base_url,
+                "api_key": target_api_key,
+            }
+            if not verify_ssl:
+                logger.warning("SSL certificate verification is DISABLED for the target client. Use only for trusted internal endpoints.")
+                client_kwargs["http_client"] = httpx.Client(verify=False)
+
+            target_client = OpenAI(**client_kwargs)
             logger.info(f"Target: {target_model_name} @ {target_base_url}")
 
             # 3. Setup evaluator LLM
@@ -175,12 +235,23 @@ class CustomRedTeamNode(ProcessorNode):
                         messages.append({"role": "system", "content": target_system_prompt})
                     messages.append({"role": "user", "content": prompt})
                     
-                    response = target_client.chat.completions.create(
-                        model=target_model_name,
-                        messages=messages,
-                        temperature=0.0,
-                    )
+                    create_kwargs = {
+                        "model": target_model_name,
+                        "messages": messages,
+                        "temperature": 0.0,
+                    }
+                    if extra_body_data:
+                        create_kwargs["extra_body"] = extra_body_data
+
+                    response = target_client.chat.completions.create(**create_kwargs)
                     llm_output = response.choices[0].message.content or "[No response]"
+                    
+                    # Apply reasoning strip if enabled
+                    if strip_reasoning and isinstance(llm_output, str):
+                        import re
+                        llm_output = re.sub(r"<think>[\s\S]*?</think>", "", llm_output)
+                        llm_output = re.sub(r"<thought>[\s\S]*?</thought>", "", llm_output)
+                        llm_output = llm_output.strip()
                     
                     # Evaluate response
                     is_safe, reason = self._evaluate_response(
@@ -333,15 +404,83 @@ UNSAFE: [reason]
             def load_model(self):
                 return self.model
 
-            def generate(self, prompt: str) -> str:
-                resp = self.model.invoke(prompt)
-                return resp.content if hasattr(resp, "content") else str(resp)
+            def generate(self, prompt: str, schema: Any = None, *args, **kwargs) -> Any:
+                if schema is not None:
+                    try:
+                        structured_model = self.model.with_structured_output(schema)
+                        return structured_model.invoke(prompt)
+                    except Exception as e:
+                        logger.warning(
+                            f"CustomRedTeam: Failed to get structured output from {name_hint} model via langchain: {e}. "
+                            "Falling back to raw string generation and manual parsing."
+                        )
+                        resp = self.model.invoke(prompt)
+                        content = resp.content if hasattr(resp, "content") else str(resp)
+                        return _Wrapper.parse_json_to_schema(content, schema)
+                else:
+                    resp = self.model.invoke(prompt)
+                    return resp.content if hasattr(resp, "content") else str(resp)
 
-            async def a_generate(self, prompt: str) -> str:
-                resp = await self.model.ainvoke(prompt)
-                return resp.content if hasattr(resp, "content") else str(resp)
+            async def a_generate(self, prompt: str, schema: Any = None, *args, **kwargs) -> Any:
+                if schema is not None:
+                    try:
+                        structured_model = self.model.with_structured_output(schema)
+                        return await structured_model.ainvoke(prompt)
+                    except Exception as e:
+                        logger.warning(
+                            f"CustomRedTeam: Failed to get structured output from {name_hint} model via langchain: {e}. "
+                            "Falling back to raw string generation and manual parsing."
+                        )
+                        resp = await self.model.ainvoke(prompt)
+                        content = resp.content if hasattr(resp, "content") else str(resp)
+                        return _Wrapper.parse_json_to_schema(content, schema)
+                else:
+                    resp = await self.model.ainvoke(prompt)
+                    return resp.content if hasattr(resp, "content") else str(resp)
 
             def get_model_name(self) -> str:
                 return getattr(self.model, "model_name", name_hint)
+
+            @staticmethod
+            def parse_json_to_schema(text: str, schema: Any) -> Any:
+                import re
+                text_str = text.strip()
+                try:
+                    if hasattr(schema, "model_validate_json"):
+                        return schema.model_validate_json(text_str)
+                    else:
+                        return schema.parse_raw(text_str)
+                except Exception:
+                    pass
+
+                # Regex 1: Markdown kod bloklarının (```json ... ```) içerisindeki JSON kısmını yakalama
+                json_block_match = re.search(r"```json\s*(.*?)\s*```", text_str, re.DOTALL)
+                if json_block_match:
+                    try:
+                        clean_content = json_block_match.group(1).strip()
+                        if hasattr(schema, "model_validate_json"):
+                            return schema.model_validate_json(clean_content)
+                        else:
+                            return schema.parse_raw(clean_content)
+                    except Exception:
+                        pass
+
+                # Regex 2: Metin içinde süslü parantezler { ... } arasına sıkışmış olan JSON'ı yakalama
+                braces_match = re.search(r"(\{.*\})", text_str, re.DOTALL)
+                if braces_match:
+                    try:
+                        clean_content = braces_match.group(1).strip()
+                        if hasattr(schema, "model_validate_json"):
+                            return schema.model_validate_json(clean_content)
+                        else:
+                            return schema.parse_raw(clean_content)
+                    except Exception:
+                        pass
+
+                # Son çare
+                if hasattr(schema, "model_validate_json"):
+                    return schema.model_validate_json(text_str)
+                else:
+                    return schema.parse_raw(text_str)
 
         return _Wrapper()

--- a/backend/app/nodes/security/llm_red_team_node.py
+++ b/backend/app/nodes/security/llm_red_team_node.py
@@ -201,6 +201,19 @@ class LLMRedTeamNode(ProcessorNode):
                          hint="Comma-separated OWASP IDs. E.g: LLM_01, LLM_06. Leave empty for all.",
                          tabName="advanced", displayOptions={"show": {"enable_owasp": True}},
                          required=False),
+            NodeProperty(name="verify_ssl", displayName="SSL Certificate Verification",
+                         type=NodePropertyType.CHECKBOX, default=True,
+                         hint="Enable SSL certificate verification. Disable this only when connecting to servers with self-signed certificates.",
+                         tabName="advanced", required=False),
+            NodeProperty(name="strip_reasoning", displayName="Strip Reasoning/Thinking Tags",
+                         type=NodePropertyType.CHECKBOX, default=False,
+                         hint="Automatically remove <think>...</think> or <thought>...</thought> tags and their contents from the target model's output.",
+                         tabName="advanced", required=False),
+            NodeProperty(name="extra_body_params", displayName="Extra Body Parameters (JSON)",
+                         type=NodePropertyType.TEXT_AREA, default="",
+                         placeholder='{"thinking_mode": false}',
+                         hint="Additional parameters to inject directly into the request body of target model (e.g. for Groq thinking configuration).",
+                         tabName="advanced", required=False),
         ]
 
     # ----------------------------------------------------------------
@@ -222,10 +235,36 @@ class LLMRedTeamNode(ProcessorNode):
             "target_base_url", "target_model_name", "target_api_key",
             "target_purpose", "target_system_prompt", "vulnerabilities",
             "attacks", "attacks_per_vuln_type", "max_concurrent",
-            "enable_owasp", "owasp_categories",
+            "enable_owasp", "owasp_categories", "verify_ssl",
+            "strip_reasoning", "extra_body_params",
         ]:
             if key not in inputs and isinstance(self.user_data, dict) and key in self.user_data:
                 inputs[key] = self.user_data[key]
+
+        # SSL verification - default to True (secure) unless explicitly disabled
+        verify_ssl_val = inputs.get("verify_ssl", True)
+        if isinstance(verify_ssl_val, str):
+            verify_ssl = verify_ssl_val.lower() not in ("false", "0", "no")
+        else:
+            verify_ssl = bool(verify_ssl_val)
+
+        # Strip Reasoning/Thinking Tags
+        strip_reasoning_val = inputs.get("strip_reasoning")
+        if strip_reasoning_val is None:
+            strip_reasoning_val = False
+        if isinstance(strip_reasoning_val, str):
+            strip_reasoning = strip_reasoning_val.lower() in ("true", "1", "yes", "on")
+        else:
+            strip_reasoning = bool(strip_reasoning_val)
+
+        # Extra Body Parameters (JSON)
+        extra_body_json = inputs.get("extra_body_params") or ""
+        extra_body_data = {}
+        if extra_body_json:
+            try:
+                extra_body_data = json.loads(extra_body_json)
+            except json.JSONDecodeError as e:
+                logger.error(f"Failed to parse extra_body_params JSON: {e}")
 
         # ── Validate & extract target params ──
         target_base_url      = inputs.get("target_base_url", "").strip()
@@ -256,7 +295,16 @@ class LLMRedTeamNode(ProcessorNode):
         # ── Build raw OpenAI client for target ──
         # Using openai.OpenAI directly — aligned with official DeepTeam guide pattern.
         # LangChain is NOT used for the target to avoid extra wrapper complexity.
-        target_client = OpenAI(base_url=target_base_url, api_key=target_api_key)
+        import httpx
+        client_kwargs = {
+            "base_url": target_base_url,
+            "api_key": target_api_key,
+        }
+        if not verify_ssl:
+            logger.warning("SSL certificate verification is DISABLED for the target client. Use only for trusted internal endpoints.")
+            client_kwargs["http_client"] = httpx.Client(verify=False)
+
+        target_client = OpenAI(**client_kwargs)
 
         # ── model_callback — async function (official docs pattern) ──
         # Signature: async def model_callback(input: str, turns=None) -> RTTurn
@@ -281,12 +329,23 @@ class LLMRedTeamNode(ProcessorNode):
             messages.append({"role": "user", "content": input})
 
             try:
-                resp = target_client.chat.completions.create(
-                    model=target_model_name,
-                    messages=messages,
-                    temperature=0.0,
-                )
+                create_kwargs = {
+                    "model": target_model_name,
+                    "messages": messages,
+                    "temperature": 0.0,
+                }
+                if extra_body_data:
+                    create_kwargs["extra_body"] = extra_body_data
+
+                resp = target_client.chat.completions.create(**create_kwargs)
                 content = resp.choices[0].message.content or "[ERROR] No content returned."
+                
+                # Apply reasoning strip if enabled
+                if strip_reasoning and isinstance(content, str):
+                    import re
+                    content = re.sub(r"<think>[\s\S]*?</think>", "", content)
+                    content = re.sub(r"<thought>[\s\S]*?</thought>", "", content)
+                    content = content.strip()
             except Exception as e:
                 logger.warning(f"LLMRedTeam: target_callback error — {type(e).__name__}: {e}")
                 content = f"[ERROR] {e}"
@@ -307,16 +366,84 @@ class LLMRedTeamNode(ProcessorNode):
                 def load_model(self):
                     return self.model
 
-                def generate(self, prompt: str) -> str:
-                    resp = self.model.invoke(prompt)
-                    return resp.content if hasattr(resp, "content") else str(resp)
+                def generate(self, prompt: str, schema: Any = None, *args, **kwargs) -> Any:
+                    if schema is not None:
+                        try:
+                            structured_model = self.model.with_structured_output(schema)
+                            return structured_model.invoke(prompt)
+                        except Exception as e:
+                            logger.warning(
+                                f"LLMRedTeam: Failed to get structured output from {name_hint} model via langchain: {e}. "
+                                "Falling back to raw string generation and manual parsing."
+                            )
+                            resp = self.model.invoke(prompt)
+                            content = resp.content if hasattr(resp, "content") else str(resp)
+                            return _Wrapper.parse_json_to_schema(content, schema)
+                    else:
+                        resp = self.model.invoke(prompt)
+                        return resp.content if hasattr(resp, "content") else str(resp)
 
-                async def a_generate(self, prompt: str) -> str:
-                    resp = await self.model.ainvoke(prompt)
-                    return resp.content if hasattr(resp, "content") else str(resp)
+                async def a_generate(self, prompt: str, schema: Any = None, *args, **kwargs) -> Any:
+                    if schema is not None:
+                        try:
+                            structured_model = self.model.with_structured_output(schema)
+                            return await structured_model.ainvoke(prompt)
+                        except Exception as e:
+                            logger.warning(
+                                f"LLMRedTeam: Failed to get structured output from {name_hint} model via langchain: {e}. "
+                                "Falling back to raw string generation and manual parsing."
+                            )
+                            resp = await self.model.ainvoke(prompt)
+                            content = resp.content if hasattr(resp, "content") else str(resp)
+                            return _Wrapper.parse_json_to_schema(content, schema)
+                    else:
+                        resp = await self.model.ainvoke(prompt)
+                        return resp.content if hasattr(resp, "content") else str(resp)
 
                 def get_model_name(self) -> str:
                     return getattr(self.model, "model_name", name_hint)
+
+                @staticmethod
+                def parse_json_to_schema(text: str, schema: Any) -> Any:
+                    import re
+                    text_str = text.strip()
+                    try:
+                        if hasattr(schema, "model_validate_json"):
+                            return schema.model_validate_json(text_str)
+                        else:
+                            return schema.parse_raw(text_str)
+                    except Exception:
+                        pass
+
+                    # Regex 1: Markdown kod bloklarının (```json ... ```) içerisindeki JSON kısmını yakalama
+                    json_block_match = re.search(r"```json\s*(.*?)\s*```", text_str, re.DOTALL)
+                    if json_block_match:
+                        try:
+                            clean_content = json_block_match.group(1).strip()
+                            if hasattr(schema, "model_validate_json"):
+                                return schema.model_validate_json(clean_content)
+                            else:
+                                return schema.parse_raw(clean_content)
+                        except Exception:
+                            pass
+
+                    # Regex 2: Metin içinde süslü parantezler { ... } arasına sıkışmış olan JSON'ı yakalama
+                    braces_match = re.search(r"(\{.*\})", text_str, re.DOTALL)
+                    if braces_match:
+                        try:
+                            clean_content = braces_match.group(1).strip()
+                            if hasattr(schema, "model_validate_json"):
+                                return schema.model_validate_json(clean_content)
+                            else:
+                                return schema.parse_raw(clean_content)
+                        except Exception:
+                            pass
+
+                    # Son çare
+                    if hasattr(schema, "model_validate_json"):
+                        return schema.model_validate_json(text_str)
+                    else:
+                        return schema.parse_raw(text_str)
 
             return _Wrapper()
 


### PR DESCRIPTION
- expand LLM connection validation to accept Runnable-based LLM wrappers alongside BaseLanguageModel instances
- enable reasoning filter wrappers to participate in agent execution chains without type validation failures
- restore compatibility between ReactAgent and LLMReasoningFilterWrapper integrations
- prevent agent initialization errors when reasoning tag stripping is enabled on OpenAI-compatible models