### PR TITLE
Feature/workflow undo redo

### DIFF
--- a/client/app/components/canvas/FlowCanvas.tsx
+++ b/client/app/components/canvas/FlowCanvas.tsx
@@ -671,6 +671,15 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
     }
   }, [currentWorkflow?.name]);
 
+  useEffect(() => {
+    if (currentWorkflow?.updated_at) {
+      setLastAutoSave(new Date(currentWorkflow.updated_at));
+    } else {
+      setLastAutoSave(null);
+    }
+    setAutoSaveStatus("idle");
+  }, [currentWorkflow?.id, currentWorkflow?.updated_at]);
+
   // Clear chats and execution data when workflow changes to prevent accumulation
   useEffect(() => {
     if (currentWorkflow?.id) {
@@ -1019,6 +1028,7 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
 
         setCurrentWorkflow(newWorkflow);
         setHasUnsavedChanges(false);
+        setLastAutoSave(new Date());
         enqueueSnackbar(`Workflow "${workflowName}" created and saved!`, {
           variant: "success",
         });
@@ -1039,6 +1049,7 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
 
       // Only set unsaved changes to false after successful update
       setHasUnsavedChanges(false);
+      setLastAutoSave(new Date());
       enqueueSnackbar("Workflow saved successfully!", { variant: "success" });
     } catch (error: any) {
       console.error("Failed to save workflow:", error);

--- a/client/app/components/canvas/FlowCanvas.tsx
+++ b/client/app/components/canvas/FlowCanvas.tsx
@@ -314,6 +314,17 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
     setNodes,
     setEdges
   );
+  const [historyRevision, setHistoryRevision] = useState(0);
+
+  const handleUndo = useCallback(() => {
+    setHistoryRevision((revision) => revision + 1);
+    undo();
+  }, [undo]);
+
+  const handleRedo = useCallback(() => {
+    setHistoryRevision((revision) => revision + 1);
+    redo();
+  }, [redo]);
   const reactFlowWrapper = useRef<HTMLDivElement>(null);
   const hasInitializedEmptyCanvas = useRef(false);
   const isImportingRef = useRef(false);
@@ -422,6 +433,8 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
   }>({
     isOpen: false,
   });
+  const fullscreenModalRef = useRef(fullscreenModal);
+  fullscreenModalRef.current = fullscreenModal;
 
   const {
     currentWorkflow,
@@ -893,19 +906,23 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
 
       if (event.key.toLowerCase() === "z" && !event.shiftKey) {
         event.preventDefault();
-        undo();
+        handleUndo();
       } else if (
         event.key.toLowerCase() === "y" ||
         (event.key.toLowerCase() === "z" && event.shiftKey)
       ) {
         event.preventDefault();
-        redo();
+        handleRedo();
       }
     };
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [undo, redo]);
+  }, [handleUndo, handleRedo]);
+
+  const activeModalNode = fullscreenModal.nodeData
+    ? nodes.find((node) => node.id === fullscreenModal.nodeData.id) ?? fullscreenModal.nodeData
+    : null;
 
   // Clean up edges when nodes are deleted
   useEffect(() => {
@@ -1845,6 +1862,27 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
     [fullscreenModal.nodeData, setNodes]
   );
 
+  const handleNodeConfigChange = useCallback(
+    (values: Record<string, unknown>) => {
+      const nodeId = fullscreenModalRef.current.nodeData?.id;
+      if (!nodeId) return;
+
+      setNodes((nodes) =>
+        nodes.map((node) => {
+          if (node.id !== nodeId) return node;
+
+          const nextData = { ...node.data, ...values };
+          if (JSON.stringify(node.data) === JSON.stringify(nextData)) {
+            return node;
+          }
+
+          return { ...node, data: nextData };
+        })
+      );
+    },
+    [setNodes]
+  );
+
   // Handle fullscreen modal close
   const handleFullscreenModalClose = useCallback(() => {
     setFullscreenModal({ isOpen: false });
@@ -1885,8 +1923,8 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
         onWorkflowImported={(importedNodes, importedEdges) => {
           resetHistory(importedNodes, importedEdges);
         }}
-        onUndo={undo}
-        onRedo={redo}
+        onUndo={handleUndo}
+        onRedo={handleRedo}
         canUndo={canUndo}
         canRedo={canRedo}
         executionLoading={executionLoading}
@@ -2059,8 +2097,10 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
             isOpen={fullscreenModal.isOpen}
             onClose={handleFullscreenModalClose}
             nodeMetadata={fullscreenModal.nodeMetadata}
-            configData={fullscreenModal.nodeData?.data || {}}
+            configData={activeModalNode?.data || {}}
             onSave={handleFullscreenModalSave}
+            onConfigChange={handleNodeConfigChange}
+            historyRevision={historyRevision}
             onExecute={() =>
               handleStartNodeExecution(fullscreenModal.nodeData?.id || "")
             }

--- a/client/app/components/canvas/FlowCanvas.tsx
+++ b/client/app/components/canvas/FlowCanvas.tsx
@@ -5,6 +5,7 @@ import React, {
   useEffect,
   useMemo,
 } from "react";
+import { flushSync } from "react-dom";
 import { v4 as uuidv4 } from "uuid";
 import {
   useNodesState,
@@ -308,23 +309,32 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
   const { enqueueSnackbar } = useSnackbar();
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
-  const { undo, redo, canUndo, canRedo, resetHistory } = useWorkflowHistory(
+  const { undo, redo, canUndo, canRedo, resetHistory, flushRecording } = useWorkflowHistory(
     nodes,
     edges,
     setNodes,
     setEdges
   );
   const [historyRevision, setHistoryRevision] = useState(0);
+  const configFlushRef = useRef<(() => void) | null>(null);
 
   const handleUndo = useCallback(() => {
+    flushSync(() => {
+      configFlushRef.current?.();
+    });
+    flushRecording();
     setHistoryRevision((revision) => revision + 1);
     undo();
-  }, [undo]);
+  }, [undo, flushRecording]);
 
   const handleRedo = useCallback(() => {
+    flushSync(() => {
+      configFlushRef.current?.();
+    });
+    flushRecording();
     setHistoryRevision((revision) => revision + 1);
     redo();
-  }, [redo]);
+  }, [redo, flushRecording]);
   const reactFlowWrapper = useRef<HTMLDivElement>(null);
   const hasInitializedEmptyCanvas = useRef(false);
   const isImportingRef = useRef(false);
@@ -2101,6 +2111,7 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
             onSave={handleFullscreenModalSave}
             onConfigChange={handleNodeConfigChange}
             historyRevision={historyRevision}
+            configFlushRef={configFlushRef}
             onExecute={() =>
               handleStartNodeExecution(fullscreenModal.nodeData?.id || "")
             }

--- a/client/app/components/canvas/FlowCanvas.tsx
+++ b/client/app/components/canvas/FlowCanvas.tsx
@@ -848,7 +848,10 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
       if (event.key.toLowerCase() === "z" && !event.shiftKey) {
         event.preventDefault();
         undo();
-      } else if (event.key.toLowerCase() === "y") {
+      } else if (
+        event.key.toLowerCase() === "y" ||
+        (event.key.toLowerCase() === "z" && event.shiftKey)
+      ) {
         event.preventDefault();
         redo();
       }

--- a/client/app/components/canvas/FlowCanvas.tsx
+++ b/client/app/components/canvas/FlowCanvas.tsx
@@ -362,6 +362,40 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
   const [autoSaveStatus, setAutoSaveStatus] = useState<
     "idle" | "saving" | "saved" | "error"
   >("idle");
+  const saveStatusTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
+
+  const markSaveSuccess = useCallback((savedAt: Date = new Date()) => {
+    setLastAutoSave(savedAt);
+    setAutoSaveStatus("saved");
+    if (saveStatusTimeoutRef.current) {
+      clearTimeout(saveStatusTimeoutRef.current);
+    }
+    saveStatusTimeoutRef.current = setTimeout(() => {
+      setAutoSaveStatus("idle");
+      saveStatusTimeoutRef.current = null;
+    }, 3000);
+  }, []);
+
+  const markSaveError = useCallback(() => {
+    setAutoSaveStatus("error");
+    if (saveStatusTimeoutRef.current) {
+      clearTimeout(saveStatusTimeoutRef.current);
+    }
+    saveStatusTimeoutRef.current = setTimeout(() => {
+      setAutoSaveStatus("idle");
+      saveStatusTimeoutRef.current = null;
+    }, 5000);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (saveStatusTimeoutRef.current) {
+        clearTimeout(saveStatusTimeoutRef.current);
+      }
+    };
+  }, []);
 
   // Unsaved changes modal ref
   const unsavedChangesModalRef = useRef<HTMLDialogElement>(null);
