### PR TITLE
fix: enable reliable cancellation of manual workflow executions

### DIFF
--- a/client/app/components/canvas/FlowCanvas.tsx
+++ b/client/app/components/canvas/FlowCanvas.tsx
@@ -331,6 +331,7 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
     Record<string, "success" | "failed" | "pending">
   >({});
   const [activeExecutionId, setActiveExecutionId] = useState<string | null>(null);
+  const [isManualExecutionRunning, setIsManualExecutionRunning] = useState(false);
 
   // Create node config components and base node types directly from nodes
   const nodeConfigComponents = useMemo(
@@ -498,6 +499,7 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
     getCurrentExecutionForWorkflow,
     setCurrentExecutionForWorkflow,
     cancelExecution,
+    cancelWorkflowExecutions,
     loading: executionLoading,
     error: executionError,
     clearError: clearExecutionError,
@@ -514,41 +516,68 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
 
   // Active stream reader ref to allow cancellation
   const activeReaderRef = useRef<ReadableStreamDefaultReader<Uint8Array> | null>(null);
+  const activeExecutionIdRef = useRef<string | null>(null);
+  const streamCancelledByUserRef = useRef(false);
 
   const handleCancelExecution = useCallback(
-    async (executionId: string) => {
-      // 1. Abort the active stream reader if there is one
-      if (activeReaderRef.current) {
-        try {
-          await activeReaderRef.current.cancel();
-          activeReaderRef.current = null;
-        } catch (err) {
-          console.error("Error cancelling stream reader:", err);
-        }
-      }
+    async (executionId?: string | null) => {
+      streamCancelledByUserRef.current = true;
+      setIsManualExecutionRunning(false);
+
+      const resolvedId =
+        executionId ||
+        activeExecutionIdRef.current ||
+        activeExecutionId;
 
       // Reset active nodes and edges states immediately
       setActiveEdges([]);
       setActiveNodes([]);
+      setActiveExecutionId(null);
+      activeExecutionIdRef.current = null;
 
-      // 2. Call the store's cancelExecution
+      // Abort the active stream reader if there is one
+      if (activeReaderRef.current) {
+        try {
+          await activeReaderRef.current.cancel();
+        } catch (err) {
+          console.error("Error cancelling stream reader:", err);
+        } finally {
+          activeReaderRef.current = null;
+        }
+      }
+
       try {
-        await cancelExecution(executionId);
+        if (resolvedId) {
+          await cancelExecution(resolvedId);
+        } else if (currentWorkflow?.id) {
+          await cancelWorkflowExecutions(currentWorkflow.id);
+        }
       } catch (err: any) {
         console.warn("Backend cancellation failed, handling locally:", err);
       } finally {
-        // Always mark the execution as cancelled/completed locally so the UI updates
-        const currentExec = currentWorkflow?.id ? getCurrentExecutionForWorkflow(currentWorkflow.id) : null;
-        if (currentWorkflow?.id && currentExec && currentExec.id === executionId) {
-          setCurrentExecutionForWorkflow(currentWorkflow.id, {
-            ...currentExec,
-            status: "cancelled",
-            completed_at: new Date().toISOString(),
-          } as any);
+        if (currentWorkflow?.id) {
+          const currentExec = getCurrentExecutionForWorkflow(currentWorkflow.id);
+          if (
+            currentExec &&
+            (currentExec.status === "running" || currentExec.status === "pending")
+          ) {
+            setCurrentExecutionForWorkflow(currentWorkflow.id, {
+              ...currentExec,
+              status: "cancelled",
+              completed_at: new Date().toISOString(),
+            } as any);
+          }
         }
       }
     },
-    [cancelExecution, currentWorkflow?.id, getCurrentExecutionForWorkflow, setCurrentExecutionForWorkflow]
+    [
+      activeExecutionId,
+      cancelExecution,
+      cancelWorkflowExecutions,
+      currentWorkflow?.id,
+      getCurrentExecutionForWorkflow,
+      setCurrentExecutionForWorkflow,
+    ]
   );
 
   // Poll for the active execution status when it is running/pending
@@ -1316,14 +1345,10 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
 
         let lastExecutionId: string | null = null;
 
-        // Set execution status to pending in store to show Cancel button immediately
-        const tempExecutionId = uuidv4();
-        setCurrentExecutionForWorkflow(currentWorkflow.id, {
-          id: tempExecutionId,
-          workflow_id: currentWorkflow.id,
-          status: "pending",
-          started_at: new Date().toISOString(),
-        } as any);
+        streamCancelledByUserRef.current = false;
+        setIsManualExecutionRunning(true);
+        activeExecutionIdRef.current = null;
+        setActiveExecutionId(null);
 
         // Show loading message
         enqueueSnackbar("Executing workflow...", { variant: "info" });
@@ -1381,9 +1406,8 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
                 const evt = JSON.parse(jsonStr);
                 if (evt.execution_id) {
                   lastExecutionId = evt.execution_id;
-                  if (!activeExecutionId) {
-                    setActiveExecutionId(evt.execution_id);
-                  }
+                  activeExecutionIdRef.current = evt.execution_id;
+                  setActiveExecutionId(evt.execution_id);
                   const currentExec = getCurrentExecutionForWorkflow(currentWorkflow.id);
                   if (!currentExec || currentExec.id !== evt.execution_id || currentExec.status !== "running") {
                     setCurrentExecutionForWorkflow(currentWorkflow.id, {
@@ -1546,18 +1570,20 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
               } catch { }
 
               const execIdToFetch = lastExecutionId;
+              const wasCancelledByUser = streamCancelledByUserRef.current;
+              setIsManualExecutionRunning(false);
               setActiveExecutionId(null);
+              activeExecutionIdRef.current = null;
               activeReaderRef.current = null;
 
-              // Show success snackbar only if no errors were received during streaming
-              if (!streamHadError) {
+              if (!streamHadError && !wasCancelledByUser) {
                 enqueueSnackbar("Workflow executed successfully", {
                   variant: "success",
                 });
                 clearExecutionError();
               }
 
-              if (execIdToFetch && currentWorkflow?.id) {
+              if (execIdToFetch && currentWorkflow?.id && !wasCancelledByUser) {
                 (async () => {
                   try {
                     const finalExecution = await getExecution(execIdToFetch);
@@ -1573,13 +1599,17 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
                   }
                 })();
               }
+
+              streamCancelledByUserRef.current = false;
             }
           })();
         } catch (_) {
           // fallback to non-streaming if needed
+          setIsManualExecutionRunning(false);
           await executeWorkflow(currentWorkflow.id, executionData);
         }
       } catch (error: any) {
+        setIsManualExecutionRunning(false);
         console.error("Error executing workflow:", error);
 
         const failedNodeId = error.node_id || undefined;
@@ -2014,6 +2044,7 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
         canUndo={canUndo}
         canRedo={canRedo}
         executionLoading={executionLoading}
+        isManualExecutionRunning={isManualExecutionRunning}
         activeExecutionId={activeExecutionId}
         currentExecution={currentExecution}
         onCancelExecution={handleCancelExecution}

--- a/client/app/components/common/Navbar.tsx
+++ b/client/app/components/common/Navbar.tsx
@@ -45,9 +45,10 @@ interface NavbarProps {
   canUndo?: boolean;
   canRedo?: boolean;
   executionLoading?: boolean;
+  isManualExecutionRunning?: boolean;
   activeExecutionId?: string | null;
   currentExecution?: any;
-  onCancelExecution?: (executionId: string) => Promise<void>;
+  onCancelExecution?: (executionId?: string | null) => Promise<void>;
   hasUnsavedChanges?: boolean;
 }
 
@@ -73,6 +74,7 @@ const Navbar: React.FC<NavbarProps> = ({
   canUndo = false,
   canRedo = false,
   executionLoading,
+  isManualExecutionRunning,
   activeExecutionId,
   currentExecution,
   onCancelExecution,
@@ -292,7 +294,15 @@ const Navbar: React.FC<NavbarProps> = ({
 
   const showExecutionStatus =
     executionLoading ||
+    isManualExecutionRunning ||
     !!activeExecutionId ||
+    (currentExecution &&
+      (currentExecution.status === "running" ||
+        currentExecution.status === "pending"));
+
+  const canCancelExecution =
+    !!activeExecutionId ||
+    isManualExecutionRunning ||
     (currentExecution &&
       (currentExecution.status === "running" ||
         currentExecution.status === "pending"));
@@ -336,8 +346,17 @@ const Navbar: React.FC<NavbarProps> = ({
                   {onCancelExecution && (
                     <button
                       onClick={async () => {
-                        const runId = activeExecutionId || (currentExecution && (currentExecution.status === "running" || currentExecution.status === "pending") ? currentExecution.id : null);
-                        if (runId && confirm("Are you sure you want to cancel this execution?")) {
+                        const runId =
+                          activeExecutionId ||
+                          (currentExecution &&
+                          (currentExecution.status === "running" ||
+                            currentExecution.status === "pending")
+                            ? currentExecution.id
+                            : null);
+                        if (
+                          (runId || isManualExecutionRunning) &&
+                          confirm("Are you sure you want to cancel this execution?")
+                        ) {
                           try {
                             await onCancelExecution(runId);
                             enqueueSnackbar("Workflow execution cancel requested.", { variant: "info" });
@@ -347,13 +366,13 @@ const Navbar: React.FC<NavbarProps> = ({
                           }
                         }
                       }}
-                      className={`px-2 py-0.5 text-[11px] text-red-500 hover:text-red-400 border border-red-500/30 hover:border-red-500/50 rounded transition-colors cursor-pointer shrink-0 ${activeExecutionId || (currentExecution && (currentExecution.status === "running" || currentExecution.status === "pending"))
+                      className={`px-2 py-0.5 text-[11px] text-red-500 hover:text-red-400 border border-red-500/30 hover:border-red-500/50 rounded transition-colors cursor-pointer shrink-0 ${canCancelExecution
                           ? "visible"
                           : "invisible pointer-events-none"
                         }`}
                       title="Cancel Execution"
-                      aria-hidden={!(activeExecutionId || (currentExecution && (currentExecution.status === "running" || currentExecution.status === "pending")))}
-                      tabIndex={activeExecutionId || (currentExecution && (currentExecution.status === "running" || currentExecution.status === "pending")) ? 0 : -1}
+                      aria-hidden={!canCancelExecution}
+                      tabIndex={canCancelExecution ? 0 : -1}
                     >
                       Cancel
                     </button>

--- a/client/app/services/executionService.ts
+++ b/client/app/services/executionService.ts
@@ -52,6 +52,10 @@ export const deleteExecution = async (execution_id: string) => {
 
 export const cancelExecution = async (execution_id: string) => {
   return apiClient.post<WorkflowExecution>(`/executions/${execution_id}/cancel`);
+};
+
+export const cancelWorkflowExecutions = async (workflow_id: string) => {
+  return apiClient.post<WorkflowExecution[]>(`/executions/workflows/${workflow_id}/cancel`);
 }; 
 
 export const exportExecutionsCSV = async (params: {

--- a/client/app/stores/executions.ts
+++ b/client/app/stores/executions.ts
@@ -24,6 +24,7 @@ interface ExecutionsStore {
   getCurrentExecutionForWorkflow: (workflow_id: string) => WorkflowExecution | null;
   deleteExecution: (execution_id: string) => Promise<void>;
   cancelExecution: (execution_id: string) => Promise<void>;
+  cancelWorkflowExecutions: (workflow_id: string) => Promise<void>;
   clearError: () => void;
 }
 
@@ -119,8 +120,15 @@ export const useExecutionsStore = create<ExecutionsStore>((set, get) => ({
       set((state) => {
         const nextCurrentExecutions = { ...state.currentExecutions };
         const wfId = updatedExecution.workflow_id;
-        if (wfId && nextCurrentExecutions[wfId] && nextCurrentExecutions[wfId]?.id === execution_id) {
-          nextCurrentExecutions[wfId] = updatedExecution;
+        if (wfId && nextCurrentExecutions[wfId]) {
+          const current = nextCurrentExecutions[wfId];
+          if (
+            current?.id === execution_id ||
+            current?.status === 'pending' ||
+            current?.status === 'running'
+          ) {
+            nextCurrentExecutions[wfId] = updatedExecution;
+          }
         }
         return {
           executions: state.executions.map(ex => ex.id === execution_id ? updatedExecution : ex),
@@ -130,6 +138,37 @@ export const useExecutionsStore = create<ExecutionsStore>((set, get) => ({
       });
     } catch (e: any) {
       set({ error: e.message || 'Failed to cancel execution', loading: false });
+      throw e;
+    }
+  },
+  cancelWorkflowExecutions: async (workflow_id) => {
+    set({ loading: true, error: null });
+    try {
+      const cancelledExecutions = await executionService.cancelWorkflowExecutions(workflow_id);
+      set((state) => {
+        const nextCurrentExecutions = { ...state.currentExecutions };
+        const current = nextCurrentExecutions[workflow_id];
+        if (current && (current.status === 'pending' || current.status === 'running')) {
+          const match =
+            cancelledExecutions.find((ex) => ex.id === current.id) ||
+            cancelledExecutions[0];
+          nextCurrentExecutions[workflow_id] = match ?? {
+            ...current,
+            status: 'cancelled',
+            completed_at: new Date().toISOString(),
+          };
+        }
+        return {
+          executions: state.executions.map((ex) => {
+            const updated = cancelledExecutions.find((c) => c.id === ex.id);
+            return updated ?? ex;
+          }),
+          currentExecutions: nextCurrentExecutions,
+          loading: false,
+        };
+      });
+    } catch (e: any) {
+      set({ error: e.message || 'Failed to cancel workflow executions', loading: false });
       throw e;
     }
   },


### PR DESCRIPTION
- remove client-side placeholder execution identifiers from manual execution flow
- track server-issued execution IDs and use them for cancellation requests
- fall back to workflow-level cancellation until execution IDs become available
- keep cancellation controls available while manual executions are pending or running
- suppress success notifications after user-initiated execution cancellation
- synchronize execution store state when cancelling active workflow runs