### PR TITLE
feat: prevent unsafe credential deletion through workflow usage tracking

### DIFF
--- a/backend/app/api/credentials.py
+++ b/backend/app/api/credentials.py
@@ -18,6 +18,7 @@ from app.schemas.user_credential import (
     CredentialUpdateRequest,
     CredentialDetailResponse,
     CredentialDeleteResponse,
+    CredentialWorkflowUsageResponse,
     UserCredentialCreate,
 )
 
@@ -115,6 +116,44 @@ async def get_credential_by_id(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to retrieve credential"
         )
+
+
+@router.get("/{credential_id}/workflows", response_model=CredentialWorkflowUsageResponse)
+async def get_credential_workflows(
+    credential_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session),
+    credential_service: CredentialService = Depends(get_credential_service_dep),
+):
+    """
+    List workflows that use the given credential in node configuration.
+
+    Returns minimal workflow metadata and node usage details (no full flow_data).
+    """
+    user_id = current_user.id
+
+    try:
+        usage = await credential_service.get_workflows_using_credential(
+            db, user_id, credential_id
+        )
+        if not usage:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Credential not found",
+            )
+        return usage
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(
+            f"Error retrieving workflow usage for credential {credential_id} "
+            f"and user {user_id}: {e}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to retrieve credential workflow usage",
+        )
+
 
 @router.post("", response_model=CredentialDetailResponse)
 async def create_credential(

--- a/backend/app/core/credential_fields.py
+++ b/backend/app/core/credential_fields.py
@@ -1,0 +1,49 @@
+"""Shared credential field names used in workflow node data."""
+
+from typing import Any, Dict, List, Optional
+
+# Field names in flow_data.nodes[].data that may hold a credential UUID.
+CREDENTIAL_FIELD_NAMES: tuple[str, ...] = (
+    "credential_id",
+    "credential",
+    "basic_auth_credential_id",
+    "header_auth_credential_id",
+    "minio_credential",
+    "llm_credential_id",
+)
+
+
+def find_credential_usages_in_flow_data(
+    flow_data: Optional[Dict[str, Any]],
+    credential_id: str,
+) -> List[Dict[str, str]]:
+    """
+    Return node usage entries where node data references the given credential ID.
+    """
+    if not flow_data or not isinstance(flow_data, dict):
+        return []
+
+    usages: List[Dict[str, str]] = []
+    nodes = flow_data.get("nodes") or []
+    if not isinstance(nodes, list):
+        return usages
+
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        node_data = node.get("data") or {}
+        if not isinstance(node_data, dict):
+            continue
+
+        for field_name in CREDENTIAL_FIELD_NAMES:
+            value = node_data.get(field_name)
+            if value is not None and str(value) == credential_id:
+                usages.append(
+                    {
+                        "node_id": str(node.get("id") or ""),
+                        "node_type": str(node.get("type") or ""),
+                        "field": field_name,
+                    }
+                )
+
+    return usages

--- a/backend/app/schemas/user_credential.py
+++ b/backend/app/schemas/user_credential.py
@@ -1,6 +1,6 @@
 import uuid
 from pydantic import BaseModel
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
 from datetime import datetime
 
 # Base schema with common fields
@@ -53,4 +53,23 @@ class CredentialDetailResponse(BaseModel):
 # Schema for API responses with success message
 class CredentialDeleteResponse(BaseModel):
     message: str
-    deleted_id: uuid.UUID 
+    deleted_id: uuid.UUID
+
+
+class CredentialWorkflowNodeUsage(BaseModel):
+    node_id: str
+    node_type: str
+    field: str
+
+
+class CredentialWorkflowUsageItem(BaseModel):
+    id: uuid.UUID
+    name: str
+    updated_at: datetime
+    using_nodes: List[CredentialWorkflowNodeUsage]
+
+
+class CredentialWorkflowUsageResponse(BaseModel):
+    credential_id: uuid.UUID
+    workflow_count: int
+    workflows: List[CredentialWorkflowUsageItem] 

--- a/backend/app/services/credential_service.py
+++ b/backend/app/services/credential_service.py
@@ -4,10 +4,22 @@ from typing import List, Optional, Dict, Any
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 from sqlalchemy.orm import selectinload
+from sqlalchemy import text, bindparam, or_
 from app.models.user_credential import UserCredential
+from app.models.workflow import Workflow
 from app.services.base import BaseService
-from app.schemas.user_credential import UserCredentialCreate, UserCredentialUpdate
+from app.schemas.user_credential import (
+    UserCredentialCreate,
+    UserCredentialUpdate,
+    CredentialWorkflowUsageResponse,
+    CredentialWorkflowUsageItem,
+    CredentialWorkflowNodeUsage,
+)
 from app.core.encryption import encrypt_data, decrypt_data
+from app.core.credential_fields import (
+    CREDENTIAL_FIELD_NAMES,
+    find_credential_usages_in_flow_data,
+)
 
 
 class CredentialService(BaseService[UserCredential]):
@@ -136,4 +148,70 @@ class CredentialService(BaseService[UserCredential]):
                 "secret": {},
                 "created_at": credential.created_at,
                 "updated_at": credential.updated_at
-            } 
+            }
+
+    async def get_workflows_using_credential(
+        self,
+        db: AsyncSession,
+        user_id: uuid.UUID,
+        credential_id: uuid.UUID,
+    ) -> Optional[CredentialWorkflowUsageResponse]:
+        """
+        Find workflows owned by the user that reference the credential in node data.
+        Uses a JSONB filter in PostgreSQL, then scans only matched workflows in Python.
+        """
+        credential = await self.get_by_user_and_id(db, user_id, credential_id)
+        if not credential:
+            return None
+
+        cred_id_str = str(credential_id)
+        containment_conditions = [
+            Workflow.flow_data.contains({"nodes": [{"data": {field: cred_id_str}}]})
+            for field in CREDENTIAL_FIELD_NAMES
+        ]
+
+        stmt = (
+            select(
+                Workflow.id,
+                Workflow.name,
+                Workflow.updated_at,
+                Workflow.flow_data,
+            )
+            .where(
+                Workflow.user_id == user_id,
+                or_(*containment_conditions),
+            )
+            .order_by(Workflow.updated_at.desc())
+        )
+
+        result = await db.execute(stmt)
+        rows = result.all()
+
+        workflows: List[CredentialWorkflowUsageItem] = []
+        for row in rows:
+            using_nodes_raw = find_credential_usages_in_flow_data(row.flow_data, cred_id_str)
+            if not using_nodes_raw:
+                continue
+
+            using_nodes = [
+                CredentialWorkflowNodeUsage(
+                    node_id=usage["node_id"],
+                    node_type=usage["node_type"],
+                    field=usage["field"],
+                )
+                for usage in using_nodes_raw
+            ]
+            workflows.append(
+                CredentialWorkflowUsageItem(
+                    id=row.id,
+                    name=row.name,
+                    updated_at=row.updated_at,
+                    using_nodes=using_nodes,
+                )
+            )
+
+        return CredentialWorkflowUsageResponse(
+            credential_id=credential_id,
+            workflow_count=len(workflows),
+            workflows=workflows,
+        ) 

