### PR TITLE
fix: remove unsupported `context_id` argument from credential resolution

### DIFF
--- a/backend/app/core/credential_provider.py
+++ b/backend/app/core/credential_provider.py
@@ -199,7 +199,7 @@ class CredentialProvider:
                 credential = credentials[0] if credentials else None
             
             if credential:
-                return await self.get_credential(credential.id, context_id=context_id, user_id=user_id)
+                return await self.get_credential(credential.id, user_id=user_id)
             
             return None
             


### PR DESCRIPTION
- Remove the unsupported `context_id` keyword argument from the `CredentialProvider.get_credential` call in `get_credential_by_service`.
- Update the method invocation to use the supported `credential_id` and `user_id` parameters, preventing runtime `TypeError` exceptions.
- Add unit tests in `backend/tests/test_issue_498.py` to verify service-based credential resolution with the corrected method signature.