### PR TITLE
fix: prevent incomplete node initialization during workflow import

### DIFF
--- a/client/app/components/canvas/FlowCanvas.tsx
+++ b/client/app/components/canvas/FlowCanvas.tsx
@@ -474,7 +474,20 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
     updateWorkflowVisibility,
   } = useWorkflows();
 
-  const { nodes: availableNodes, customNodes } = useNodes();
+  const { 
+    nodes: availableNodes, 
+    customNodes,
+    fetchNodes,
+    fetchCategories,
+    fetchCustomNodes
+  } = useNodes();
+
+  // Load all node metadata on canvas mount to ensure registry is available for import/load
+  useEffect(() => {
+    fetchNodes();
+    fetchCategories();
+    fetchCustomNodes();
+  }, [fetchNodes, fetchCategories, fetchCustomNodes]);
 
   // Smart suggestions integration
   const { setLastAddedNode, updateRecommendations } = useSmartSuggestions();
@@ -764,27 +777,7 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
     }
   }, [currentWorkflow?.id, clearAllChats, setCurrentExecutionForWorkflow, setActiveChatflowId]);
 
-  // Initialize nodes from store when loaded for the first time
-  useEffect(() => {
-    if (!workflowId && availableNodes.length > 0 && nodes.length === 0 && !currentWorkflow && !hasInitializedEmptyCanvas.current) {
-      // Sadece start node'u ekle
-      const startNodeMeta = availableNodes.find((n) => n.name === "StartNode");
-      if (startNodeMeta) {
-        const startNode = {
-          id: "StartNode__" + crypto.randomUUID(),
-          type: "StartNode",
-          position: { x: 100, y: 100 },
-          data: {
-            name: "Start",
-            metadata: startNodeMeta,
-          },
-        };
-        setNodes([startNode]);
-        hasInitializedEmptyCanvas.current = true;
-        resetHistory([startNode], []);
-      }
-    }
-  }, [workflowId, availableNodes, currentWorkflow, nodes.length, setNodes, resetHistory]);
+
 
   useEffect(() => {
     // If currentWorkflow is null and we had a loaded workflow, reset the canvas
@@ -2012,7 +2005,7 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
         lastAutoSave={lastAutoSave}
         onAutoSaveSettings={handleAutoSaveSettings}
         updateWorkflowVisibility={updateWorkflowVisibility}
-        onImportStart={() => { isImportingRef.current = true; }}
+        onImportStart={() => { isImportingRef.current = true; loadedWorkflowIdRef.current = null; }}
         onWorkflowImported={(importedNodes, importedEdges) => {
           resetHistory(importedNodes, importedEdges);
         }}

--- a/client/app/components/common/FullscreenNodeModal.tsx
+++ b/client/app/components/common/FullscreenNodeModal.tsx
@@ -652,9 +652,9 @@ export default function FullscreenNodeModal({
     nodeAliasRef.current = alias;
     setNodeAlias(alias);
     setNodeAliasError(null);
-    // Sync workflow state into the form only after undo/redo — not on live edits.
+    // Sync workflow state into the form after undo/redo or when configData changes externally (e.g., import).
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [historyRevision]);
+  }, [historyRevision, configData]);
 
   useEffect(() => {
     if (prevHistoryRevisionRef.current === historyRevision) return;

--- a/client/app/components/common/Navbar.tsx
+++ b/client/app/components/common/Navbar.tsx
@@ -151,8 +151,11 @@ const Navbar: React.FC<NavbarProps> = ({
           if (nodeStore.nodes.length === 0) {
             await nodeStore.fetchNodes();
             await nodeStore.fetchCategories();
-            nodeStore = useNodeStore.getState();
           }
+          if (nodeStore.customNodes.length === 0) {
+            await nodeStore.fetchCustomNodes();
+          }
+          nodeStore = useNodeStore.getState();
 
           const allNodesMetadata = [...(nodeStore.nodes || []), ...(nodeStore.customNodes || [])];
           const enrichedNodes = (json.flow_data?.nodes || []).map((node: any) => {


### PR DESCRIPTION
- eagerly load node metadata and custom node definitions to guarantee import-time node resolution
- hydrate custom node registry before import to eliminate missing node mappings
- synchronize node configuration forms with externally imported workflow state
- prevent automatic start node creation from introducing unintended history mutations on empty canvases
- improve import consistency by ensuring registry and editor state are initialized before workflow restoration