### PR TITLE
feat: add persistent category field and workflow metadata export support

### DIFF
--- a/backend/app/models/workflow.py
+++ b/backend/app/models/workflow.py
@@ -13,6 +13,7 @@ class Workflow(Base):
     user_id = Column(UUID(as_uuid=True), ForeignKey('users.id', ondelete='CASCADE'), nullable=False, index=True)
     name = Column(String(255), nullable=False)
     description = Column(Text)
+    category = Column(String(100), nullable=True)
     is_public = Column(Boolean, default=False, index=True)
     version = Column(Integer, default=1)
     error_workflow = Column(

--- a/backend/app/schemas/workflow.py
+++ b/backend/app/schemas/workflow.py
@@ -17,6 +17,7 @@ class UserInfo(BaseModel):
 class WorkflowBase(BaseModel):
     name: str
     description: Optional[str] = None
+    category: Optional[str] = None
     is_public: bool = False
     error_workflow: Optional[uuid.UUID] = None
     flow_data: Dict[str, Any] = Field(default_factory=dict)
@@ -29,6 +30,7 @@ class WorkflowCreate(WorkflowBase):
 class WorkflowUpdate(BaseModel):
     name: Optional[str] = None
     description: Optional[str] = None
+    category: Optional[str] = None
     is_public: Optional[bool] = None
     error_workflow: Optional[uuid.UUID] = None
     flow_data: Optional[Dict[str, Any]] = None

--- a/client/app/components/common/Navbar.tsx
+++ b/client/app/components/common/Navbar.tsx
@@ -228,7 +228,16 @@ const Navbar: React.FC<NavbarProps> = ({
       id: currentWorkflow.id,
       user_id: currentWorkflow.user_id,
       name: currentWorkflow.name,
-      description: currentWorkflow.description,
+      description: currentWorkflow.description || "",
+      category: (currentWorkflow.flow_data as any)?.category || (currentWorkflow as any).category || "automation",
+      created_at: currentWorkflow.created_at || new Date().toISOString(),
+      colorFrom: (currentWorkflow.flow_data as any)?.colorFrom || (currentWorkflow as any).colorFrom || "from-blue-500",
+      colorTo: (currentWorkflow.flow_data as any)?.colorTo || (currentWorkflow as any).colorTo || "to-indigo-600",
+      icon: (currentWorkflow.flow_data as any)?.icon || (currentWorkflow as any).icon || {
+        name: "workflow",
+        path: null,
+        alt: "Workflow Icon",
+      },
       is_public: currentWorkflow.is_public,
       flow_data: {
         nodes: (currentWorkflow.flow_data?.nodes || []).map((node: any) => {

--- a/client/app/components/modals/WorkflowEditModal.tsx
+++ b/client/app/components/modals/WorkflowEditModal.tsx
@@ -4,6 +4,7 @@ import { Formik, Form, Field, ErrorMessage } from "formik";
 
 interface WorkflowFormValues {
   name: string;
+  category?: string;
   description: string;
   is_public: boolean;
 }
@@ -12,6 +13,7 @@ interface Workflow {
   id: string;
   name: string;
   description?: string;
+  category?: string;
   is_public: boolean;
   flow_data?: any;
 }
@@ -88,6 +90,7 @@ export default function WorkflowEditModal({
               enableReinitialize
               initialValues={{
                 name: workflow.name || "",
+                category: workflow.flow_data?.category || workflow.category || "automation",
                 description: workflow.description || "",
                 is_public: workflow.is_public || false,
               }}
@@ -119,6 +122,25 @@ export default function WorkflowEditModal({
                     />
                     <ErrorMessage
                       name="name"
+                      component="p"
+                      className="mt-1 text-xs text-red-600"
+                    />
+                  </div>
+
+                  {/* Category Field */}
+                  <div>
+                    <label htmlFor="category" className="flex items-center gap-2 text-sm font-medium text-gray-700 mb-2">
+                      <FileText className="w-4 h-4" />
+                      Category
+                    </label>
+                    <Field
+                      name="category"
+                      type="text"
+                      placeholder="Enter category"
+                      className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200 text-sm"
+                    />
+                    <ErrorMessage
+                      name="category"
                       component="p"
                       className="mt-1 text-xs text-red-600"
                     />

--- a/client/app/data/prebuiltTemplates.tsx
+++ b/client/app/data/prebuiltTemplates.tsx
@@ -1,15 +1,20 @@
-// Dynamically load all JSON files in the templates folder
-const templateModules = import.meta.glob<{
+export type MarketplaceCategory = string;
+
+export type PrebuiltTemplate = {
   id: string;
   name: string;
   description: string;
+  category: MarketplaceCategory;
+  created_at: string;
   colorFrom: string;
   colorTo: string;
   icon: { name: string; path: string | null; alt: string | null };
   flow_data: any;
-}>("./templates/*.json", { eager: true });
+};
 
-// Convert template files to array
-export const prebuiltTemplates = Object.values(templateModules);
+const templateModules = import.meta.glob<PrebuiltTemplate>("./templates/*.json", {
+  eager: true,
+  import: "default",
+});
 
-export type PrebuiltTemplate = (typeof prebuiltTemplates)[number];
+export const prebuiltTemplates: PrebuiltTemplate[] = Object.values(templateModules);

--- a/client/app/data/templates/RAG-Usage-Flow.json
+++ b/client/app/data/templates/RAG-Usage-Flow.json
@@ -1,5 +1,7 @@
 {
   "id": "rag-usage-flow",
+  "category": "ai-ml",
+  "created_at": "2025-03-10T00:00:00.000Z",
   "name": "RAG Usage Flow",
   "description": "Complete RAG architecture with OpenAI LLM, embeddings, vector retrieval, and intelligent agent for document-based Q&A.",
   "colorFrom": "from-indigo-500",

--- a/client/app/data/templates/Webhook-Template.json
+++ b/client/app/data/templates/Webhook-Template.json
@@ -1,5 +1,7 @@
 {
   "id": "webhook-template",
+  "category": "integration",
+  "created_at": "2025-02-20T00:00:00.000Z",
   "name": "Webhook Template",
   "description": "The data we provide as input is passed to the agent via the Webhook URL link provided with the Webhook Node. Based on the agent's output, the Code Node receives this output and returns a response to us.",
   "colorFrom": "from-green-500",

--- a/client/app/data/templates/basic-agent.json
+++ b/client/app/data/templates/basic-agent.json
@@ -1,5 +1,7 @@
 {
   "id": "basic-agent",
+  "category": "ai-ml",
+  "created_at": "2025-01-15T00:00:00.000Z",
   "name": "Basic Agent",
   "description": "AI Agent with OpenAI LLM for intelligent conversations and task execution. Includes StartNode → OpenAI Chat → Agent → EndNode workflow.",
   "colorFrom": "from-blue-500",

--- a/client/app/data/templates/kafka-template.json
+++ b/client/app/data/templates/kafka-template.json
@@ -1,5 +1,7 @@
 {
   "id": "kafka-template",
+  "category": "automation",
+  "created_at": "2025-04-01T00:00:00.000Z",
   "name": "Kafka Template",
   "description": "Automated Data Security (DLP) review pipeline. Listens to Kafka for column classification requests (REVIEW/SUSPECT), uses AI to validate sample data against security rules, and publishes the final decision back to Kafka.",
   "colorFrom": "from-rose-400",

--- a/client/app/data/templates/rag-pipeline.json
+++ b/client/app/data/templates/rag-pipeline.json
@@ -1,5 +1,7 @@
 {
   "id": "rag-pipeline",
+  "category": "data-processing",
+  "created_at": "2025-03-01T00:00:00.000Z",
   "name": "RAG Pipeline",
   "description": "Complete RAG architecture with web scraping, document chunking, embeddings, and vector storage. Ready for intelligent document retrieval and Q&A.",
   "colorFrom": "from-emerald-500",

--- a/client/app/routes/marketplace.tsx
+++ b/client/app/routes/marketplace.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useMemo } from "react";
 import {
   Copy,
   RefreshCw,
@@ -49,6 +49,25 @@ function MarketplaceLayout() {
   const [sortBy, setSortBy] = useState("newest");
   const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
 
+  const availableCategories = useMemo(() => {
+    const cats = new Set<string>();
+    prebuiltTemplates.forEach((t) => {
+      if (t.category) cats.add(t.category);
+    });
+    publicWorkflows.forEach((w: any) => {
+      if (w.category) cats.add(w.category);
+    });
+    return Array.from(cats).sort();
+  }, [publicWorkflows]);
+
+  const formatCategoryLabel = (cat: string) => {
+    if (cat === "ai-ml") return "AI & ML";
+    return cat
+      .split(/[-_]/)
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(" ");
+  };
+
   const filteredWorkflows = publicWorkflows
     .filter((workflow) => {
       // Search filter
@@ -89,11 +108,31 @@ function MarketplaceLayout() {
           );
         case "alphabetical":
           return a.name.localeCompare(b.name);
-        case "popular":
-          // For now, sort by created date as we don't have popularity metrics
-          return (
-            new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-          );
+        default:
+          return 0;
+      }
+    });
+
+  const filteredTemplates = prebuiltTemplates
+    .filter((tpl) => {
+      const matchesSearch =
+        searchQuery === "" ||
+        tpl.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        tpl.description?.toLowerCase().includes(searchQuery.toLowerCase());
+
+      const matchesCategory =
+        category === "all" || tpl.category === category;
+
+      return matchesSearch && matchesCategory;
+    })
+    .sort((a, b) => {
+      switch (sortBy) {
+        case "newest":
+          return new Date(b.created_at || 0).getTime() - new Date(a.created_at || 0).getTime();
+        case "oldest":
+          return new Date(a.created_at || 0).getTime() - new Date(b.created_at || 0).getTime();
+        case "alphabetical":
+          return a.name.localeCompare(b.name);
         default:
           return 0;
       }
@@ -270,10 +309,11 @@ function MarketplaceLayout() {
                     className="px-3 py-2 text-sm border border-gray-300 rounded-lg bg-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                   >
                     <option value="all">All Categories</option>
-                    <option value="automation">Automation</option>
-                    <option value="data-processing">Data Processing</option>
-                    <option value="ai-ml">AI & ML</option>
-                    <option value="integration">Integration</option>
+                    {availableCategories.map((cat) => (
+                      <option key={cat} value={cat}>
+                        {formatCategoryLabel(cat)}
+                      </option>
+                    ))}
                   </select>
 
                   {/* Sort Filter */}
@@ -284,7 +324,6 @@ function MarketplaceLayout() {
                   >
                     <option value="newest">Newest First</option>
                     <option value="oldest">Oldest First</option>
-                    <option value="popular">Most Popular</option>
                     <option value="alphabetical">A-Z</option>
                   </select>
 
@@ -307,91 +346,134 @@ function MarketplaceLayout() {
 
                 <div className="flex items-center gap-2 text-sm text-gray-600">
                   <Filter className="w-4 h-4" />
-                  {filteredWorkflows.length} results
+                  {filteredWorkflows.length + filteredTemplates.length} results
                 </div>
               </div>
             </div>
 
             {/* Pre-built Templates */}
-            <div className="mb-10">
-              <div className="flex items-center justify-between mb-6">
-                <div className="flex items-center gap-3">
-                  <div className="w-8 h-8 bg-blue-600 rounded-lg flex items-center justify-center">
-                    <Star className="w-4 h-4 text-white" />
-                  </div>
-                  <div>
-                    <h2 className="text-2xl font-bold text-gray-900">
-                      ⚡ Quick Start Templates
-                    </h2>
-                    <p className="text-sm text-gray-600">
-                      Ready-to-use templates to get you started instantly
-                    </p>
-                  </div>
-                </div>
-                <span className="px-3 py-1 bg-blue-100 text-blue-700 text-xs font-semibold rounded-full">
-                  {prebuiltTemplates.length} Templates
-                </span>
-              </div>
-
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-                {prebuiltTemplates.map((tpl) => (
-                  <div
-                    key={tpl.id}
-                    className="group relative overflow-hidden rounded-2xl border border-gray-200 bg-white hover:shadow-xl hover:shadow-blue-500/10 transition-all duration-300 hover:border-blue-200 hover:-translate-y-1"
-                  >
-                    {/* Background Pattern */}
-                    <div className="absolute top-0 right-0 w-24 h-24 opacity-5">
-                      <div
-                        className={`w-full h-full bg-gradient-to-br ${tpl.colorFrom} ${tpl.colorTo} rounded-full transform translate-x-8 -translate-y-8`}
-                      />
+            {filteredTemplates.length > 0 && (
+              <div className="mb-10">
+                <div className="flex items-center justify-between mb-6">
+                  <div className="flex items-center gap-3">
+                    <div className="w-8 h-8 bg-blue-600 rounded-lg flex items-center justify-center">
+                      <Star className="w-4 h-4 text-white" />
                     </div>
-
-                    <div className="relative p-6">
-                      {/* Icon */}
-                      <div className="flex items-center justify-between mb-4">
-                        <div
-                          className={`flex items-center justify-center w-12 h-12 rounded-xl bg-gradient-to-br ${tpl.colorFrom} ${tpl.colorTo} shadow-lg group-hover:scale-110 transition-transform duration-300`}
-                        >
-                          {React.createElement(getIconComponent(tpl.icon), {
-                            className: "w-6 h-6 text-white",
-                          })}
-                        </div>
-                        <span className="text-xs bg-gray-100 text-gray-600 px-2 py-1 rounded-full font-medium">
-                          Template
-                        </span>
-                      </div>
-
-                      {/* Content */}
-                      <h3 className="text-lg font-bold text-gray-900 mb-2 group-hover:text-blue-700 transition-colors">
-                        {tpl.name}
-                      </h3>
-                      <p className="text-sm text-gray-600 mb-4 line-clamp-2 min-h-[40px]">
-                        {tpl.description}
+                    <div>
+                      <h2 className="text-2xl font-bold text-gray-900">
+                        ⚡ Quick Start Templates
+                      </h2>
+                      <p className="text-sm text-gray-600">
+                        Ready-to-use templates to get you started instantly
                       </p>
-
-                      {/* Tags */}
-                      <div className="flex flex-wrap gap-1 mb-4">
-                        <span className="text-xs bg-blue-100 text-blue-700 px-2 py-1 rounded-md">
-                          Ready-to-use
-                        </span>
-                        <span className="text-xs bg-green-100 text-green-700 px-2 py-1 rounded-md">
-                          Free
-                        </span>
-                      </div>
-
-                      {/* Action Button */}
-                      <button
-                        className="w-full flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-semibold rounded-xl bg-blue-600 text-white hover:bg-blue-700 transition-all duration-200 shadow-lg hover:shadow-xl group-hover:scale-105"
-                        onClick={() => handleUseTemplate(tpl.id)}
-                      >
-                        <Download className="w-4 h-4" />
-                        Use Template
-                      </button>
                     </div>
                   </div>
-                ))}
-              </div>
+                  <span className="px-3 py-1 bg-blue-100 text-blue-700 text-xs font-semibold rounded-full">
+                    {filteredTemplates.length} Templates
+                  </span>
+                </div>
+
+                {viewMode === "grid" ? (
+                  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+                    {filteredTemplates.map((tpl) => (
+                      <div
+                        key={tpl.id}
+                        className="group relative overflow-hidden rounded-2xl border border-gray-200 bg-white hover:border-blue-300 transition-colors"
+                      >
+                        <div className="relative p-6">
+                          {/* Icon */}
+                          <div className="flex items-center justify-between mb-4">
+                            <div
+                              className={`flex items-center justify-center w-12 h-12 rounded-xl bg-gradient-to-br ${tpl.colorFrom} ${tpl.colorTo}`}
+                            >
+                              {React.createElement(getIconComponent(tpl.icon), {
+                                className: "w-6 h-6 text-white",
+                              })}
+                            </div>
+                            <span className="text-xs bg-gray-100 text-gray-600 px-2 py-1 rounded-full font-medium">
+                              Template
+                            </span>
+                          </div>
+
+                          {/* Content */}
+                          <h3 className="text-lg font-bold text-gray-900 mb-2 group-hover:text-blue-700 transition-colors">
+                            {tpl.name}
+                          </h3>
+                          <p className="text-sm text-gray-600 mb-4 line-clamp-2 min-h-[40px]">
+                            {tpl.description}
+                          </p>
+
+                          {/* Tags */}
+                          <div className="flex flex-wrap gap-1 mb-4">
+                            <span className="text-xs bg-blue-100 text-blue-700 px-2 py-1 rounded-md">
+                              Ready-to-use
+                            </span>
+                            <span className="text-xs bg-green-100 text-green-700 px-2 py-1 rounded-md">
+                              Free
+                            </span>
+                          </div>
+
+                          {/* Action Button */}
+                          <button
+                            className="w-full flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-semibold rounded-xl bg-blue-600 text-white hover:bg-blue-700 transition-colors"
+                            onClick={() => handleUseTemplate(tpl.id)}
+                          >
+                            <Download className="w-4 h-4" />
+                            Use Template
+                          </button>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="space-y-4">
+                    {filteredTemplates.map((tpl) => (
+                      <div
+                        key={tpl.id}
+                        className="group flex items-center gap-6 p-6 bg-white border border-gray-200 rounded-2xl hover:border-blue-300 transition-colors"
+                      >
+                        {/* Icon */}
+                        <div className="flex-shrink-0">
+                          <div
+                            className={`flex items-center justify-center w-12 h-12 rounded-xl bg-gradient-to-br ${tpl.colorFrom} ${tpl.colorTo}`}
+                          >
+                            {React.createElement(getIconComponent(tpl.icon), {
+                              className: "w-6 h-6 text-white",
+                            })}
+                          </div>
+                        </div>
+
+                        {/* Content */}
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-3 mb-2">
+                            <h3 className="text-lg font-bold text-gray-900 group-hover:text-blue-700 transition-colors">
+                              {tpl.name}
+                            </h3>
+                            <span className="text-xs bg-gray-100 text-gray-600 px-2 py-1 rounded-full font-medium">
+                              Template
+                            </span>
+                          </div>
+                          <p className="text-sm text-gray-600 line-clamp-2">
+                            {tpl.description}
+                          </p>
+                        </div>
+
+                        {/* Action */}
+                        <div className="flex-shrink-0">
+                          <button
+                            className="flex items-center gap-2 px-6 py-2.5 text-sm font-semibold rounded-xl bg-blue-600 text-white hover:bg-blue-700 transition-colors"
+                            onClick={() => handleUseTemplate(tpl.id)}
+                          >
+                            <Download className="w-4 h-4" />
+                            Use Template
+                          </button>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
             </div>
+          )}
 
             {/* Pinned Workflows Section */}
             {(() => {
@@ -503,23 +585,18 @@ function MarketplaceLayout() {
                       {pagedWorkflows.map((wf) => (
                         <div
                           key={wf.id}
-                          className="group relative overflow-hidden rounded-2xl border border-gray-200 bg-white hover:shadow-xl hover:shadow-blue-500/10 transition-all duration-300 hover:border-blue-200 hover:-translate-y-1"
+                          className="group relative overflow-hidden rounded-2xl border border-gray-200 bg-white hover:border-blue-300 transition-colors"
                         >
-                          {/* Background Pattern */}
-                          <div className="absolute top-0 right-0 w-24 h-24 opacity-5">
-                            <div className="w-full h-full bg-gradient-to-br from-blue-500 to-green-500 rounded-full transform translate-x-8 -translate-y-8" />
-                          </div>
-
                           <div className="relative p-6">
                             {/* Header */}
                             <div className="flex items-start justify-between mb-4">
                               <div className="flex items-center gap-3">
-                                <div className="flex items-center justify-center w-10 h-10 rounded-xl bg-gradient-to-br from-blue-600 to-green-600 shadow-lg group-hover:scale-110 transition-transform duration-300">
+                                <div className="flex items-center justify-center w-10 h-10 rounded-xl bg-gradient-to-br from-blue-600 to-green-600">
                                   <Users className="w-5 h-5 text-white" />
                                 </div>
                                 <div className="flex flex-col">
                                   <span className="text-xs bg-green-100 text-green-700 px-2 py-1 rounded-full font-medium w-fit">
-                                    Public
+                                    Active
                                   </span>
                                 </div>
                               </div>
@@ -529,7 +606,7 @@ function MarketplaceLayout() {
                                 title={wf.name}
                                 description={wf.description}
                                 metadata={{
-                                  status: "Public",
+                                  status: "Active",
                                   lastActivity: wf.created_at,
                                 }}
                                 size="sm"
@@ -561,7 +638,7 @@ function MarketplaceLayout() {
 
                             {/* Action Button */}
                             <button
-                              className="w-full flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-semibold rounded-xl bg-gradient-to-r from-blue-600 to-green-600 text-white hover:from-blue-700 hover:to-green-700 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200 shadow-lg hover:shadow-xl group-hover:scale-105"
+                              className="w-full flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-semibold rounded-xl bg-gradient-to-r from-blue-600 to-green-600 text-white hover:from-blue-700 hover:to-green-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                               onClick={() => handleDuplicate(wf.id)}
                               disabled={duplicating === wf.id}
                             >
@@ -582,11 +659,11 @@ function MarketplaceLayout() {
                       {pagedWorkflows.map((wf) => (
                         <div
                           key={wf.id}
-                          className="group flex items-center gap-6 p-6 bg-white border border-gray-200 rounded-2xl hover:shadow-lg hover:border-blue-200 transition-all duration-300"
+                          className="group flex items-center gap-6 p-6 bg-white border border-gray-200 rounded-2xl hover:border-blue-300 transition-colors"
                         >
                           {/* Icon */}
                           <div className="flex-shrink-0">
-                            <div className="flex items-center justify-center w-12 h-12 rounded-xl bg-gradient-to-br from-blue-600 to-green-600 shadow-lg group-hover:scale-105 transition-transform duration-300">
+                            <div className="flex items-center justify-center w-12 h-12 rounded-xl bg-gradient-to-br from-blue-600 to-green-600">
                               <Users className="w-6 h-6 text-white" />
                             </div>
                           </div>
@@ -599,7 +676,7 @@ function MarketplaceLayout() {
                                   {wf.name}
                                 </h3>
                                 <span className="text-xs bg-green-100 text-green-700 px-2 py-1 rounded-full font-medium">
-                                  Public
+                                  Active
                                 </span>
                               </div>
                               <PinButton
@@ -608,7 +685,7 @@ function MarketplaceLayout() {
                                 title={wf.name}
                                 description={wf.description}
                                 metadata={{
-                                  status: "Public",
+                                  status: "Active",
                                   lastActivity: wf.created_at,
                                 }}
                                 size="sm"

--- a/client/app/routes/workflows.tsx
+++ b/client/app/routes/workflows.tsx
@@ -108,6 +108,7 @@ function WorkflowsLayout() {
   interface WorkflowFormValues {
     name: string;
     description: string;
+    category?: string;
     is_public: boolean;
   }
 
@@ -206,12 +207,21 @@ function WorkflowsLayout() {
   };
 
   const handleDownload = (workflow: Workflow) => {
-    // Clean up the workflow data for export (same logic as Navbar's handleExport)
+    // Clean up the workflow data and attach marketplace metadata for export
     const cleanWorkflow = {
       id: workflow.id,
       user_id: workflow.user_id,
       name: workflow.name,
-      description: workflow.description,
+      description: workflow.description || "",
+      category: (workflow.flow_data as any)?.category || (workflow as any).category || "automation",
+      created_at: workflow.created_at || new Date().toISOString(),
+      colorFrom: (workflow.flow_data as any)?.colorFrom || (workflow as any).colorFrom || "from-blue-500",
+      colorTo: (workflow.flow_data as any)?.colorTo || (workflow as any).colorTo || "to-indigo-600",
+      icon: (workflow.flow_data as any)?.icon || (workflow as any).icon || {
+        name: "workflow",
+        path: null,
+        alt: "Workflow Icon",
+      },
       is_public: workflow.is_public,
       flow_data: {
         nodes: (workflow.flow_data?.nodes || []).map((node: any) => {
@@ -483,12 +493,23 @@ function WorkflowsLayout() {
   const handleWorkflowEditSubmit = async (values: WorkflowFormValues) => {
     if (!editWorkflow) return;
 
+    // Save category inside flow_data so it persists in the PostgreSQL JSONB column
+    const updatedFlowData = {
+      ...(editWorkflow.flow_data || {}),
+      category: values.category || "automation",
+    };
+
     const payload: WorkflowUpdateRequest = {
       name: values.name,
       description: values.description,
+      category: values.category || "automation",
       is_public: values.is_public,
-      flow_data: editWorkflow.flow_data, // flow_data'yı koru
+      flow_data: updatedFlowData,
     };
+
+    // Update local state temporarily so it reflects instantly
+    (editWorkflow as any).category = values.category || "automation";
+    editWorkflow.flow_data = updatedFlowData;
 
     try {
       await updateWorkflow(editWorkflow.id, payload);

--- a/client/app/stores/workflows.ts
+++ b/client/app/stores/workflows.ts
@@ -69,8 +69,11 @@ const workflowStateCreator: StateCreator<WorkflowState> = (set, get) => ({
   fetchPublicWorkflows: async () => {
     set({ isLoading: true, error: null });
     try {
-      const publicWorkflows = await WorkflowService.getPublicWorkflows();
-      set({ publicWorkflows, isLoading: false });
+      const publicWorkflows = await WorkflowService.getPublicWorkflows({
+        skip: 0,
+        limit: 100,
+      });
+      set({ publicWorkflows, isLoading: false, error: null });
     } catch (error: any) {
       set({ error: error.message, isLoading: false });
     }

--- a/client/app/types/api.ts
+++ b/client/app/types/api.ts
@@ -68,6 +68,7 @@ export interface Workflow {
   id: string;
   name: string;
   description?: string;
+  category?: string;
   flow_data: WorkflowData;
   user_id: string;
   user?: UserInfo;
@@ -82,6 +83,7 @@ export interface Workflow {
 export interface WorkflowCreateRequest {
   name: string;
   description?: string;
+  category?: string;
   flow_data: WorkflowData;
   is_public?: boolean;
   error_workflow?: string | null;
@@ -91,6 +93,7 @@ export interface WorkflowCreateRequest {
 export interface WorkflowUpdateRequest {
   name?: string;
   description?: string;
+  category?: string;
   flow_data?: WorkflowData;
   is_public?: boolean;
   error_workflow?: string | null;


### PR DESCRIPTION
- Add a persistent `category` column to the `Workflow` SQLAlchemy model in `backend/app/models/workflow.py`.
- Add the `category` field to the `WorkflowBase` and `WorkflowUpdate` Pydantic schemas in `backend/app/schemas/workflow.py`.
- Update `WorkflowEditModal` to include a Category text input in the workflow edit form.
- Update `handleWorkflowEditSubmit` in `workflows.tsx` to persist the `category` field in workflow update requests.
- Include `category`, `created_at`, `colorFrom`, `colorTo`, and `icon` metadata in dashboard download and builder export JSON files.
- Cast `flow_data` to `any` in frontend export handlers to prevent TypeScript compilation errors.