### PR TITLE
feat: preserve cross-workflow error handler references during bundle import

### DIFF
--- a/backend/app/api/export.py
+++ b/backend/app/api/export.py
@@ -19,6 +19,7 @@ from app.models.workflow import Workflow
 from app.models.user_credential import UserCredential
 from app.models.user import User
 from app.auth.dependencies import get_current_user
+from scripts.workflow_bundle_utils import collect_missing_error_workflow_warnings
 
 
 router = APIRouter(prefix="/export", tags=["export"])
@@ -215,11 +216,15 @@ async def export_workflows(
             "name": workflow.name,
             "description": workflow.description or "",
             "is_public": workflow.is_public,
+            "error_workflow": str(workflow.error_workflow) if workflow.error_workflow else None,
             "flow_file": flow_filename
         })
     
     if not config["workflows"]:
         raise HTTPException(status_code=404, detail="No workflows found to export")
+
+    for warning in collect_missing_error_workflow_warnings(config["workflows"]):
+        logger.warning(warning)
     
     # Add credentials to config
     for cred_info in seen_credentials.values():

--- a/backend/scripts/export_workflows.py
+++ b/backend/scripts/export_workflows.py
@@ -34,6 +34,8 @@ from app.models.user import User
 from sqlalchemy import select
 import logging
 
+from scripts.workflow_bundle_utils import collect_missing_error_workflow_warnings
+
 logger = logging.getLogger(__name__)
 
 def get_empty_secret_from_credential(credential: UserCredential) -> Dict[str, Any]:
@@ -188,6 +190,7 @@ async def export_workflows(
                 "name": workflow.name,
                 "description": workflow.description or "",
                 "is_public": workflow.is_public,
+                "error_workflow": str(workflow.error_workflow) if workflow.error_workflow else None,
                 "flow_file": flow_file
             })
             