--- a/client/app/components/canvas/FlowCanvas.tsx
+++ b/client/app/components/canvas/FlowCanvas.tsx
@@ -694,7 +694,7 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
   );
 
   const [workflowName, setWorkflowName] = useState(
-    currentWorkflow?.name || "isimsiz dosya"
+    currentWorkflow?.name || "Untitled Workflow"
   );
 
   const {
@@ -771,7 +771,7 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
       setCurrentWorkflow(null);
       setNodes([]);
       setEdges([]);
-      setWorkflowName("isimsiz dosya");
+      setWorkflowName("Untitled Workflow");
       clearAllChats(); // Clear chats for new workflow
       hasInitializedEmptyCanvas.current = false;
     }
@@ -781,7 +781,7 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
     if (currentWorkflow?.name) {
       setWorkflowName(currentWorkflow.name);
     } else {
-      setWorkflowName("isimsiz dosya");
+      setWorkflowName("Untitled Workflow");
     }
   }, [currentWorkflow?.name]);
 

--- a/client/app/components/credentials/CredentialCard.tsx
+++ b/client/app/components/credentials/CredentialCard.tsx
@@ -1,9 +1,11 @@
 import React, { useState } from "react";
-import { Check, Loader2, Pencil, Trash, Zap, X as XIcon } from "lucide-react";
+import { Check, Loader2, Pencil, Trash, Zap, Link2, X as XIcon } from "lucide-react";
 import { timeAgo } from "~/lib/dateFormatter";
 import { resolveIconPath } from "~/lib/iconUtils";
 import { getServiceDefinition } from "~/types/credentials";