@@ -672,13 +706,16 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
   }, [currentWorkflow?.name]);
 
   useEffect(() => {
-    if (currentWorkflow?.updated_at) {
-      setLastAutoSave(new Date(currentWorkflow.updated_at));
-    } else {
+    if (!currentWorkflow) {
       setLastAutoSave(null);
+      setAutoSaveStatus("idle");
+      return;
+    }
+    if (currentWorkflow.updated_at) {
+      setLastAutoSave(new Date(currentWorkflow.updated_at));
     }
     setAutoSaveStatus("idle");
-  }, [currentWorkflow?.id, currentWorkflow?.updated_at]);
+  }, [currentWorkflow?.id]);
 
   // Clear chats and execution data when workflow changes to prevent accumulation
   useEffect(() => {
@@ -1014,6 +1051,8 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
       return;
     }
 
+    setAutoSaveStatus("saving");
+
     if (!currentWorkflow) {
       try {
         const newWorkflow = await createWorkflow({
@@ -1028,7 +1067,11 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
 
         setCurrentWorkflow(newWorkflow);
         setHasUnsavedChanges(false);
-        setLastAutoSave(new Date());
+        markSaveSuccess(
+          newWorkflow.updated_at
+            ? new Date(newWorkflow.updated_at)
+            : new Date()
+        );
         enqueueSnackbar(`Workflow "${workflowName}" created and saved!`, {
           variant: "success",
         });
@@ -1036,26 +1079,30 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
         console.error("Failed to create workflow:", error);
         const errorMessage = error?.response?.data?.detail || error?.message || "Failed to create workflow";
         enqueueSnackbar(errorMessage, { variant: "error" });
+        markSaveError();
       }
       return;
     }
 
     try {
-      await updateWorkflow(currentWorkflow.id, {
+      const updatedWorkflow = await updateWorkflow(currentWorkflow.id, {
         name: workflowName,
         description: currentWorkflow.description,
         flow_data: flowData,
       });
 
-      // Only set unsaved changes to false after successful update
       setHasUnsavedChanges(false);
-      setLastAutoSave(new Date());
+      markSaveSuccess(
+        updatedWorkflow?.updated_at
+          ? new Date(updatedWorkflow.updated_at)
+          : new Date()
+      );
       enqueueSnackbar("Workflow saved successfully!", { variant: "success" });
     } catch (error: any) {
       console.error("Failed to save workflow:", error);
       const errorMessage = error?.response?.data?.detail || error?.message || "Failed to save workflow";
       enqueueSnackbar(errorMessage, { variant: "error" });
-      // Don't set hasUnsavedChanges to false on error
+      markSaveError();
     }
   }, [
     currentWorkflow,
@@ -1067,6 +1114,8 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
     setCurrentWorkflow,
     setHasUnsavedChanges,
     workflowName,
+    markSaveSuccess,
+    markSaveError,
   ]);
 
   // Context Menu Handlers
@@ -1152,41 +1201,33 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
         settings: currentWorkflow.flow_data?.settings,
       };
 
-      await updateWorkflow(currentWorkflow.id, {
+      const updatedWorkflow = await updateWorkflow(currentWorkflow.id, {
         name: workflowName,
         description: currentWorkflow.description,
         flow_data: flowData,
       });
 
       setHasUnsavedChanges(false);
-      setLastAutoSave(new Date());
-      setAutoSaveStatus("saved");
+      markSaveSuccess(
+        updatedWorkflow?.updated_at
+          ? new Date(updatedWorkflow.updated_at)
+          : new Date()
+      );
 
-      // Show subtle notification
       enqueueSnackbar("Auto-saved", {
         variant: "success",
         autoHideDuration: 2000,
         anchorOrigin: { vertical: "bottom", horizontal: "right" },
       });
-
-      // Reset status after 3 seconds
-      setTimeout(() => {
-        setAutoSaveStatus("idle");
-      }, 3000);
     } catch (error) {
       console.error("Auto-save failed:", error);
-      setAutoSaveStatus("error");
+      markSaveError();
 
       enqueueSnackbar("Auto-save failed", {
         variant: "error",
         autoHideDuration: 3000,
         anchorOrigin: { vertical: "bottom", horizontal: "right" },
       });
-
-      // Reset error status after 5 seconds
-      setTimeout(() => {
-        setAutoSaveStatus("idle");
-      }, 5000);
     }
   }, [
     autoSaveEnabled,
@@ -1198,6 +1239,8 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
     workflowName,
     setHasUnsavedChanges,
     enqueueSnackbar,
+    markSaveSuccess,
+    markSaveError,
   ]);
 
   // Auto-save timer effect

--- a/client/app/components/canvas/FlowCanvas.tsx
+++ b/client/app/components/canvas/FlowCanvas.tsx
@@ -57,6 +57,7 @@ import GenericNode from "../node";
 // Import config components
 import { config } from "../../lib/config";
 import { GenericNodeForm } from "../node";
+import { useWorkflowHistory, isEditableKeyboardTarget } from "../../lib/useWorkflowHistory";
 
 interface FlowCanvasProps {
   workflowId?: string;
@@ -307,6 +308,12 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
   const { enqueueSnackbar } = useSnackbar();
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
+  const { undo, redo, canUndo, canRedo, resetHistory } = useWorkflowHistory(
+    nodes,
+    edges,
+    setNodes,
+    setEdges
+  );
   const reactFlowWrapper = useRef<HTMLDivElement>(null);
   const hasInitializedEmptyCanvas = useRef(false);
   const isImportingRef = useRef(false);
@@ -682,21 +689,21 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
       // Sadece start node'u ekle
       const startNodeMeta = availableNodes.find((n) => n.name === "StartNode");
       if (startNodeMeta) {
-        setNodes([
-          {
-            id: "StartNode__" + crypto.randomUUID(),
-            type: "StartNode",
-            position: { x: 100, y: 100 },
-            data: {
-              name: "Start",
-              metadata: startNodeMeta,
-            },
+        const startNode = {
+          id: "StartNode__" + crypto.randomUUID(),
+          type: "StartNode",
+          position: { x: 100, y: 100 },
+          data: {
+            name: "Start",
+            metadata: startNodeMeta,
           },
-        ]);
+        };
+        setNodes([startNode]);
         hasInitializedEmptyCanvas.current = true;
+        resetHistory([startNode], []);
       }
     }
-  }, [availableNodes, currentWorkflow, nodes.length, setNodes]);
+  }, [availableNodes, currentWorkflow, nodes.length, setNodes, resetHistory]);
 
   useEffect(() => {
     if (currentWorkflow?.flow_data) {
@@ -749,16 +756,20 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
           (edge) => nodeIds.has(edge.source) && nodeIds.has(edge.target)
         );
         setEdges(validEdges);
+        resetHistory(enrichedNodes, validEdges);
       } else {
-        setEdges(edges || []);
+        const loadedEdges = edges || [];
+        setEdges(loadedEdges);
+        resetHistory(enrichedNodes, loadedEdges);
       }
     } else if (!isImportingRef.current) {
       setNodes([]);
       setEdges([]);
+      resetHistory([], []);
     }
     // Reset import flag after every useEffect run (self-healing)
     isImportingRef.current = false;
