### PR TITLE
fix: sync sticky note text in real-time to prevent text reset on auto-save

### DIFF
--- a/client/app/components/canvas/FlowCanvas.tsx
+++ b/client/app/components/canvas/FlowCanvas.tsx
@@ -1744,9 +1744,7 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
           EndNode: (props: any) => (
             <EndNode {...props} isActive={activeNodes.includes(props.id)} />
           ),
-          StickyNoteNode: (props: any) => (
-            <StickyNoteNode {...props} />
-          ),
+          StickyNoteNode,
         } as Record<string, React.ComponentType<any> | null>
       ),
     [nodes, handleStartNodeExecution, executionLoading, activeNodes]

--- a/client/app/components/node/StickyNoteNode.tsx
+++ b/client/app/components/node/StickyNoteNode.tsx
@@ -74,26 +74,28 @@ function StickyNoteNode({ id, data, selected }: StickyNoteNodeProps) {
   };
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setText(e.target.value);
+    const nextText = e.target.value;
+    setText(nextText);
+
+    // Keep the React Flow node data current while editing. Auto-save reads from
+    // the canvas state, so waiting for blur can otherwise persist stale text.
+    setNodes((nodes) =>
+      nodes.map((node) =>
+        node.id === id
+          ? {
+              ...node,
+              data: {
+                ...node.data,
+                text: nextText,
+              },
+            }
+          : node
+      )
+    );
   };
 
   const handleBlur = () => {
     setIsEditing(false);
-    // Auto-save the text to the node's data so it persists
-    setNodes((nodes) =>
-      nodes.map((n) => {
-        if (n.id === id) {
-          return {
-            ...n,
-            data: {
-              ...n.data,
-              text: text,
-            },
-          };
-        }
-        return n;
-      })
-    );
   };
 
   return (


### PR DESCRIPTION
- Update `handleChange` in `StickyNoteNode` to update `node.data.text` in React Flow state immediately on input change instead of delaying until blur.
- Remove redundant node data update logic from `handleBlur` in `StickyNoteNode`.
- Pass direct `StickyNoteNode` component reference in `FlowCanvas` `nodeTypes` map to prevent node remounting during canvas state updates.