### PR TITLE
Fix sticky note text reset during auto-save

### DIFF
--- a/client/app/components/canvas/FlowCanvas.tsx
+++ b/client/app/components/canvas/FlowCanvas.tsx
@@ -1744,9 +1744,7 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
           EndNode: (props: any) => (
             <EndNode {...props} isActive={activeNodes.includes(props.id)} />
           ),
-          StickyNoteNode: (props: any) => (
-            <StickyNoteNode {...props} />
-          ),
+          StickyNoteNode,
         } as Record<string, React.ComponentType<any> | null>
       ),
     [nodes, handleStartNodeExecution, executionLoading, activeNodes]

--- a/client/app/components/node/StickyNoteNode.tsx
+++ b/client/app/components/node/StickyNoteNode.tsx
@@ -74,26 +74,28 @@ function StickyNoteNode({ id, data, selected }: StickyNoteNodeProps) {
   };
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setText(e.target.value);
+    const nextText = e.target.value;
+    setText(nextText);
+
+    // Keep the React Flow node data current while editing. Auto-save reads from
+    // the canvas state, so waiting for blur can otherwise persist stale text.
+    setNodes((nodes) =>
+      nodes.map((node) =>
+        node.id === id
+          ? {
+              ...node,
+              data: {
+                ...node.data,
+                text: nextText,
+              },
+            }
+          : node
+      )
+    );
   };
 
   const handleBlur = () => {
     setIsEditing(false);
-    // Auto-save the text to the node's data so it persists
-    setNodes((nodes) =>
-      nodes.map((n) => {
-        if (n.id === id) {
-          return {
-            ...n,
-            data: {
-              ...n.data,
-              text: text,
-            },
-          };
-        }
-        return n;
-      })
-    );
   };
 
   return (


### PR DESCRIPTION
## What changed

- Persist sticky note text to React Flow node data on every edit.
- Register `StickyNoteNode` with a stable component identity.

## Why

Sticky note drafts previously lived only in local component state until blur. If auto-save or another canvas update occurred while typing, the node could remount with stale persisted data and reset the user's text.

## Impact

Users can continue typing while auto-save runs without losing the note text or editor state. No new dependency is introduced.

## Validation

- `npm.cmd run build` passes.
- `npm.cmd run typecheck` reaches the repository's existing baseline errors in node field `show` typings and credential `helpText` typings; no new error comes from this change.