-  }, [currentWorkflow, availableNodes, customNodes]);
+  }, [currentWorkflow, availableNodes, customNodes, resetHistory]);
 
   useEffect(() => {
     if (currentWorkflow) {
@@ -827,6 +838,25 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
       );
     };
   }, [enqueueSnackbar]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!(event.ctrlKey || event.metaKey) || isEditableKeyboardTarget(event.target)) {
+        return;
+      }
+
+      if (event.key.toLowerCase() === "z" && !event.shiftKey) {
+        event.preventDefault();
+        undo();
+      } else if (event.key.toLowerCase() === "y") {
+        event.preventDefault();
+        redo();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [undo, redo]);
 
   // Clean up edges when nodes are deleted
   useEffect(() => {
@@ -1795,6 +1825,13 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
         updateWorkflowStatus={updateWorkflowStatus}
         updateWorkflowVisibility={updateWorkflowVisibility}
         onImportStart={() => { isImportingRef.current = true; }}
+        onWorkflowImported={(importedNodes, importedEdges) => {
+          resetHistory(importedNodes, importedEdges);
+        }}
+        onUndo={undo}
+        onRedo={redo}
+        canUndo={canUndo}
+        canRedo={canRedo}
         executionLoading={executionLoading}
         activeExecutionId={activeExecutionId}
         currentExecution={currentExecution}

--- a/client/app/components/common/FullscreenNodeModal.tsx
+++ b/client/app/components/common/FullscreenNodeModal.tsx
@@ -63,6 +63,7 @@ interface FullscreenNodeModalProps {
   onSave: (values: any) => void;
   onConfigChange?: (values: any) => void;
   historyRevision?: number;
+  configFlushRef?: React.MutableRefObject<(() => void) | null>;
   onExecute?: () => void; // New execute function
   ConfigComponent: React.ComponentType<{
     configData: any;
@@ -101,6 +102,7 @@ export default function FullscreenNodeModal({
   onSave,
   onConfigChange,
   historyRevision = 0,
+  configFlushRef,
   onExecute,
   ConfigComponent,
   executionData,
@@ -109,6 +111,7 @@ export default function FullscreenNodeModal({
   const [formKey, setFormKey] = useState(0);
   const configChangeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const configChangeRevisionRef = useRef(0);
+  const pendingConfigValuesRef = useRef<Record<string, unknown> | null>(null);
   const prevHistoryRevisionRef = useRef(historyRevision);
   const nodeAliasRef = useRef(
     configData?.name || nodeMetadata.display_name || nodeMetadata.name
@@ -128,6 +131,8 @@ export default function FullscreenNodeModal({
     (values: Record<string, unknown>) => {
       if (!onConfigChange) return;
 
+      pendingConfigValuesRef.current = values;
+
       if (configChangeTimerRef.current) {
         clearTimeout(configChangeTimerRef.current);
       }
@@ -138,10 +143,29 @@ export default function FullscreenNodeModal({
         configChangeTimerRef.current = null;
         if (scheduledRevision !== configChangeRevisionRef.current) return;
         onConfigChange(values);
-      }, 400);
+      }, 200);
     },
     [onConfigChange]
   );
+
+  const flushConfigChange = useCallback(() => {
+    if (configChangeTimerRef.current) {
+      clearTimeout(configChangeTimerRef.current);
+      configChangeTimerRef.current = null;
+    }
+
+    if (onConfigChange && pendingConfigValuesRef.current) {
+      onConfigChange(pendingConfigValuesRef.current);
+    }
+  }, [onConfigChange]);
+
+  useEffect(() => {
+    if (!configFlushRef) return;
+    configFlushRef.current = flushConfigChange;
+    return () => {
+      configFlushRef.current = null;
+    };
+  }, [configFlushRef, flushConfigChange]);
 
   const handleFormChange = useCallback(
     (values: Record<string, unknown>) => {
@@ -187,7 +211,10 @@ export default function FullscreenNodeModal({
     nodeAliasRef.current = value;
     setNodeAlias(value);
     setNodeAliasError(validateNodeAlias(value));
-    scheduleConfigChange({ name: value });
+    scheduleConfigChange({
+      ...(pendingConfigValuesRef.current ?? configValues),
+      name: value,
+    });
   };
 
   // Helper function to filter out metadata and system fields from node data

--- a/client/app/components/common/FullscreenNodeModal.tsx
+++ b/client/app/components/common/FullscreenNodeModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import {
   X,
   Settings,
@@ -61,11 +61,14 @@ interface FullscreenNodeModalProps {
   nodeMetadata: NodeMetadata;
   configData: any;
   onSave: (values: any) => void;
+  onConfigChange?: (values: any) => void;
+  historyRevision?: number;
   onExecute?: () => void; // New execute function
   ConfigComponent: React.ComponentType<{
     configData: any;
     onSave: (values: any) => void;
     onCancel: () => void;
+    onChange?: (values: any) => void;
   }>;
   executionData?: {
     nodeId: string;
@@ -96,15 +99,56 @@ export default function FullscreenNodeModal({
   nodeMetadata,
   configData,
   onSave,
+  onConfigChange,
+  historyRevision = 0,
   onExecute,
   ConfigComponent,
   executionData,
 }: FullscreenNodeModalProps) {
   const [configValues, setConfigValues] = useState(configData);
-  const [nodeAlias, setNodeAlias] = useState(
+  const [formKey, setFormKey] = useState(0);
+  const configChangeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const configChangeRevisionRef = useRef(0);
+  const prevHistoryRevisionRef = useRef(historyRevision);
+  const nodeAliasRef = useRef(
     configData?.name || nodeMetadata.display_name || nodeMetadata.name
   );
+  const [nodeAlias, setNodeAlias] = useState(nodeAliasRef.current);
   const [nodeAliasError, setNodeAliasError] = useState<string | null>(null);
+
+  const cancelPendingConfigChange = useCallback(() => {
+    configChangeRevisionRef.current += 1;
+    if (configChangeTimerRef.current) {
+      clearTimeout(configChangeTimerRef.current);
+      configChangeTimerRef.current = null;
+    }
+  }, []);
+
+  const scheduleConfigChange = useCallback(
+    (values: Record<string, unknown>) => {
+      if (!onConfigChange) return;
+
+      if (configChangeTimerRef.current) {
+        clearTimeout(configChangeTimerRef.current);
+      }
+
+      const scheduledRevision = configChangeRevisionRef.current;
+
+      configChangeTimerRef.current = setTimeout(() => {
+        configChangeTimerRef.current = null;
+        if (scheduledRevision !== configChangeRevisionRef.current) return;
+        onConfigChange(values);
+      }, 400);
+    },
+    [onConfigChange]
+  );
+
+  const handleFormChange = useCallback(
+    (values: Record<string, unknown>) => {
+      scheduleConfigChange({ ...values, name: nodeAliasRef.current });
+    },
+    [scheduleConfigChange]
+  );
 
   const inputDataToDisplay = executionData?.inputs;
 
@@ -140,8 +184,10 @@ export default function FullscreenNodeModal({
 
   const handleNodeAliasChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
+    nodeAliasRef.current = value;
     setNodeAlias(value);
     setNodeAliasError(validateNodeAlias(value));
+    scheduleConfigChange({ name: value });
   };
 
   // Helper function to filter out metadata and system fields from node data
@@ -551,10 +597,27 @@ export default function FullscreenNodeModal({
 
   useEffect(() => {
     setConfigValues(configData);
-    setNodeAlias(
-      configData?.name || nodeMetadata.display_name || nodeMetadata.name
-    );
-  }, [configData, nodeMetadata.display_name, nodeMetadata.name]);
+    const alias =
+      configData?.name || nodeMetadata.display_name || nodeMetadata.name;
+    nodeAliasRef.current = alias;
+    setNodeAlias(alias);
+    setNodeAliasError(null);
+    // Sync workflow state into the form only after undo/redo — not on live edits.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [historyRevision]);
+
+  useEffect(() => {
+    if (prevHistoryRevisionRef.current === historyRevision) return;
+    prevHistoryRevisionRef.current = historyRevision;
+    cancelPendingConfigChange();
+    setFormKey((key) => key + 1);
+  }, [historyRevision, cancelPendingConfigChange]);
+
+  useEffect(() => {
+    return () => {
+      cancelPendingConfigChange();
+    };
+  }, [cancelPendingConfigChange]);
 
   const handleSave = (values: any) => {
     try {
@@ -614,6 +677,7 @@ export default function FullscreenNodeModal({
         className="fixed inset-0 z-50 bg-black/80 backdrop-blur-sm"
         onKeyDown={handleKeyDown}
         tabIndex={-1}
+        data-workflow-history
       >
         <div className="w-full h-full flex flex-col bg-gray-900">
           {/* Header */}
@@ -758,9 +822,11 @@ export default function FullscreenNodeModal({
                 <div className="flex-1 p-3 overflow-y-auto">
                   <div className="max-w-full">
                     <ConfigComponent
+                      key={formKey}
                       configData={configValues}
                       onSave={handleSave}
                       onCancel={onClose}
+                      onChange={handleFormChange}
                     />
                   </div>
                 </div>

--- a/client/app/components/common/Navbar.tsx
+++ b/client/app/components/common/Navbar.tsx
@@ -296,7 +296,6 @@ const Navbar: React.FC<NavbarProps> = ({
               onChange={(e) => setWorkflowName(e.target.value)}
               onBlur={handleBlur}
               placeholder="Dosya Adı"
-              data-native-undo="true"
               className="text-lg font-medium text-white/90 bg-transparent px-4 py-1.5 rounded-md border border-transparent hover:border-white/20 focus:border-white/30 hover:bg-white/5 focus:bg-white/10 focus:outline-none transition-all duration-300 text-center w-full max-w-[400px] focus:max-w-[800px]"
             />
           </div>

--- a/client/app/components/common/Navbar.tsx
+++ b/client/app/components/common/Navbar.tsx
@@ -274,6 +274,31 @@ const Navbar: React.FC<NavbarProps> = ({
     autoSaveStatus &&
     (autoSaveStatus !== "idle" || lastAutoSave != null);
 
+  const formatSavedTime = (date: Date) =>
+    date.toLocaleTimeString("tr-TR", {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+
+  const saveStatusLabel =
+    autoSaveStatus === "saving"
+      ? "Saving..."
+      : autoSaveStatus === "saved"
+        ? "Saved"
+        : autoSaveStatus === "error"
+          ? "Error"
+          : lastAutoSave
+            ? `Last saved: ${formatSavedTime(lastAutoSave)}`
+            : null;
+
+  const showExecutionStatus =
+    executionLoading ||
+    !!activeExecutionId ||
+    (currentExecution &&
+      (currentExecution.status === "running" ||
+        currentExecution.status === "pending"));
+
   return (
     <>
       <header className="w-full h-16 bg-[#18181B] text-foreground fixed top-0 left-0 z-20">
@@ -305,32 +330,112 @@ const Navbar: React.FC<NavbarProps> = ({
           </div>
 
           <div className="flex items-center gap-2 relative">
-            {(executionLoading || activeExecutionId || (currentExecution && (currentExecution.status === "running" || currentExecution.status === "pending"))) && (
-              <div className="flex items-center gap-2 text-gray-400">
-                <Loader className="w-3.5 h-3.5 animate-spin" />
-                <span className="text-xs font-medium">Executing...</span>
-                {(activeExecutionId || (currentExecution && (currentExecution.status === "running" || currentExecution.status === "pending") ? currentExecution.id : null)) && onCancelExecution && (
-                  <button
-                    onClick={async () => {
-                      const runId = activeExecutionId || (currentExecution ? currentExecution.id : null);
-                      if (runId && confirm("Are you sure you want to cancel this execution?")) {
-                        try {
-                          await onCancelExecution(runId);
-                          enqueueSnackbar("Workflow execution cancel requested.", { variant: "info" });
-                        } catch (err) {
-                          console.error("Failed to cancel execution:", err);
-                          enqueueSnackbar("Failed to cancel execution.", { variant: "error" });
-                        }
-                      }
-                    }}
-                    className="ml-1 px-2 py-0.5 text-[11px] text-red-500 hover:text-red-400 border border-red-500/30 hover:border-red-500/50 rounded transition-colors cursor-pointer"
-                    title="Cancel Execution"
-                  >
-                    Cancel
-                  </button>
+            <div
+              className={`grid transition-[grid-template-columns] duration-200 ease-out ${
+                showExecutionStatus ? "grid-cols-[1fr]" : "grid-cols-[0fr]"
+              }`}
+            >
+              <div className="overflow-hidden min-w-0">
+                {showExecutionStatus && (
+                  <div className="flex items-center gap-2 text-gray-400 shrink-0 whitespace-nowrap">
+                    <Loader className="w-3.5 h-3.5 animate-spin" />
+                    <span className="text-xs font-medium">Executing...</span>
+                    {(activeExecutionId || (currentExecution && (currentExecution.status === "running" || currentExecution.status === "pending") ? currentExecution.id : null)) && onCancelExecution && (
+                      <button
+                        onClick={async () => {
+                          const runId = activeExecutionId || (currentExecution ? currentExecution.id : null);
+                          if (runId && confirm("Are you sure you want to cancel this execution?")) {
+                            try {
+                              await onCancelExecution(runId);
+                              enqueueSnackbar("Workflow execution cancel requested.", { variant: "info" });
+                            } catch (err) {
+                              console.error("Failed to cancel execution:", err);
+                              enqueueSnackbar("Failed to cancel execution.", { variant: "error" });
+                            }
+                          }
+                        }}
+                        className="px-2 py-0.5 text-[11px] text-red-500 hover:text-red-400 border border-red-500/30 hover:border-red-500/50 rounded transition-colors cursor-pointer"
+                        title="Cancel Execution"
+                      >
+                        Cancel
+                      </button>
+                    )}
+                  </div>
                 )}
               </div>
-            )}
+            </div>
+
+            <div
+              className={`grid transition-[grid-template-columns] duration-200 ease-out ${
+                showAutoSaveStatus ? "grid-cols-[1fr]" : "grid-cols-[0fr]"
+              }`}
+              aria-live="polite"
+            >
+              <div className="overflow-hidden min-w-0">
+                {saveStatusLabel && (
+                  <div
+                    className={`flex items-center gap-1 text-xs whitespace-nowrap tabular-nums transition-opacity duration-200 ${
+                      autoSaveStatus === "error"
+                        ? "text-red-400"
+                        : autoSaveStatus === "idle"
+                          ? "text-white/60"
+                          : "text-green-400"
+                    }`}
+                    title={
+                      lastAutoSave && autoSaveStatus === "idle"
+                        ? `Last saved: ${formatSavedTime(lastAutoSave)}`
+                        : undefined
+                    }
+                  >
+                    {autoSaveStatus !== "idle" && (
+                      <div
+                        className={`w-2 h-2 rounded-full shrink-0 ${
+                          autoSaveStatus === "error"
+                            ? "bg-red-400"
+                            : "bg-green-400"
+                        } ${autoSaveStatus === "saving" ? "animate-pulse" : ""}`}
+                      />
+                    )}
+                    <span>{saveStatusLabel}</span>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="flex items-center shrink-0">
+              <button
+                type="button"
+                className={`p-0 border-0 bg-transparent rounded-4xl transition duration-500 ${
+                  canUndo ? "cursor-pointer hover:bg-muted" : "cursor-not-allowed"
+                }`}
+                onClick={canUndo ? onUndo : undefined}
+                disabled={!canUndo}
+                aria-label="Undo (Ctrl+Z)"
+                title="Undo (Ctrl+Z)"
+              >
+                <Undo2
+                  className={`w-10 h-10 p-2 ${
+                    canUndo ? "text-white" : "text-white/30"
+                  }`}
+                />
+              </button>
+              <button
+                type="button"
+                className={`p-0 border-0 bg-transparent rounded-4xl transition duration-500 ${
+                  canRedo ? "cursor-pointer hover:bg-muted" : "cursor-not-allowed"
+                }`}
+                onClick={canRedo ? onRedo : undefined}
+                disabled={!canRedo}
+                aria-label="Redo (Ctrl+Y)"
+                title="Redo (Ctrl+Y)"
+              >
+                <Redo2
+                  className={`w-10 h-10 p-2 ${
+                    canRedo ? "text-white" : "text-white/30"
+                  }`}
+                />
+              </button>
+            </div>
 
             {currentWorkflow && updateWorkflowVisibility && (
               <ToggleSwitch
@@ -358,145 +463,81 @@ const Navbar: React.FC<NavbarProps> = ({
               />
             )}
 
-            {showAutoSaveStatus && (
-              <div
-                className="min-w-[10.5rem] flex items-center justify-end shrink-0"
-                aria-live="polite"
-              >
-                {autoSaveStatus === "saving" && (
-                  <div className="flex items-center gap-1 text-green-400">
-                    <div className="w-2 h-2 bg-green-400 rounded-full animate-pulse" />
-                    <span className="text-xs whitespace-nowrap">Saving...</span>
-                  </div>
-                )}
-                {autoSaveStatus === "saved" && (
-                  <div className="flex items-center gap-1 text-green-400">
-                    <div className="w-2 h-2 bg-green-400 rounded-full" />
-                    <span className="text-xs whitespace-nowrap">Saved</span>
-                  </div>
-                )}
-                {autoSaveStatus === "error" && (
-                  <div className="flex items-center gap-1 text-red-400">
-                    <div className="w-2 h-2 bg-red-400 rounded-full" />
-                    <span className="text-xs whitespace-nowrap">Error</span>
-                  </div>
-                )}
-                {lastAutoSave && autoSaveStatus === "idle" && (
-                  <div
-                    className="flex items-center gap-1 text-white/60 text-xs whitespace-nowrap"
-                    title={`Last saved: ${lastAutoSave.toLocaleTimeString()}`}
-                  >
-                    Last saved: {lastAutoSave.toLocaleTimeString()}
-                  </div>
-                )}
-              </div>
-            )}
-
-            <button
-              type="button"
-              className={`p-0 border-0 bg-transparent rounded-4xl transition duration-500 ${
-                canUndo ? "cursor-pointer hover:bg-muted" : "cursor-not-allowed"
-              }`}
-              onClick={canUndo ? onUndo : undefined}
-              disabled={!canUndo}
-              aria-label="Undo (Ctrl+Z)"
-              title="Undo (Ctrl+Z)"
-            >
-              <Undo2
-                className={`w-10 h-10 p-2 ${
-                  canUndo ? "text-white" : "text-white/30"
-                }`}
-              />
-            </button>
-            <button
-              type="button"
-              className={`p-0 border-0 bg-transparent rounded-4xl transition duration-500 ${
-                canRedo ? "cursor-pointer hover:bg-muted" : "cursor-not-allowed"
-              }`}
-              onClick={canRedo ? onRedo : undefined}
-              disabled={!canRedo}
-              aria-label="Redo (Ctrl+Y)"
-              title="Redo (Ctrl+Y)"
-            >
-              <Redo2
-                className={`w-10 h-10 p-2 ${
-                  canRedo ? "text-white" : "text-white/30"
-                }`}
-              />
-            </button>
             {isLoading ? (
-              <Loader className="animate-spin text-white w-10 h-10 p-2 rounded-4xl" />
+              <Loader className="animate-spin text-white w-10 h-10 p-2 rounded-4xl shrink-0" />
             ) : (
               <Save
-                className="text-white cursor-pointer w-10 h-10 p-2 rounded-4xl hover:bg-muted transition duration-500"
+                className="text-white cursor-pointer w-10 h-10 p-2 rounded-4xl hover:bg-muted transition duration-500 shrink-0"
                 onClick={onSave}
               />
             )}
+
             {onAutoSaveSettings && (
               <Clock
-                className="text-white cursor-pointer w-10 h-10 p-2 rounded-4xl hover:bg-muted transition duration-500"
+                className="text-white cursor-pointer w-10 h-10 p-2 rounded-4xl hover:bg-muted transition duration-500 shrink-0"
                 onClick={onAutoSaveSettings}
               />
             )}
-              <div className="relative" ref={dropdownRef}>
-                <Settings
-                  className="text-white cursor-pointer w-10 h-10 p-2 rounded-4xl hover:bg-muted transition duration-500"
-                  onClick={() => setIsDropdownOpen(!isDropdownOpen)}
-                />
-                {isDropdownOpen && (
-                  <div
-                    className="absolute right-0 mt-2 w-56 bg-white border border-gray-200 rounded-lg shadow-lg z-50 p-2"
+
+            <div className="relative shrink-0" ref={dropdownRef}>
+              <Settings
+                className="text-white cursor-pointer w-10 h-10 p-2 rounded-4xl hover:bg-muted transition duration-500"
+                onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+              />
+              {isDropdownOpen && (
+                <div
+                  className="absolute right-0 mt-2 w-56 bg-white border border-gray-200 rounded-lg shadow-lg z-50 p-2"
+                >
+                  <button
+                    className="w-full font-medium text-black text-left px-3 py-2 hover:bg-blue-50 rounded flex gap-3 items-center transition-colors"
+                    onClick={() => fileInputRef.current?.click()}
                   >
-                    <button
-                      className="w-full font-medium text-black text-left px-3 py-2 hover:bg-blue-50 rounded flex gap-3 items-center transition-colors"
-                      onClick={() => fileInputRef.current?.click()}
-                    >
-                      <FileUp className="w-5 h-5 text-blue-600" />
-                      Load Workflow
-                    </button>
-                    <input ref={fileInputRef} type="file" accept="application/json" className="hidden" onChange={handleLoad} />
-                    
-                    <button className="w-full text-left px-3 py-2 text-black hover:bg-gray-100 rounded flex gap-3 items-center" onClick={handleExport}>
-                      <Download className="w-5 h-5" />
-                      Export JSON
-                    </button>
+                    <FileUp className="w-5 h-5 text-blue-600" />
+                    Load Workflow
+                  </button>
+                  <input ref={fileInputRef} type="file" accept="application/json" className="hidden" onChange={handleLoad} />
+                  
+                  <button className="w-full text-left px-3 py-2 text-black hover:bg-gray-100 rounded flex gap-3 items-center" onClick={handleExport}>
+                    <Download className="w-5 h-5" />
+                    Export JSON
+                  </button>
 
-                    <button
-                      className="w-full text-left px-3 py-2 text-black hover:bg-gray-100 rounded flex gap-3 items-center"
-                      onClick={() => {
-                        setIsDropdownOpen(false);
-                        setTimeout(() => widgetExportDialogRef.current?.showModal(), 100);
-                      }}
-                    >
-                      <MessageSquare className="w-5 h-5" />
-                      Export Widget
-                    </button>
+                  <button
+                    className="w-full text-left px-3 py-2 text-black hover:bg-gray-100 rounded flex gap-3 items-center"
+                    onClick={() => {
+                      setIsDropdownOpen(false);
+                      setTimeout(() => widgetExportDialogRef.current?.showModal(), 100);
+                    }}
+                  >
+                    <MessageSquare className="w-5 h-5" />
+                    Export Widget
+                  </button>
 
-                    <button
-                      className="w-full text-left px-3 py-2 text-black hover:bg-red-50 hover:text-red-600 rounded flex gap-3 items-center transition-colors"
-                      onClick={() => {
-                        setIsDropdownOpen(false);
-                        setIsErrorModalOpen(true);
-                        setTimeout(() => errorWorkflowDialogRef.current?.showModal(), 100);
-                      }}
-                    >
-                      <ShieldAlert className="w-5 h-5" />
-                      Error Handler
-                    </button>
+                  <button
+                    className="w-full text-left px-3 py-2 text-black hover:bg-red-50 hover:text-red-600 rounded flex gap-3 items-center transition-colors"
+                    onClick={() => {
+                      setIsDropdownOpen(false);
+                      setIsErrorModalOpen(true);
+                      setTimeout(() => errorWorkflowDialogRef.current?.showModal(), 100);
+                    }}
+                  >
+                    <ShieldAlert className="w-5 h-5" />
+                    Error Handler
+                  </button>
 
-                    <button
-                      className="w-full text-left px-3 py-2 hover:bg-red-50 text-red-600 rounded flex gap-3 items-center transition-colors"
-                      onClick={() => {
-                        setIsDropdownOpen(false);
-                        setTimeout(() => deleteDialogRef.current?.showModal(), 100);
-                      }}
-                    >
-                      <Trash className="w-5 h-5" />
-                      Delete Workflow
-                    </button>
-                  </div>
-                )}
-              </div>
+                  <button
+                    className="w-full text-left px-3 py-2 hover:bg-red-50 text-red-600 rounded flex gap-3 items-center transition-colors"
+                    onClick={() => {
+                      setIsDropdownOpen(false);
+                      setTimeout(() => deleteDialogRef.current?.showModal(), 100);
+                    }}
+                  >
+                    <Trash className="w-5 h-5" />
+                    Delete Workflow
+                  </button>
+                </div>
+              )}
+            </div>
           </div>
         </nav>
       </header>

--- a/client/app/components/common/Navbar.tsx
+++ b/client/app/components/common/Navbar.tsx
@@ -270,6 +270,10 @@ const Navbar: React.FC<NavbarProps> = ({
     deleteDialogRef.current?.close();
   };
 
+  const showAutoSaveStatus =
+    autoSaveStatus &&
+    (autoSaveStatus !== "idle" || lastAutoSave != null);
+
   return (
     <>
       <header className="w-full h-16 bg-[#18181B] text-foreground fixed top-0 left-0 z-20">
@@ -300,7 +304,7 @@ const Navbar: React.FC<NavbarProps> = ({
             />
           </div>
 
-          <div className="flex items-center space-x-4 gap-2 relative">
+          <div className="flex items-center gap-2 relative">
             {(executionLoading || activeExecutionId || (currentExecution && (currentExecution.status === "running" || currentExecution.status === "pending"))) && (
               <div className="flex items-center gap-2 text-gray-400">
                 <Loader className="w-3.5 h-3.5 animate-spin" />
@@ -330,6 +334,7 @@ const Navbar: React.FC<NavbarProps> = ({
 
             {currentWorkflow && updateWorkflowVisibility && (
               <ToggleSwitch
+                theme="dark"
                 isActive={currentWorkflow.is_public ?? false}
                 disabled={isPublicTogglePending}
                 onToggle={async (isPublic) => {
@@ -349,100 +354,97 @@ const Navbar: React.FC<NavbarProps> = ({
                 }}
                 size="sm"
                 label="Activity"
-                description={currentWorkflow.is_public ? "Active" : "Inactive"}
+                description={currentWorkflow.is_public ? "Active" : undefined}
               />
             )}
 
-            <div className="flex items-center gap-2">
-              {autoSaveStatus && (
-                <div
-                  className="min-w-[5.5rem] flex items-center justify-end shrink-0"
-                  aria-live="polite"
-                >
-                  {autoSaveStatus === "saving" && (
-                    <div className="flex items-center gap-1 text-green-400">
-                      <div className="w-2 h-2 bg-green-400 rounded-full animate-pulse" />
-                      <span className="text-xs whitespace-nowrap">Saving...</span>
-                    </div>
-                  )}
-                  {autoSaveStatus === "saved" && (
-                    <div className="flex items-center gap-1 text-green-400">
-                      <div className="w-2 h-2 bg-green-400 rounded-full" />
-                      <span className="text-xs whitespace-nowrap">Saved</span>
-                    </div>
-                  )}
-                  {autoSaveStatus === "error" && (
-                    <div className="flex items-center gap-1 text-red-400">
-                      <div className="w-2 h-2 bg-red-400 rounded-full" />
-                      <span className="text-xs whitespace-nowrap">Error</span>
-                    </div>
-                  )}
-                  {lastAutoSave && autoSaveStatus === "idle" && (
-                    <div
-                      className="flex items-center gap-1 text-gray-400 text-xs truncate max-w-[8rem]"
-                      title={`Last saved: ${lastAutoSave.toLocaleTimeString()}`}
-                    >
-                      <span className="truncate">
-                        Last saved: {lastAutoSave.toLocaleTimeString()}
-                      </span>
-                    </div>
-                  )}
-                </div>
-              )}
-              <button
-                type="button"
-                className={`p-0 border-0 bg-transparent rounded-4xl transition duration-500 ${
-                  canUndo ? "cursor-pointer hover:bg-muted" : "cursor-not-allowed"
-                }`}
-                onClick={canUndo ? onUndo : undefined}
-                disabled={!canUndo}
-                aria-label="Undo (Ctrl+Z)"
-                title="Undo (Ctrl+Z)"
+            {showAutoSaveStatus && (
+              <div
+                className="min-w-[10.5rem] flex items-center justify-end shrink-0"
+                aria-live="polite"
               >
-                <Undo2
-                  className={`w-10 h-10 p-2 ${
-                    canUndo ? "text-white" : "text-white/30"
-                  }`}
-                />
-              </button>
-              <button
-                type="button"
-                className={`p-0 border-0 bg-transparent rounded-4xl transition duration-500 ${
-                  canRedo ? "cursor-pointer hover:bg-muted" : "cursor-not-allowed"
+                {autoSaveStatus === "saving" && (
+                  <div className="flex items-center gap-1 text-green-400">
+                    <div className="w-2 h-2 bg-green-400 rounded-full animate-pulse" />
+                    <span className="text-xs whitespace-nowrap">Saving...</span>
+                  </div>
+                )}
+                {autoSaveStatus === "saved" && (
+                  <div className="flex items-center gap-1 text-green-400">
+                    <div className="w-2 h-2 bg-green-400 rounded-full" />
+                    <span className="text-xs whitespace-nowrap">Saved</span>
+                  </div>
+                )}
+                {autoSaveStatus === "error" && (
+                  <div className="flex items-center gap-1 text-red-400">
+                    <div className="w-2 h-2 bg-red-400 rounded-full" />
+                    <span className="text-xs whitespace-nowrap">Error</span>
+                  </div>
+                )}
+                {lastAutoSave && autoSaveStatus === "idle" && (
+                  <div
+                    className="flex items-center gap-1 text-gray-400 text-xs whitespace-nowrap"
+                    title={`Last saved: ${lastAutoSave.toLocaleTimeString()}`}
+                  >
+                    Last saved: {lastAutoSave.toLocaleTimeString()}
+                  </div>
+                )}
+              </div>
+            )}
+
+            <button
+              type="button"
+              className={`p-0 border-0 bg-transparent rounded-4xl transition duration-500 ${
+                canUndo ? "cursor-pointer hover:bg-muted" : "cursor-not-allowed"
+              }`}
+              onClick={canUndo ? onUndo : undefined}
+              disabled={!canUndo}
+              aria-label="Undo (Ctrl+Z)"
+              title="Undo (Ctrl+Z)"
+            >
+              <Undo2
+                className={`w-10 h-10 p-2 ${
+                  canUndo ? "text-white" : "text-white/30"
                 }`}
-                onClick={canRedo ? onRedo : undefined}
-                disabled={!canRedo}
-                aria-label="Redo (Ctrl+Y)"
-                title="Redo (Ctrl+Y)"
-              >
-                <Redo2
-                  className={`w-10 h-10 p-2 ${
-                    canRedo ? "text-white" : "text-white/30"
-                  }`}
-                />
-              </button>
-              {isLoading ? (
-                <Loader className="animate-spin text-white w-10 h-10 p-2 rounded-4xl" />
-              ) : (
-                <Save
-                  className="text-white cursor-pointer w-10 h-10 p-2 rounded-4xl hover:bg-muted transition duration-500"
-                  onClick={onSave}
-                />
-              )}
-              {onAutoSaveSettings && (
-                <Clock
-                  className="text-white cursor-pointer w-10 h-10 p-2 rounded-4xl hover:bg-muted transition duration-500"
-                  onClick={onAutoSaveSettings}
-                />
-              )}
-              <div className="relative">
+              />
+            </button>
+            <button
+              type="button"
+              className={`p-0 border-0 bg-transparent rounded-4xl transition duration-500 ${
+                canRedo ? "cursor-pointer hover:bg-muted" : "cursor-not-allowed"
+              }`}
+              onClick={canRedo ? onRedo : undefined}
+              disabled={!canRedo}
+              aria-label="Redo (Ctrl+Y)"
+              title="Redo (Ctrl+Y)"
+            >
+              <Redo2
+                className={`w-10 h-10 p-2 ${
+                  canRedo ? "text-white" : "text-white/30"
+                }`}
+              />
+            </button>
+            {isLoading ? (
+              <Loader className="animate-spin text-white w-10 h-10 p-2 rounded-4xl" />
+            ) : (
+              <Save
+                className="text-white cursor-pointer w-10 h-10 p-2 rounded-4xl hover:bg-muted transition duration-500"
+                onClick={onSave}
+              />
+            )}
+            {onAutoSaveSettings && (
+              <Clock
+                className="text-white cursor-pointer w-10 h-10 p-2 rounded-4xl hover:bg-muted transition duration-500"
+                onClick={onAutoSaveSettings}
+              />
+            )}
+              <div className="relative" ref={dropdownRef}>
                 <Settings
                   className="text-white cursor-pointer w-10 h-10 p-2 rounded-4xl hover:bg-muted transition duration-500"
                   onClick={() => setIsDropdownOpen(!isDropdownOpen)}
                 />
                 {isDropdownOpen && (
                   <div
-                    ref={dropdownRef}
                     className="absolute right-0 mt-2 w-56 bg-white border border-gray-200 rounded-lg shadow-lg z-50 p-2"
                   >
                     <button
@@ -495,7 +497,6 @@ const Navbar: React.FC<NavbarProps> = ({
                   </div>
                 )}
               </div>
-            </div>
           </div>
         </nav>
       </header>

--- a/client/app/components/common/Navbar.tsx
+++ b/client/app/components/common/Navbar.tsx
@@ -64,7 +64,7 @@ const Navbar: React.FC<NavbarProps> = ({
   autoSaveStatus,
   lastAutoSave,
   onAutoSaveSettings,
-  updateWorkflowVisibility,
+  updateWorkflowStatus,
   onImportStart,
   onWorkflowImported,
   onUndo,
@@ -79,7 +79,6 @@ const Navbar: React.FC<NavbarProps> = ({
   const { enqueueSnackbar } = useSnackbar();
   const navigate = useNavigate();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-  const [isPublicTogglePending, setIsPublicTogglePending] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const deleteDialogRef = useRef<HTMLDialogElement>(null);
@@ -302,8 +301,8 @@ const Navbar: React.FC<NavbarProps> = ({
   return (
     <>
       <header className="w-full h-16 bg-[#18181B] text-foreground fixed top-0 left-0 z-20">
-        <nav className="flex justify-between items-center p-4 bg-background text-foreground m-auto">
-          <div className="flex items-center gap-2">
+        <nav className="relative flex items-center p-4 bg-background text-foreground m-auto">
+          <div className="flex items-center gap-2 z-10">
             <Link
               to="/workflows"
               className="flex items-center"
@@ -318,51 +317,51 @@ const Navbar: React.FC<NavbarProps> = ({
             </Link>
           </div>
 
-          <div className="flex-1 flex justify-center items-center px-10">
+          <div className="absolute inset-x-0 flex justify-center items-center px-48 pointer-events-none z-0">
             <input
               type="text"
               value={workflowName}
               onChange={(e) => setWorkflowName(e.target.value)}
               onBlur={handleBlur}
               placeholder="Dosya Adı"
-              className="text-lg font-medium text-white/90 bg-transparent px-4 py-1.5 rounded-md border border-transparent hover:border-white/20 focus:border-white/30 hover:bg-white/5 focus:bg-white/10 focus:outline-none transition-all duration-300 text-center w-full max-w-[400px] focus:max-w-[800px]"
+              className="pointer-events-auto text-lg font-medium text-white/90 bg-transparent px-4 py-1.5 rounded-md border border-transparent hover:border-white/20 focus:border-white/30 hover:bg-white/5 focus:bg-white/10 focus:outline-none transition-all duration-300 text-center w-full max-w-[400px] focus:max-w-[800px]"
             />
           </div>
 
-          <div className="flex items-center gap-2 relative">
-            <div
-              className={`grid transition-[grid-template-columns] duration-200 ease-out ${
-                showExecutionStatus ? "grid-cols-[1fr]" : "grid-cols-[0fr]"
-              }`}
-            >
-              <div className="overflow-hidden min-w-0">
-                {showExecutionStatus && (
-                  <div className="flex items-center gap-2 text-gray-400 shrink-0 whitespace-nowrap">
-                    <Loader className="w-3.5 h-3.5 animate-spin" />
-                    <span className="text-xs font-medium">Executing...</span>
-                    {(activeExecutionId || (currentExecution && (currentExecution.status === "running" || currentExecution.status === "pending") ? currentExecution.id : null)) && onCancelExecution && (
-                      <button
-                        onClick={async () => {
-                          const runId = activeExecutionId || (currentExecution ? currentExecution.id : null);
-                          if (runId && confirm("Are you sure you want to cancel this execution?")) {
-                            try {
-                              await onCancelExecution(runId);
-                              enqueueSnackbar("Workflow execution cancel requested.", { variant: "info" });
-                            } catch (err) {
-                              console.error("Failed to cancel execution:", err);
-                              enqueueSnackbar("Failed to cancel execution.", { variant: "error" });
-                            }
+          <div className="flex items-center gap-2 relative ml-auto z-10">
+            <div className={`flex items-center justify-end shrink-0 ${showExecutionStatus ? "min-w-[9.5rem]" : ""}`}>
+              {showExecutionStatus && (
+                <div className="flex items-center gap-2 text-gray-400 whitespace-nowrap">
+                  <Loader className="w-3.5 h-3.5 animate-spin shrink-0" />
+                  <span className="text-xs font-medium">Executing...</span>
+                  {onCancelExecution && (
+                    <button
+                      onClick={async () => {
+                        const runId = activeExecutionId || (currentExecution && (currentExecution.status === "running" || currentExecution.status === "pending") ? currentExecution.id : null);
+                        if (runId && confirm("Are you sure you want to cancel this execution?")) {
+                          try {
+                            await onCancelExecution(runId);
+                            enqueueSnackbar("Workflow execution cancel requested.", { variant: "info" });
+                          } catch (err) {
+                            console.error("Failed to cancel execution:", err);
+                            enqueueSnackbar("Failed to cancel execution.", { variant: "error" });
                           }
-                        }}
-                        className="px-2 py-0.5 text-[11px] text-red-500 hover:text-red-400 border border-red-500/30 hover:border-red-500/50 rounded transition-colors cursor-pointer"
-                        title="Cancel Execution"
-                      >
-                        Cancel
-                      </button>
-                    )}
-                  </div>
-                )}
-              </div>
+                        }
+                      }}
+                      className={`px-2 py-0.5 text-[11px] text-red-500 hover:text-red-400 border border-red-500/30 hover:border-red-500/50 rounded transition-colors cursor-pointer shrink-0 ${
+                        activeExecutionId || (currentExecution && (currentExecution.status === "running" || currentExecution.status === "pending"))
+                          ? "visible"
+                          : "invisible pointer-events-none"
+                      }`}
+                      title="Cancel Execution"
+                      aria-hidden={!(activeExecutionId || (currentExecution && (currentExecution.status === "running" || currentExecution.status === "pending")))}
+                      tabIndex={activeExecutionId || (currentExecution && (currentExecution.status === "running" || currentExecution.status === "pending")) ? 0 : -1}
+                    >
+                      Cancel
+                    </button>
+                  )}
+                </div>
+              )}
             </div>
 
             <div
@@ -437,29 +436,28 @@ const Navbar: React.FC<NavbarProps> = ({
               </button>
             </div>
 
-            {currentWorkflow && updateWorkflowVisibility && (
+            {currentWorkflow && updateWorkflowStatus && (
               <ToggleSwitch
-                theme="dark"
-                isActive={currentWorkflow.is_public ?? false}
-                disabled={isPublicTogglePending}
-                onToggle={async (isPublic) => {
-                  if (isPublicTogglePending) return;
-                  setIsPublicTogglePending(true);
+                isActive={currentWorkflow.is_active ?? false}
+                onToggle={async (isActive) => {
                   try {
-                    await updateWorkflowVisibility(currentWorkflow.id, isPublic);
+                    await updateWorkflowStatus(currentWorkflow.id, isActive);
                     if (setCurrentWorkflow) {
-                      setCurrentWorkflow({ ...currentWorkflow, is_public: isPublic });
+                      setCurrentWorkflow({ ...currentWorkflow, is_active: isActive });
                     }
-                    enqueueSnackbar(`Workflow is now ${isPublic ? "Public" : "Private"}`, { variant: "success" });
+                    enqueueSnackbar(
+                      `Workflow ${isActive ? "activated" : "deactivated"}`,
+                      { variant: "success" }
+                    );
                   } catch (error) {
-                    enqueueSnackbar("Workflow visibility could not be updated", { variant: "error" });
-                  } finally {
-                    setIsPublicTogglePending(false);
+                    enqueueSnackbar("Workflow status could not be updated", {
+                      variant: "error",
+                    });
                   }
                 }}
                 size="sm"
-                label="Activity"
-                description={currentWorkflow.is_public ? "Active" : undefined}
+                label="Workflow Status"
+                description={currentWorkflow.is_active ? "Active" : "Inactive"}
               />
             )}
 

--- a/client/app/components/common/Navbar.tsx
+++ b/client/app/components/common/Navbar.tsx
@@ -10,6 +10,8 @@ import {
   MessageSquare,
   ShieldAlert,
   StopCircle,
+  Undo2,
+  Redo2,
 } from "lucide-react";
 import React, { useState, useRef, useEffect } from "react";
 import { Link, useNavigate } from "react-router";
@@ -37,6 +39,11 @@ interface NavbarProps {
   updateWorkflowStatus?: (id: string, is_active: boolean) => Promise<void>;
   updateWorkflowVisibility?: (id: string, is_public: boolean) => Promise<void>;
   onImportStart?: () => void;
+  onWorkflowImported?: (nodes: any[], edges: any[]) => void;
+  onUndo?: () => void;
+  onRedo?: () => void;
+  canUndo?: boolean;
+  canRedo?: boolean;
   executionLoading?: boolean;
   activeExecutionId?: string | null;
   currentExecution?: any;
@@ -59,6 +66,11 @@ const Navbar: React.FC<NavbarProps> = ({
   onAutoSaveSettings,
   updateWorkflowVisibility,
   onImportStart,
+  onWorkflowImported,
+  onUndo,
+  onRedo,
+  canUndo = false,
+  canRedo = false,
   executionLoading,
   activeExecutionId,
   currentExecution,
@@ -183,6 +195,7 @@ const Navbar: React.FC<NavbarProps> = ({
 
           setNodes(enrichedNodes);
           setEdges(json.flow_data?.edges || []);
+          onWorkflowImported?.(enrichedNodes, json.flow_data?.edges || []);
           if (json.name) {
             setWorkflowName(json.name);
           }
@@ -283,6 +296,7 @@ const Navbar: React.FC<NavbarProps> = ({
               onChange={(e) => setWorkflowName(e.target.value)}
               onBlur={handleBlur}
               placeholder="Dosya Adı"
+              data-native-undo="true"
               className="text-lg font-medium text-white/90 bg-transparent px-4 py-1.5 rounded-md border border-transparent hover:border-white/20 focus:border-white/30 hover:bg-white/5 focus:bg-white/10 focus:outline-none transition-all duration-300 text-center w-full max-w-[400px] focus:max-w-[800px]"
             />
           </div>
@@ -340,35 +354,74 @@ const Navbar: React.FC<NavbarProps> = ({
               />
             )}
 
-            {autoSaveStatus && (
-              <div className="flex items-center gap-2">
-                {autoSaveStatus === "saving" && (
-                  <div className="flex items-center gap-1 text-green-400">
-                    <div className="w-2 h-2 bg-green-400 rounded-full animate-pulse"></div>
-                    <span className="text-xs">Saving...</span>
-                  </div>
-                )}
-                {autoSaveStatus === "saved" && (
-                  <div className="flex items-center gap-1 text-green-400">
-                    <div className="w-2 h-2 bg-green-400 rounded-full"></div>
-                    <span className="text-xs">Saved</span>
-                  </div>
-                )}
-                {autoSaveStatus === "error" && (
-                  <div className="flex items-center gap-1 text-red-400">
-                    <div className="w-2 h-2 bg-red-400 rounded-full"></div>
-                    <span className="text-xs">Error</span>
-                  </div>
-                )}
-                {lastAutoSave && autoSaveStatus === "idle" && (
-                  <div className="flex items-center gap-1 text-gray-400 text-xs">
-                    Last saved: {lastAutoSave.toLocaleTimeString()}
-                  </div>
-                )}
-              </div>
-            )}
-
             <div className="flex items-center gap-2">
+              {autoSaveStatus && (
+                <div
+                  className="min-w-[5.5rem] flex items-center justify-end shrink-0"
+                  aria-live="polite"
+                >
+                  {autoSaveStatus === "saving" && (
+                    <div className="flex items-center gap-1 text-green-400">
+                      <div className="w-2 h-2 bg-green-400 rounded-full animate-pulse" />
+                      <span className="text-xs whitespace-nowrap">Saving...</span>
+                    </div>
+                  )}
+                  {autoSaveStatus === "saved" && (
+                    <div className="flex items-center gap-1 text-green-400">
+                      <div className="w-2 h-2 bg-green-400 rounded-full" />
+                      <span className="text-xs whitespace-nowrap">Saved</span>
+                    </div>
+                  )}
+                  {autoSaveStatus === "error" && (
+                    <div className="flex items-center gap-1 text-red-400">
+                      <div className="w-2 h-2 bg-red-400 rounded-full" />
+                      <span className="text-xs whitespace-nowrap">Error</span>
+                    </div>
+                  )}
+                  {lastAutoSave && autoSaveStatus === "idle" && (
+                    <div
+                      className="flex items-center gap-1 text-gray-400 text-xs truncate max-w-[8rem]"
+                      title={`Last saved: ${lastAutoSave.toLocaleTimeString()}`}
+                    >
+                      <span className="truncate">
+                        Last saved: {lastAutoSave.toLocaleTimeString()}
+                      </span>
+                    </div>
+                  )}
+                </div>
+              )}
+              <button
+                type="button"
+                className={`p-0 border-0 bg-transparent rounded-4xl transition duration-500 ${
+                  canUndo ? "cursor-pointer hover:bg-muted" : "cursor-not-allowed"
+                }`}
+                onClick={canUndo ? onUndo : undefined}
+                disabled={!canUndo}
+                aria-label="Undo (Ctrl+Z)"
+                title="Undo (Ctrl+Z)"
+              >
+                <Undo2
+                  className={`w-10 h-10 p-2 ${
+                    canUndo ? "text-white" : "text-white/30"
+                  }`}
+                />
+              </button>
+              <button
+                type="button"
+                className={`p-0 border-0 bg-transparent rounded-4xl transition duration-500 ${
+                  canRedo ? "cursor-pointer hover:bg-muted" : "cursor-not-allowed"
+                }`}
+                onClick={canRedo ? onRedo : undefined}
+                disabled={!canRedo}
+                aria-label="Redo (Ctrl+Y)"
+                title="Redo (Ctrl+Y)"
+              >
+                <Redo2
+                  className={`w-10 h-10 p-2 ${
+                    canRedo ? "text-white" : "text-white/30"
+                  }`}
+                />
+              </button>
               {isLoading ? (
                 <Loader className="animate-spin text-white w-10 h-10 p-2 rounded-4xl" />
               ) : (

--- a/client/app/components/common/Navbar.tsx
+++ b/client/app/components/common/Navbar.tsx
@@ -383,7 +383,7 @@ const Navbar: React.FC<NavbarProps> = ({
                 )}
                 {lastAutoSave && autoSaveStatus === "idle" && (
                   <div
-                    className="flex items-center gap-1 text-gray-400 text-xs whitespace-nowrap"
+                    className="flex items-center gap-1 text-white/60 text-xs whitespace-nowrap"
                     title={`Last saved: ${lastAutoSave.toLocaleTimeString()}`}
                   >
                     Last saved: {lastAutoSave.toLocaleTimeString()}

--- a/client/app/components/common/ToggleSwitch.tsx
+++ b/client/app/components/common/ToggleSwitch.tsx
@@ -9,6 +9,7 @@ interface ToggleSwitchProps {
   showIcon?: boolean;
   label?: string;
   description?: string;
+  theme?: "light" | "dark";
   activeIcon?: React.ReactNode;
   inactiveIcon?: React.ReactNode;
 }
@@ -21,6 +22,7 @@ export default function ToggleSwitch({
   showIcon = true,
   label,
   description,
+  theme = "light",
   activeIcon,
   inactiveIcon,
 }: ToggleSwitchProps) {
@@ -95,14 +97,26 @@ export default function ToggleSwitch({
           {label && (
             <span
               className={`font-medium ${
-                isActive ? "text-green-700" : "text-gray-600"
+                theme === "dark"
+                  ? isActive
+                    ? "text-green-400"
+                    : "text-white/80"
+                  : isActive
+                    ? "text-green-700"
+                    : "text-gray-600"
               }`}
             >
               {label}
             </span>
           )}
           {description && (
-            <span className="text-xs text-gray-500">{description}</span>
+            <span
+              className={`text-xs ${
+                theme === "dark" ? "text-white/50" : "text-gray-500"
+              }`}
+            >
+              {description}
+            </span>
           )}
         </div>
       )}

--- a/client/app/components/node/GenericNode.tsx
+++ b/client/app/components/node/GenericNode.tsx
@@ -80,7 +80,6 @@ export default function GenericNode({ data, id }: GenericNodeProps) {
   const handleSaveConfig = (values: Partial<GenericData>) => {
     console.log(values);
     const updatedData = { ...data, ...values };
-    // Update node data without affecting local configData to prevent loops
     setNodes((nodes) =>
       nodes.map((node) =>
         node.id === id ? { ...node, data: updatedData } : node
@@ -88,6 +87,22 @@ export default function GenericNode({ data, id }: GenericNodeProps) {
     );
     setIsConfigMode(false);
   };
+
+  const handleConfigChange = useCallback(
+    (values: Partial<GenericData>) => {
+      const updatedData = { ...data, ...values };
+      setNodes((nodes) =>
+        nodes.map((node) => {
+          if (node.id !== id) return node;
+          if (JSON.stringify(node.data) === JSON.stringify(updatedData)) {
+            return node;
+          }
+          return { ...node, data: updatedData };
+        })
+      );
+    },
+    [data, id, setNodes]
+  );
 
   const handleDeleteNode = useCallback(
     (e: React.MouseEvent) => {
@@ -434,6 +449,7 @@ export default function GenericNode({ data, id }: GenericNodeProps) {
         }}
         validate={validate}
         onSubmit={handleSaveConfig}
+        onChange={handleConfigChange}
         onCancel={() => setIsConfigMode(false)}
       />
     );

--- a/client/app/components/node/GenericNodeForm.tsx
+++ b/client/app/components/node/GenericNodeForm.tsx
@@ -28,6 +28,34 @@ interface GenericNodeFormProps {
   onCancel: () => void;
   configData?: any;
   onSave?: (values: any) => void;
+  onChange?: (values: GenericData) => void;
+}
+
+function FormValuesObserver({
+  values,
+  onChange,
+}: {
+  values: GenericData;
+  onChange?: (values: GenericData) => void;
+}) {
+  const isFirstRender = useRef(true);
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+  const valuesKeyRef = useRef<string>("");
+
+  useEffect(() => {
+    const nextKey = JSON.stringify(values);
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      valuesKeyRef.current = nextKey;
+      return;
+    }
+    if (valuesKeyRef.current === nextKey) return;
+    valuesKeyRef.current = nextKey;
+    onChangeRef.current?.(values);
+  }, [values]);
+
+  return null;
 }
 
 export default function GenericNodeForm({
@@ -37,6 +65,7 @@ export default function GenericNodeForm({
   onCancel,
   configData,
   onSave,
+  onChange,
 }: GenericNodeFormProps) {
   const properties = configData?.metadata?.properties || [];
 
@@ -181,7 +210,9 @@ export default function GenericNodeForm({
         enableReinitialize
       >
         {({ values, errors, touched, isSubmitting, setFieldValue }) => (
-          <Form className="grid grid-cols-2 gap-3 w-full p-6">
+          <>
+            <FormValuesObserver values={values} onChange={onChange} />
+            <Form className="grid grid-cols-2 gap-3 w-full p-6">
             {getVisibleProperties(activeTab).map((property: NodeProperty) => {
               // Check display options
               if (property.displayOptions?.show) {
@@ -389,6 +420,7 @@ export default function GenericNodeForm({
               </div>
             )}
           </Form>
+          </>
         )}
       </Formik>
     </div>

--- a/client/app/lib/useWorkflowHistory.ts
+++ b/client/app/lib/useWorkflowHistory.ts
@@ -150,12 +150,20 @@ export function useWorkflowHistory(
   return { undo, redo, canUndo, canRedo, resetHistory };
 }
 
-/** Returns true only for fields that should keep native text undo (e.g. workflow name). */
+/** True when focus is in a text-editing surface — workflow undo must not steal Ctrl+Z/Ctrl+Y. */
 export const isEditableKeyboardTarget = (target: EventTarget | null): boolean => {
   if (!(target instanceof HTMLElement)) return false;
+
+  if (target.closest(".monaco-editor")) return true;
+
   const tag = target.tagName;
-  const isEditable =
-    tag === "INPUT" || tag === "TEXTAREA" || target.isContentEditable;
-  if (!isEditable) return false;
-  return target.closest('[data-native-undo="true"]') !== null;
+  if (tag === "INPUT") {
+    const type = (target as HTMLInputElement).type;
+    if (type === "checkbox" || type === "radio" || type === "button" || type === "submit" || type === "file") {
+      return false;
+    }
+    return true;
+  }
+
+  return tag === "TEXTAREA" || target.isContentEditable;
 };

--- a/client/app/lib/useWorkflowHistory.ts
+++ b/client/app/lib/useWorkflowHistory.ts
@@ -66,6 +66,11 @@ export function useWorkflowHistory(
   const previousSnapshotRef = useRef<WorkflowSnapshot | null>(null);
   const isApplyingHistoryRef = useRef(false);
   const skipRecordingRef = useRef(false);
+  const recordTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const nodesRef = useRef(nodes);
+  const edgesRef = useRef(edges);
+  nodesRef.current = nodes;
+  edgesRef.current = edges;
   const [canUndo, setCanUndo] = useState(false);
   const [canRedo, setCanRedo] = useState(false);
 
@@ -73,6 +78,27 @@ export function useWorkflowHistory(
     setCanUndo(pastRef.current.length > 0);
     setCanRedo(futureRef.current.length > 0);
   }, []);
+
+  const recordSnapshot = useCallback(() => {
+    const currentNodes = nodesRef.current;
+    const currentEdges = edgesRef.current;
+    const currentKey = normalizeSnapshot(currentNodes, currentEdges);
+    const previous = previousSnapshotRef.current;
+
+    if (previous) {
+      const previousKey = normalizeSnapshot(previous.nodes, previous.edges);
+      if (previousKey !== currentKey) {
+        pastRef.current.push(previous);
+        if (pastRef.current.length > MAX_HISTORY) {
+          pastRef.current.shift();
+        }
+        futureRef.current = [];
+        updateAvailability();
+      }
+    }
+
+    previousSnapshotRef.current = cloneSnapshot(currentNodes, currentEdges);
+  }, [updateAvailability]);
 
   const resetHistory = useCallback(
     (snapshotNodes: Node[], snapshotEdges: Edge[]) => {
@@ -97,32 +123,40 @@ export function useWorkflowHistory(
       return;
     }
 
-    const timer = setTimeout(() => {
-      const currentKey = normalizeSnapshot(nodes, edges);
-      const previous = previousSnapshotRef.current;
+    if (recordTimerRef.current) {
+      clearTimeout(recordTimerRef.current);
+    }
 
-      if (previous) {
-        const previousKey = normalizeSnapshot(previous.nodes, previous.edges);
-        if (previousKey !== currentKey) {
-          pastRef.current.push(previous);
-          if (pastRef.current.length > MAX_HISTORY) {
-            pastRef.current.shift();
-          }
-          futureRef.current = [];
-          updateAvailability();
-        }
-      }
-
-      previousSnapshotRef.current = cloneSnapshot(nodes, edges);
+    recordTimerRef.current = setTimeout(() => {
+      recordTimerRef.current = null;
+      recordSnapshot();
     }, 300);
 
-    return () => clearTimeout(timer);
-  }, [nodes, edges, updateAvailability]);
+    return () => {
+      if (recordTimerRef.current) {
+        clearTimeout(recordTimerRef.current);
+        recordTimerRef.current = null;
+      }
+    };
+  }, [nodes, edges, recordSnapshot]);
+
+  const flushRecording = useCallback(() => {
+    if (recordTimerRef.current) {
+      clearTimeout(recordTimerRef.current);
+      recordTimerRef.current = null;
+    }
+
+    if (isApplyingHistoryRef.current || skipRecordingRef.current) {
+      return;
+    }
+
+    recordSnapshot();
+  }, [recordSnapshot]);
 
   const undo = useCallback(() => {
     if (pastRef.current.length === 0) return;
 
-    const current = cloneSnapshot(nodes, edges);
+    const current = cloneSnapshot(nodesRef.current, edgesRef.current);
     futureRef.current.push(current);
 
     const previous = pastRef.current.pop()!;
@@ -131,12 +165,12 @@ export function useWorkflowHistory(
     setNodes(previous.nodes);
     setEdges(previous.edges);
     updateAvailability();
-  }, [nodes, edges, setNodes, setEdges, updateAvailability]);
+  }, [setNodes, setEdges, updateAvailability]);
 
   const redo = useCallback(() => {
     if (futureRef.current.length === 0) return;
 
-    const current = cloneSnapshot(nodes, edges);
+    const current = cloneSnapshot(nodesRef.current, edgesRef.current);
     pastRef.current.push(current);
 
     const next = futureRef.current.pop()!;
@@ -145,9 +179,9 @@ export function useWorkflowHistory(
     setNodes(next.nodes);
     setEdges(next.edges);
     updateAvailability();
-  }, [nodes, edges, setNodes, setEdges, updateAvailability]);
+  }, [setNodes, setEdges, updateAvailability]);
 
-  return { undo, redo, canUndo, canRedo, resetHistory };
+  return { undo, redo, canUndo, canRedo, resetHistory, flushRecording };
 }
 
 /** Node config modal / workflow canvas — workflow undo/redo should apply here. */

--- a/client/app/lib/useWorkflowHistory.ts
+++ b/client/app/lib/useWorkflowHistory.ts
@@ -150,9 +150,17 @@ export function useWorkflowHistory(
   return { undo, redo, canUndo, canRedo, resetHistory };
 }
 
+/** Node config modal / workflow canvas — workflow undo/redo should apply here. */
+export const isWorkflowHistoryScope = (target: EventTarget | null): boolean => {
+  if (!(target instanceof HTMLElement)) return false;
+  return target.closest("[data-workflow-history]") !== null;
+};
+
 /** True when focus is in a text-editing surface — workflow undo must not steal Ctrl+Z/Ctrl+Y. */
 export const isEditableKeyboardTarget = (target: EventTarget | null): boolean => {
   if (!(target instanceof HTMLElement)) return false;
+
+  if (isWorkflowHistoryScope(target)) return false;
 
   if (target.closest(".monaco-editor")) return true;
 

--- a/client/app/lib/useWorkflowHistory.ts
+++ b/client/app/lib/useWorkflowHistory.ts
@@ -1,0 +1,161 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Node, Edge } from "@xyflow/react";
+
+interface WorkflowSnapshot {
+  nodes: Node[];
+  edges: Edge[];
+}
+
+const MAX_HISTORY = 50;
+
+const stableStringify = (obj: unknown): string => {
+  if (obj === null || obj === undefined) return JSON.stringify(obj);
+  if (typeof obj !== "object") return JSON.stringify(obj);
+  if (Array.isArray(obj)) {
+    return "[" + obj.map((item) => stableStringify(item)).join(",") + "]";
+  }
+  const sortedKeys = Object.keys(obj as Record<string, unknown>).sort();
+  const parts = sortedKeys.map((key) => {
+    const value = (obj as Record<string, unknown>)[key];
+    return JSON.stringify(key) + ":" + stableStringify(value);
+  });
+  return "{" + parts.join(",") + "}";
+};
+
+const normalizeSnapshot = (nodes: Node[], edges: Edge[]): string => {
+  const normalizedNodes = nodes.map((node) => ({
+    id: node.id,
+    type: node.type,
+    position: {
+      x: Math.round((node.position?.x || 0) * 1000) / 1000,
+      y: Math.round((node.position?.y || 0) * 1000) / 1000,
+    },
+    data: node.data,
+    width: node.width,
+    height: node.height,
+  }));
+
+  const normalizedEdges = edges.map((edge) => ({
+    id: edge.id,
+    source: edge.source,
+    target: edge.target,
+    sourceHandle: edge.sourceHandle || null,
+    targetHandle: edge.targetHandle || null,
+    type: edge.type || "custom",
+  }));
+
+  normalizedNodes.sort((a, b) => a.id.localeCompare(b.id));
+  normalizedEdges.sort((a, b) => a.id.localeCompare(b.id));
+
+  return stableStringify({ nodes: normalizedNodes, edges: normalizedEdges });
+};
+
+const cloneSnapshot = (nodes: Node[], edges: Edge[]): WorkflowSnapshot => ({
+  nodes: JSON.parse(JSON.stringify(nodes)),
+  edges: JSON.parse(JSON.stringify(edges)),
+});
+
+export function useWorkflowHistory(
+  nodes: Node[],
+  edges: Edge[],
+  setNodes: React.Dispatch<React.SetStateAction<Node[]>>,
+  setEdges: React.Dispatch<React.SetStateAction<Edge[]>>
+) {
+  const pastRef = useRef<WorkflowSnapshot[]>([]);
+  const futureRef = useRef<WorkflowSnapshot[]>([]);
+  const previousSnapshotRef = useRef<WorkflowSnapshot | null>(null);
+  const isApplyingHistoryRef = useRef(false);
+  const skipRecordingRef = useRef(false);
+  const [canUndo, setCanUndo] = useState(false);
+  const [canRedo, setCanRedo] = useState(false);
+
+  const updateAvailability = useCallback(() => {
+    setCanUndo(pastRef.current.length > 0);
+    setCanRedo(futureRef.current.length > 0);
+  }, []);
+
+  const resetHistory = useCallback(
+    (snapshotNodes: Node[], snapshotEdges: Edge[]) => {
+      pastRef.current = [];
+      futureRef.current = [];
+      previousSnapshotRef.current = cloneSnapshot(snapshotNodes, snapshotEdges);
+      skipRecordingRef.current = true;
+      updateAvailability();
+    },
+    [updateAvailability]
+  );
+
+  useEffect(() => {
+    if (isApplyingHistoryRef.current) {
+      isApplyingHistoryRef.current = false;
+      return;
+    }
+
+    if (skipRecordingRef.current) {
+      skipRecordingRef.current = false;
+      previousSnapshotRef.current = cloneSnapshot(nodes, edges);
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      const currentKey = normalizeSnapshot(nodes, edges);
+      const previous = previousSnapshotRef.current;
+
+      if (previous) {
+        const previousKey = normalizeSnapshot(previous.nodes, previous.edges);
+        if (previousKey !== currentKey) {
+          pastRef.current.push(previous);
+          if (pastRef.current.length > MAX_HISTORY) {
+            pastRef.current.shift();
+          }
+          futureRef.current = [];
+          updateAvailability();
+        }
+      }
+
+      previousSnapshotRef.current = cloneSnapshot(nodes, edges);
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, [nodes, edges, updateAvailability]);
+
+  const undo = useCallback(() => {
+    if (pastRef.current.length === 0) return;
+
+    const current = cloneSnapshot(nodes, edges);
+    futureRef.current.push(current);
+
+    const previous = pastRef.current.pop()!;
+    isApplyingHistoryRef.current = true;
+    previousSnapshotRef.current = previous;
+    setNodes(previous.nodes);
+    setEdges(previous.edges);
+    updateAvailability();
+  }, [nodes, edges, setNodes, setEdges, updateAvailability]);
+
+  const redo = useCallback(() => {
+    if (futureRef.current.length === 0) return;
+
+    const current = cloneSnapshot(nodes, edges);
+    pastRef.current.push(current);
+
+    const next = futureRef.current.pop()!;
+    isApplyingHistoryRef.current = true;
+    previousSnapshotRef.current = next;
+    setNodes(next.nodes);
+    setEdges(next.edges);
+    updateAvailability();
+  }, [nodes, edges, setNodes, setEdges, updateAvailability]);
+
+  return { undo, redo, canUndo, canRedo, resetHistory };
+}
+
+/** Returns true only for fields that should keep native text undo (e.g. workflow name). */
+export const isEditableKeyboardTarget = (target: EventTarget | null): boolean => {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  const isEditable =
+    tag === "INPUT" || tag === "TEXTAREA" || target.isContentEditable;
+  if (!isEditable) return false;
+  return target.closest('[data-native-undo="true"]') !== null;
+};

--- a/client/app/stores/workflows.ts
+++ b/client/app/stores/workflows.ts
@@ -27,7 +27,7 @@ interface WorkflowState {
   fetchPublicWorkflows: () => Promise<void>;
   fetchWorkflow: (id: string) => Promise<void>;
   createWorkflow: (data: WorkflowCreateRequest) => Promise<Workflow>;
-  updateWorkflow: (id: string, data: WorkflowUpdateRequest) => Promise<void>;
+  updateWorkflow: (id: string, data: WorkflowUpdateRequest) => Promise<Workflow>;
   deleteWorkflow: (id: string) => Promise<void>;
   duplicateWorkflow: (id: string, new_name?: string) => Promise<Workflow>;
   updateWorkflowVisibility: (id: string, is_public: boolean) => Promise<void>;
@@ -111,6 +111,7 @@ const workflowStateCreator: StateCreator<WorkflowState> = (set, get) => ({
         isLoading: false,
         error: null,
       }));
+      return updatedWorkflow;
     } catch (error: any) {
       const errorMessage = error?.response?.data?.detail || error?.message || "Failed to update workflow";
       console.error("Update workflow error:", errorMessage, error);


### PR DESCRIPTION
- Add workflow canvas undo/redo history with Ctrl+Z and Ctrl+Y keyboard shortcuts 
- Add undo/redo navigation buttons to the top-right workflow navbar 
- Reset edit history when workflows are loaded or imported