### PR TITLE
fix: enable environment variable overrides for application core constants

### DIFF
--- a/backend/app/core/constants.py
+++ b/backend/app/core/constants.py
@@ -119,7 +119,7 @@ def _decrypt_env_val(key: str, default: Optional[str] = None) -> Optional[str]:
 
 # Core Application Settings
 SECRET_KEY = _decrypt_env_val("SECRET_KEY", "your-secret-key-here-change-in-production")
-ENVIRONMENT = "development"
+ENVIRONMENT = os.getenv("ENVIRONMENT", "development").lower()
 PORT = int(os.getenv("BACKEND_PORT","23056"))
 ROOT_PATH = os.getenv("ROOT_PATH")
 API_START = "api"
@@ -147,7 +147,7 @@ CREDENTIAL_MASTER_KEY = _decrypt_env_val("CREDENTIAL_MASTER_KEY")
 if not CREDENTIAL_MASTER_KEY:
     raise RuntimeError("CREDENTIAL_MASTER_KEY environment variable is required. Generate one with: python -c \"from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())\"")
 # Logging
-LOG_LEVEL = "DEBUG"
+LOG_LEVEL = os.getenv("LOG_LEVEL", "DEBUG").upper()
 DEBUG = os.getenv("BACKEND_DEBUG", "false").lower() in ("true", "1", "t")
 
 # CORS Settings


### PR DESCRIPTION
- Retrieve `ENVIRONMENT` and `LOG_LEVEL` values dynamically from system environment variables.
- Normalize configuration values using `lower()` and `upper()` to prevent case-related mismatches.
- Preserve the default `development` environment and `DEBUG` log level as fallback values for backward compatibility.