### PR TITLE
fix: grant security-events write permission for Trivy SARIF upload

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -88,6 +88,9 @@ jobs:
     name: Security Scan
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
- Add `security-events: write` and `contents: read` permissions to the `security-scan` job in `.github/workflows/backend-ci.yml`.
- Fix the `Resource not accessible by integration` error when uploading Trivy SARIF vulnerability scan results to the GitHub Security tab.