-import type { UserCredential } from "~/types/api";
+import { getCredentialWorkflows } from "~/services/userCredentialService";
+import type { CredentialWorkflowUsageResponse, UserCredential } from "~/types/api";
+import CredentialWorkflowUsage from "./CredentialWorkflowUsage";
 
 interface CredentialCardProps {
   credential: UserCredential;
@@ -25,6 +27,40 @@ const CredentialCard: React.FC<CredentialCardProps> = ({
   const [iconFailed, setIconFailed] = useState(false);
   const [testState, setTestState] = useState<TestState>("idle");
   const [testMessage, setTestMessage] = useState<string>("");
+  const [isUsageOpen, setIsUsageOpen] = useState(false);
+  const [workflowUsage, setWorkflowUsage] = useState<CredentialWorkflowUsageResponse | null>(null);
+  const [workflowUsageLoading, setWorkflowUsageLoading] = useState(false);
+  const [workflowUsageError, setWorkflowUsageError] = useState<string | null>(null);
+  const [hasLoadedUsage, setHasLoadedUsage] = useState(false);
+
+  const loadUsageData = async () => {
+    if (hasLoadedUsage) return;
+    setWorkflowUsageLoading(true);
+    setWorkflowUsageError(null);
+    try {
+      const usage = await getCredentialWorkflows(credential.id);
+      setWorkflowUsage(usage);
+      setHasLoadedUsage(true);
+    } catch {
+      setWorkflowUsage(null);
+      setWorkflowUsageError("Could not load workflow usage.");
+    } finally {
+      setWorkflowUsageLoading(false);
+    }
+  };
+
+  const handleToggleUsage = () => {
+    const nextState = !isUsageOpen;
+    setIsUsageOpen(nextState);
+    if (nextState) {
+      loadUsageData();
+    }
+  };
+
+  const handleDeleteClick = () => {
+    setShowDeleteConfirm(true);
+    loadUsageData();
+  };
 
   const handleTest = async () => {
     setTestState("loading");
@@ -88,10 +124,35 @@ const CredentialCard: React.FC<CredentialCardProps> = ({
         </div>
       </div>
 
-      {/* Metadata */}
-      <div className="flex items-center gap-3 text-xs text-gray-500 mb-3">
+      {/* Metadata & Usage Trigger */}
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-gray-500 mb-3">
         <span>Created: {timeAgo(credential.created_at)}</span>
+        <span>·</span>
         <span>Updated: {timeAgo(credential.updated_at)}</span>
+        <span>·</span>
+        <button
+          type="button"
+          onClick={handleToggleUsage}
+          className="inline-flex items-center gap-1 text-blue-600 hover:text-blue-800 hover:underline font-medium transition-colors cursor-pointer"
+        >
+          {workflowUsageLoading ? (
+            <Loader2 className="w-3 h-3 animate-spin text-blue-600" />
+          ) : (
+            <Link2 className="w-3 h-3" />
+          )}
+          {workflowUsageLoading ? (
+            <span>Loading...</span>
+          ) : !hasLoadedUsage ? (
+            <span>Show usage</span>
+          ) : workflowUsage && workflowUsage.workflow_count > 0 ? (
+            <span>
+              Used in {workflowUsage.workflow_count} workflow
+              {workflowUsage.workflow_count === 1 ? "" : "s"}
+            </span>
+          ) : (
+            <span>Not used</span>
+          )}
+        </button>
       </div>
 
       {/* Test result message */}
@@ -129,7 +190,7 @@ const CredentialCard: React.FC<CredentialCardProps> = ({
         </button>
 
         <button
-          onClick={() => setShowDeleteConfirm(true)}
+          onClick={handleDeleteClick}
           className="p-1.5 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-md transition-all duration-200"
           title="Delete credential"
         >
@@ -137,28 +198,74 @@ const CredentialCard: React.FC<CredentialCardProps> = ({
         </button>
       </div>
 
+      {/* Expanded workflow list (expands under the card actions) */}
+      <CredentialWorkflowUsage
+        usage={workflowUsage}
+        isLoading={workflowUsageLoading}
+        error={workflowUsageError}
+        isOpen={isUsageOpen}
+      />
+
       {/* Delete Confirmation Modal */}
       {showDeleteConfirm && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg p-5 max-w-sm mx-4">
-            <h3 className="text-base font-bold mb-3">Delete Credential</h3>
-            <p className="text-gray-600 mb-5 text-sm">
-              Are you sure you want to delete <strong>{credential.name}</strong>
-              ? This action cannot be undone.
-            </p>
-            <div className="flex gap-2 justify-end">
+          <div className="bg-white rounded-xl p-6 max-w-md w-full mx-4 shadow-xl border border-gray-100 animate-in fade-in zoom-in-95 duration-200">
+            <h3 className="text-lg font-bold mb-3 text-red-600">Delete Credential</h3>
+            
+            {workflowUsageLoading ? (
+              <div className="flex items-center gap-2 py-4 justify-center text-sm text-gray-500">
+                <Loader2 className="h-5 w-5 animate-spin text-purple-600" />
+                Checking workflow usage safety...
+              </div>
+            ) : workflowUsage && workflowUsage.workflow_count > 0 ? (
+              <div className="space-y-4">
+                <div className="bg-red-50 border border-red-200 rounded-lg p-3 text-sm text-red-800">
+                  <p className="font-semibold mb-1">
+                    Warning: This credential is in use!
+                  </p>
+                  <p className="text-xs">
+                    Deleting <strong>{credential.name}</strong> will break the configurations of <strong>{workflowUsage.workflow_count}</strong> active workflow{workflowUsage.workflow_count === 1 ? "" : "s"}. These workflows will fail during execution!
+                  </p>
+                </div>
+                
+                <div>
+                  <h4 className="text-xs font-semibold text-gray-700 mb-2 uppercase tracking-wider">
+                    Affected Workflows:
+                  </h4>
+                  <ul className="space-y-1.5 max-h-32 overflow-y-auto pr-1 border border-gray-200 rounded-md p-2 bg-gray-50 scrollbar-thin text-xs">
+                    {workflowUsage.workflows.map((workflow) => (
+                      <li key={workflow.id} className="text-gray-700 font-medium truncate">
+                        • {workflow.name}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+                
+                <p className="text-xs text-gray-500">
+                  Are you absolutely sure you want to proceed? This action is highly disruptive and cannot be undone.
+                </p>
+              </div>
+            ) : (
+              <p className="text-gray-600 mb-5 text-sm">
+                Are you sure you want to delete <strong>{credential.name}</strong>? This action cannot be undone.
+              </p>
+            )}
+
+            <div className="flex gap-2.5 justify-end mt-6">
               <button
+                type="button"
                 onClick={() => setShowDeleteConfirm(false)}
-                className="px-3 py-1.5 text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200 text-sm"
+                className="px-4 py-2 text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200 text-sm font-medium transition-all duration-200"
               >
                 Cancel
               </button>
               <button
+                type="button"
                 onClick={() => {
                   onDelete(credential.id);
                   setShowDeleteConfirm(false);
                 }}
-                className="px-3 py-1.5 bg-red-600 text-white rounded-md hover:bg-red-700 text-sm"
+                className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 text-sm font-medium transition-all duration-200 shadow-sm hover:shadow"
               >
                 Delete
               </button>

--- a/client/app/components/credentials/CredentialWorkflowUsage.tsx
+++ b/client/app/components/credentials/CredentialWorkflowUsage.tsx
@@ -1,0 +1,110 @@
+import React, { useState } from "react";
+import { ExternalLink, Loader2, Search } from "lucide-react";
+import { Link } from "react-router";
+import { timeAgo } from "~/lib/dateFormatter";
+import type { CredentialWorkflowUsageResponse } from "~/types/api";
+
+interface CredentialWorkflowUsageProps {
+  usage: CredentialWorkflowUsageResponse | null;
+  isLoading: boolean;
+  error: string | null;
+  isOpen: boolean;
+}
+
+const CredentialWorkflowUsage: React.FC<CredentialWorkflowUsageProps> = ({
+  usage,
+  isLoading,
+  error,
+  isOpen,
+}) => {
+  const [searchTerm, setSearchTerm] = useState("");
+
+  // Hide component while loading or when not open
+  if (!isOpen || isLoading) return null;
+
+  const count = usage?.workflow_count ?? 0;
+
+  // Filter workflows by search term
+  const filteredWorkflows = usage?.workflows.filter((w) =>
+    w.name.toLowerCase().includes(searchTerm.toLowerCase())
+  ) || [];
+
+  return (
+    <div className="mt-3 pt-3 border-t border-gray-100 space-y-2.5 animate-in slide-in-from-top-2 duration-200">
+      {error ? (
+        <p className="text-xs text-red-500 py-0.5">{error}</p>
+      ) : count === 0 ? (
+        <p className="text-xs text-gray-500 py-0.5">Not used in any workflow</p>
+      ) : (
+        <>
+          <div className="flex items-center justify-between">
+            <span className="text-[10px] font-bold text-gray-400 uppercase tracking-wider">
+              Used in workflows ({count})
+            </span>
+          </div>
+
+          {/* Search Input for 5+ workflows */}
+          {count > 5 && (
+            <div className="relative">
+              <Search className="absolute left-2 top-1/2 transform -translate-y-1/2 h-3 w-3 text-gray-400" />
+              <input
+                type="text"
+                placeholder="Search workflows..."
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                className="w-full pl-7 pr-3 py-1 text-xs border border-gray-200 rounded-md focus:ring-1 focus:ring-blue-500 focus:border-transparent outline-none bg-gray-50/50"
+              />
+            </div>
+          )}
+
+          {/* Workflows List */}
+          {filteredWorkflows.length === 0 ? (
+            <p className="text-xs text-gray-400 py-1 text-center">No matching workflows found</p>
+          ) : (
+            <ul className="space-y-1.5 max-h-36 overflow-y-auto pr-1 scrollbar-thin">
+              {filteredWorkflows.map((workflow) => {
+                const primaryNode = workflow.using_nodes[0];
+                const extraNodes = workflow.using_nodes.length - 1;
+
+                return (
+                  <li
+                    key={workflow.id}
+                    className="flex items-start justify-between gap-2 text-xs py-1 hover:bg-gray-50 rounded px-1.5 transition-colors"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <Link
+                        to={`/canvas?workflow=${workflow.id}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="font-medium text-blue-600 hover:text-blue-800 hover:underline truncate block"
+                      >
+                        {workflow.name}
+                      </Link>
+                      <p className="text-[10px] text-gray-400 mt-0.5">
+                        {primaryNode?.node_type || "Node"}
+                        {extraNodes > 0 ? ` (+${extraNodes})` : ""}
+                        {" · "}
+                        updated {timeAgo(workflow.updated_at)}
+                      </p>
+                    </div>
+                    <Link
+                      to={`/canvas?workflow=${workflow.id}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="shrink-0 p-0.5 text-gray-400 hover:text-blue-600 transition-colors"
+                      title="Open workflow"
+                    >
+                      <ExternalLink className="h-3 w-3" />
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default CredentialWorkflowUsage;

--- a/client/app/lib/config.ts
+++ b/client/app/lib/config.ts
@@ -79,6 +79,7 @@ export const API_ENDPOINTS = {
     DELETE: (id: string) => `/credentials/${id}`,
     TEST: (id: string) => `/credentials/${id}/test`,
     TEST_RAW: '/credentials/test-raw',
+    WORKFLOWS: (id: string) => `/credentials/${id}/workflows`,
   },
   API_KEYS: {
     LIST: '/api-keys',

--- a/client/app/routes/credentials.tsx
+++ b/client/app/routes/credentials.tsx
@@ -11,15 +11,13 @@ import {
   Cloud,
   Settings,
 } from "lucide-react";
-import { testUserCredential, testCredentialRaw } from "~/services/userCredentialService";
+import { testUserCredential, testCredentialRaw, getUserCredentialById } from "~/services/userCredentialService";
 import React, { useState, useEffect } from "react";
 import DashboardSidebar from "~/components/dashboard/DashboardSidebar";
 import { useUserCredentialStore } from "../stores/userCredential";
 import type { CredentialCreateRequest, UserCredential } from "../types/api";
 import Loading from "~/components/Loading";
 import AuthGuard from "~/components/AuthGuard";
-import { apiClient } from "../lib/api-client";
-import { getUserCredentialById } from "~/services/userCredentialService";
 import ServiceSelectionModal from "../components/credentials/ServiceSelectionModal";
 import DynamicCredentialForm from "../components/credentials/DynamicCredentialForm";
 import CredentialCard from "../components/credentials/CredentialCard";
@@ -51,6 +49,11 @@ function CredentialsLayout() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState<string>("all");
   const [editingInitialValues, setEditingInitialValues] = useState<Record<string, any>>({});
+  const resetCredentialModal = () => {
+    setSelectedService(null);
+    setEditingCredential(null);
+    setEditingInitialValues({});
+  };
 
   const servicesByCategory = getServicesByCategory();
   const categories = Object.keys(servicesByCategory);
@@ -127,6 +130,7 @@ function CredentialsLayout() {
     if (serviceDef) {
       setSelectedService(serviceDef);
     }
+
     try {
       const detail = await getUserCredentialById(credential.id);
       if (detail?.secret && typeof detail.secret === "object") {
@@ -161,9 +165,7 @@ function CredentialsLayout() {
       };
 
       await updateCredential(editingCredential.id, payload);
-      setEditingCredential(null);
-      setSelectedService(null);
-      setEditingInitialValues({});
+      resetCredentialModal();
     } catch (e: any) {
       console.error("Failed to update credential:", e);
     } finally {
@@ -386,11 +388,7 @@ function CredentialsLayout() {
                     : "Connect to " + selectedService.name}
                 </h2>
                 <button
-                  onClick={() => {
-                    setSelectedService(null);
-                    setEditingCredential(null);
-                    setEditingInitialValues({});
-                  }}
+                  onClick={resetCredentialModal}
                   className="text-gray-400 hover:text-gray-600 transition-colors"
                 >
                   <svg
@@ -416,11 +414,7 @@ function CredentialsLayout() {
                     ? handleUpdateCredential
                     : handleCredentialSubmit
                 }
-                onCancel={() => {
-                  setSelectedService(null);
-                  setEditingCredential(null);
-                  setEditingInitialValues({});
-                }}
+                onCancel={resetCredentialModal}
                 onTest={async (values) => {
                   const { name, ...data } = values;
                   return await testCredentialRaw(selectedService.id, data);

--- a/client/app/services/userCredentialService.ts
+++ b/client/app/services/userCredentialService.ts
@@ -1,7 +1,12 @@
 // User Credential Service Template
 import { apiClient } from '~/lib/api-client';
 import { API_ENDPOINTS } from '~/lib/config';
-import type { UserCredential, CredentialDetailResponse, CredentialCreateRequest } from '~/types/api';
+import type {
+  UserCredential,
+  CredentialDetailResponse,
+  CredentialCreateRequest,
+  CredentialWorkflowUsageResponse,
+} from '~/types/api';
 
 export const getUserCredentials = async (): Promise<UserCredential[]> => {
   return await apiClient.get<UserCredential[]>(API_ENDPOINTS.CREDENTIALS.LIST);
@@ -34,5 +39,13 @@ export const testCredentialRaw = async (
   return await apiClient.post<{ success: boolean; message: string }>(
     API_ENDPOINTS.CREDENTIALS.TEST_RAW,
     { service_type: serviceType, data }
+  );
+};
+
+export const getCredentialWorkflows = async (
+  id: string
+): Promise<CredentialWorkflowUsageResponse> => {
+  return await apiClient.get<CredentialWorkflowUsageResponse>(
+    API_ENDPOINTS.CREDENTIALS.WORKFLOWS(id)
   );
 };

--- a/client/app/types/api.ts
+++ b/client/app/types/api.ts
@@ -280,6 +280,25 @@ export interface CredentialCreateRequest {
   service_type?: string;
 }
 
+export interface CredentialWorkflowNodeUsage {
+  node_id: string;
+  node_type: string;
+  field: string;
+}
+
+export interface CredentialWorkflowUsageItem {
+  id: string;
+  name: string;
+  updated_at: string;
+  using_nodes: CredentialWorkflowNodeUsage[];
+}
+
+export interface CredentialWorkflowUsageResponse {
+  credential_id: string;
+  workflow_count: number;
+  workflows: CredentialWorkflowUsageItem[];
+}
+
 // Variables types (for future implementation)
 export interface Variable {
   id: string;


### PR DESCRIPTION
- add backend APIs to discover workflows referencing selected credentials
- optimize credential usage lookups with GIN-indexed JSONB containment queries scoped to the current user
- guard against invalid workflow structures during usage discovery to prevent database query failures
- include llm_credential_id references when resolving workflow credential dependencies
- lazy-load workflow usage data to eliminate unnecessary client-side requests
- display active workflow dependency warnings before credential deletion
- add a collapsible workflow usage list with bounded layout and scroll support
- support workflow search when credentials are referenced by large numbers of workflows
- open workflow links in new tabs using safe navigation attributes
- consolidate modal reset logic through shared helper utilities
- standardize unnamed workflow fallback labels to "Untitled Workflow"