### PR TITLE
refactor: update Tavily connection check to use httpx

### DIFF
--- a/backend/app/api/credentials.py
+++ b/backend/app/api/credentials.py
@@ -399,13 +399,19 @@ async def _test_cohere(secret: Dict[str, Any]) -> CredentialTestResponse:
 
 
 async def _test_tavily(secret: Dict[str, Any]) -> CredentialTestResponse:
-    try:
-        from tavily import AsyncTavilyClient
+    api_key = str(secret.get("api_key", "")).strip()
+    if not api_key:
+        return CredentialTestResponse(success=False, message="API key is required.")
 
-        client = AsyncTavilyClient(api_key=secret.get("api_key", ""))
-        await asyncio.wait_for(client.search("test"), timeout=10)
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            response = await client.get(
+                "https://api.tavily.com/usage",
+                headers={"Authorization": f"Bearer {api_key}"},
+            )
+            response.raise_for_status()
         return CredentialTestResponse(success=True, message="Connected to Tavily successfully.")
-    except asyncio.TimeoutError:
+    except (asyncio.TimeoutError, httpx.TimeoutException):
         return CredentialTestResponse(success=False, message="Connection timed out.")
     except Exception as e:
         return CredentialTestResponse(success=False, message=str(e))


### PR DESCRIPTION
## Summary

Fixes the Tavily credential connection test that incorrectly reported a backend dependency error even when the API key was valid.

## Root Cause

The connection test used `AsyncTavilyClient` from the `tavily-python` SDK, but this package was not included in the backend dependencies.

## Changes

- Removed the unavailable SDK dependency from the connection test.
- Used the existing `httpx` dependency and Tavily `/usage` endpoint.
- Added empty API key and timeout handling.
- Prevented search credit consumption during connection testing.

## Validation

- Python syntax check passed.
- Success, invalid key, empty key and timeout scenarios were checked.

## Scope

Only `backend/app/api/credentials.py` was changed.