@@ -196,6 +199,9 @@ async def export_workflows(
         # Add all found credentials to config
         for cred_info in seen_credentials.values():
             config["credentials"].append(cred_info)
+
+        for warning in collect_missing_error_workflow_warnings(config["workflows"]):
+            logger.warning(warning)
     
     # Write YAML config
     yaml_content = yaml.dump(

--- a/backend/scripts/import_workflows.py
+++ b/backend/scripts/import_workflows.py
@@ -22,7 +22,7 @@ import base64
 import sys
 import traceback
 from pathlib import Path
-from typing import Dict, Any
+from typing import Dict, Any, List, Optional
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
@@ -38,6 +38,11 @@ from app.models.user import User
 from app.models.user_credential import UserCredential
 from app.models.workflow import Workflow
 from sqlalchemy import select
+from scripts.workflow_bundle_utils import (
+    apply_error_workflow_link,
+    map_credentials_in_flow_data,
+    resolve_exported_error_workflow_id,
+)
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -198,12 +203,16 @@ async def import_from_config(config_path: str, dry_run: bool = False):
                         log(f"  ERROR creating {name}: {e}")
                         skipped_credentials += 1
 
-            # 3. Import workflows with NEW UUIDs and mapped credentials
+            # 3. Prepare workflow payloads
             created_workflows = 0
             skipped_workflows = 0
             updated_workflows = 0
+            error_handlers_linked = 0
+            error_handlers_skipped = 0
 
             log(f"\nProcessing workflows...")
+
+            workflow_payloads: List[Dict[str, Any]] = []
 
             for wf_config in config.get("workflows", []):
                 old_wf_id = wf_config.get("id")
@@ -222,7 +231,6 @@ async def import_from_config(config_path: str, dry_run: bool = False):
                     skipped_workflows += 1
                     continue
 
-                # Check if workflow with exact name already exists for target user
                 existing_wf = None
                 try:
                     existing = await db.execute(
@@ -235,61 +243,129 @@ async def import_from_config(config_path: str, dry_run: bool = False):
                 except Exception as e:
                     log(f"  WARN: Error checking workflow {wf_name}: {e}")
 
-                # Read flow data and map credentials
                 try:
                     flow_data = json.loads(flow_file.read_text(encoding="utf-8"))
-                    
-                    # Replace old credential UUIDs with new/mapped ones
-                    CREDENTIAL_FIELD_NAMES = [
-                        "credential_id", "credential",
-                        "basic_auth_credential_id", "header_auth_credential_id"
-                    ]
-                    
-                    for node in flow_data.get("nodes", []):
-                        node_data = node.get("data", {})
-                        for field_name in CREDENTIAL_FIELD_NAMES:
-                            cred_val = node_data.get(field_name)
-                            if cred_val and isinstance(cred_val, str) and cred_val in uuid_mapping:
-                                node_data[field_name] = uuid_mapping[cred_val]
-                                
+                    map_credentials_in_flow_data(flow_data, uuid_mapping)
                 except Exception as e:
                     log(f"  ERROR reading or parsing {flow_file}: {e}")
                     skipped_workflows += 1
                     continue
 
-                if dry_run:
+                workflow_payloads.append({
+                    "wf_config": wf_config,
+                    "flow_data": flow_data,
+                    "wf_name": wf_name,
+                    "old_wf_id": old_wf_id,
+                    "existing_wf": existing_wf,
+                })
+
+            workflow_uuid_mapping: Dict[str, str] = {}
+            workflow_records: List[Dict[str, Any]] = []
+
+            if dry_run:
+                for payload in workflow_payloads:
+                    old_wf_id = payload["old_wf_id"]
+                    wf_name = payload["wf_name"]
+                    existing_wf = payload["existing_wf"]
+
                     if existing_wf:
+                        workflow_uuid_mapping[old_wf_id] = str(existing_wf.id)
                         log(f"  Would UPDATE: {wf_name}")
                     else:
+                        workflow_uuid_mapping[old_wf_id] = f"<new:{wf_name}>"
                         log(f"  Would import: {wf_name}")
-                    continue
 
-                # Create or Update Workflow
-                try:
-                    if existing_wf:
-                        # Update workflow
-                        existing_wf.description = wf_config.get("description", "")
-                        existing_wf.is_public = wf_config.get("is_public", False)
-                        existing_wf.flow_data = flow_data
-                        updated_workflows += 1
-                        log(f"  Updated: {wf_name}")
+                log(f"\nProcessing error handler links...")
+                for payload in workflow_payloads:
+                    wf_name = payload["wf_name"]
+                    old_error_id = resolve_exported_error_workflow_id(
+                        payload["wf_config"],
+                        payload["flow_data"],
+                    )
+                    if not old_error_id:
+                        continue
+
+                    mapped_id = workflow_uuid_mapping.get(old_error_id)
+                    if mapped_id and not mapped_id.startswith("<new:"):
+                        log(f"  Would link error handler: {wf_name} -> {mapped_id}")
+                        error_handlers_linked += 1
                     else:
-                        # Create workflow with NEW UUID
-                        workflow = Workflow(
-                            id=uuid.uuid4(),
-                            user_id=user.id,
-                            name=wf_name,
-                            description=wf_config.get("description", ""),
-                            is_public=wf_config.get("is_public", False),
-                            flow_data=flow_data
-                        )
-                        db.add(workflow)
-                        created_workflows += 1
-                        log(f"  Imported: {wf_name}")
+                        log(f"  WARN: Error handler not in bundle for {wf_name} (ref: {old_error_id})")
+                        error_handlers_skipped += 1
+            else:
+                # Pass 1: import workflows and build UUID mapping
+                for payload in workflow_payloads:
+                    wf_config = payload["wf_config"]
+                    flow_data = payload["flow_data"]
+                    wf_name = payload["wf_name"]
+                    old_wf_id = payload["old_wf_id"]
+                    existing_wf = payload["existing_wf"]
 
-                except Exception as e:
-                    log(f"  ERROR importing/updating {wf_name}: {e}")
-                    skipped_workflows += 1
+                    try:
+                        if existing_wf:
+                            existing_wf.description = wf_config.get("description", "")
+                            existing_wf.is_public = wf_config.get("is_public", False)
+                            existing_wf.flow_data = flow_data
+                            workflow_uuid_mapping[old_wf_id] = str(existing_wf.id)
+                            workflow_records.append({
+                                "workflow": existing_wf,
+                                "flow_data": flow_data,
+                                "wf_config": wf_config,
+                                "wf_name": wf_name,
+                            })
+                            updated_workflows += 1
+                            log(f"  Updated: {wf_name}")
+                        else:
+                            new_wf_id = uuid.uuid4()
+                            workflow = Workflow(
+                                id=new_wf_id,
+                                user_id=user.id,
+                                name=wf_name,
+                                description=wf_config.get("description", ""),
+                                is_public=wf_config.get("is_public", False),
+                                flow_data=flow_data,
+                            )
+                            db.add(workflow)
+                            workflow_uuid_mapping[old_wf_id] = str(new_wf_id)
+                            workflow_records.append({
+                                "workflow": workflow,
+                                "flow_data": flow_data,
+                                "wf_config": wf_config,
+                                "wf_name": wf_name,
+                            })
+                            created_workflows += 1
+                            log(f"  Imported: {wf_name}")
+                    except Exception as e:
+                        log(f"  ERROR importing/updating {wf_name}: {e}")
+                        skipped_workflows += 1
+
+                await db.flush()
+
+                # Pass 2: restore error handler links
+                log(f"\nProcessing error handler links...")
+                for record in workflow_records:
+                    workflow = record["workflow"]
+                    flow_data = record["flow_data"]
+                    wf_config = record["wf_config"]
+                    wf_name = record["wf_name"]
+
+                    old_error_id = resolve_exported_error_workflow_id(wf_config, flow_data)
+                    if not old_error_id:
+                        continue
+
+                    linked = apply_error_workflow_link(
+                        workflow,
+                        flow_data,
+                        old_error_id,
+                        workflow_uuid_mapping,
+                    )
+                    if linked:
+                        mapped_id = str(workflow.error_workflow)
+                        log(f"  Linked error handler: {wf_name} -> {mapped_id}")
+                        error_handlers_linked += 1
+                    else:
+                        log(f"  WARN: Error handler not in bundle for {wf_name} (ref: {old_error_id})")
+                        error_handlers_skipped += 1
 
             # Commit all changes
             if not dry_run:
@@ -300,6 +376,7 @@ async def import_from_config(config_path: str, dry_run: bool = False):
             log(f"Import Summary")
             log(f"  Credentials: {created_credentials} created, {updated_credentials} updated, {skipped_credentials} skipped")
             log(f"  Workflows: {created_workflows} imported, {updated_workflows} updated, {skipped_workflows} skipped")
+            log(f"  Error handlers: {error_handlers_linked} linked, {error_handlers_skipped} skipped")
 
             if dry_run:
                 log(f"\n** DRY RUN - No changes were made **")
@@ -329,4 +406,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/backend/scripts/workflow_bundle_utils.py
+++ b/backend/scripts/workflow_bundle_utils.py
@@ -1,0 +1,108 @@
+"""Shared helpers for workflow export/import bundles."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, Dict, List, Optional
+
+CREDENTIAL_FIELD_NAMES = [
+    "credential_id",
+    "credential",
+    "basic_auth_credential_id",
+    "header_auth_credential_id",
+]
+
+
+def map_credentials_in_flow_data(flow_data: dict, uuid_mapping: Dict[str, str]) -> None:
+    """Replace exported credential UUIDs with mapped IDs in flow node data."""
+    for node in flow_data.get("nodes", []):
+        node_data = node.get("data", {})
+        for field_name in CREDENTIAL_FIELD_NAMES:
+            cred_val = node_data.get(field_name)
+            if cred_val and isinstance(cred_val, str) and cred_val in uuid_mapping:
+                node_data[field_name] = uuid_mapping[cred_val]
+
+
+def resolve_exported_error_workflow_id(
+    wf_config: dict,
+    flow_data: dict,
+) -> Optional[str]:
+    """Resolve error workflow ID from YAML config or flow_data settings."""
+    error_id = wf_config.get("error_workflow")
+    if error_id and str(error_id).strip():
+        return str(error_id).strip()
+
+    settings = flow_data.get("settings")
+    if isinstance(settings, dict):
+        flow_error_id = settings.get("error_workflow_id")
+        if flow_error_id and str(flow_error_id).strip():
+            return str(flow_error_id).strip()
+
+    return None
+
+
+def _clear_error_workflow_settings(flow_data: dict) -> None:
+    settings = flow_data.get("settings")
+    if isinstance(settings, dict) and "error_workflow_id" in settings:
+        settings.pop("error_workflow_id", None)
+
+
+def apply_error_workflow_link(
+    workflow: Any,
+    flow_data: dict,
+    old_error_id: str,
+    workflow_uuid_mapping: Dict[str, str],
+) -> bool:
+    """
+    Map and apply error handler workflow link on import.
+
+    Returns True when a valid mapped link was applied, False otherwise.
+    """
+    old_error_id = str(old_error_id).strip()
+    if not old_error_id:
+        return False
+
+    mapped_id = workflow_uuid_mapping.get(old_error_id)
+    workflow_id = str(workflow.id)
+
+    if not mapped_id or mapped_id == workflow_id:
+        workflow.error_workflow = None
+        _clear_error_workflow_settings(flow_data)
+        workflow.flow_data = flow_data
+        return False
+
+    try:
+        new_uuid = uuid.UUID(mapped_id)
+    except (ValueError, AttributeError):
+        workflow.error_workflow = None
+        _clear_error_workflow_settings(flow_data)
+        workflow.flow_data = flow_data
+        return False
+
+    workflow.error_workflow = new_uuid
+    settings = flow_data.get("settings")
+    if not isinstance(settings, dict):
+        settings = {}
+        flow_data["settings"] = settings
+    settings["error_workflow_id"] = mapped_id
+    workflow.flow_data = flow_data
+    return True
+
+
+def collect_missing_error_workflow_warnings(workflows: List[dict]) -> List[str]:
+    """Return warning messages for error handlers not included in the export bundle."""
+    exported_ids = {str(wf["id"]) for wf in workflows if wf.get("id")}
+    warnings: List[str] = []
+
+    for wf in workflows:
+        error_workflow_id = wf.get("error_workflow")
+        if not error_workflow_id:
+            continue
+        error_workflow_id = str(error_workflow_id)
+        if error_workflow_id not in exported_ids:
+            warnings.append(
+                f"WARN: error handler workflow not included in export for "
+                f"'{wf.get('name', 'unknown')}' (ref: {error_workflow_id})"
+            )
+
+    return warnings


### PR DESCRIPTION
- export error handler workflow references in workflow bundle configuration
- build workflow UUID mappings to remap cross-workflow dependencies during import
- restore error handler links after all workflows have been created or updated
- synchronize error handler references across database fields and workflow settings
- warn when imported bundles reference error handler workflows that are not included
- extract shared workflow bundle import and export utilities to reduce duplication