### PR TITLE
fix: Workflow delete confirmation modal

### DIFF
--- a/client/app/app.css
+++ b/client/app/app.css
@@ -15,6 +15,22 @@ html {
     animation: slide-up 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   }
 
+  .animate-modal-backdrop-in {
+    animation: modal-backdrop-in 0.2s ease-out both;
+  }
+
+  .animate-modal-content-in {
+    animation: modal-content-in 0.3s ease-out both;
+  }
+
+  .animate-modal-backdrop-out {
+    animation: modal-backdrop-out 0.2s ease-in both;
+  }
+
+  .animate-modal-content-out {
+    animation: modal-content-out 0.2s ease-in both;
+  }
+
   @keyframes slide-up {
     from {
       transform: translateY(100%);
@@ -24,6 +40,59 @@ html {
     to {
       transform: translateY(0);
       opacity: 1;
+    }
+  }
+
+  @keyframes modal-backdrop-in {
+    from {
+      opacity: 0;
+    }
+
+    to {
+      opacity: 1;
+    }
+  }
+
+  @keyframes modal-content-in {
+    from {
+      opacity: 0;
+      transform: translateY(0.5rem) scale(0.95);
+    }
+
+    to {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+  }
+
+  @keyframes modal-backdrop-out {
+    from {
+      opacity: 1;
+    }
+
+    to {
+      opacity: 0;
+    }
+  }
+
+  @keyframes modal-content-out {
+    from {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+
+    to {
+      opacity: 0;
+      transform: translateY(0.5rem) scale(0.95);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .animate-modal-backdrop-in,
+    .animate-modal-content-in,
+    .animate-modal-backdrop-out,
+    .animate-modal-content-out {
+      animation: none;
     }
   }
 

--- a/client/app/components/modals/DeleteConfirmationModal.tsx
+++ b/client/app/components/modals/DeleteConfirmationModal.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { AlertTriangle, X } from "lucide-react";
 
 interface DeleteConfirmationModalProps {
@@ -22,7 +22,30 @@ export default function DeleteConfirmationModal({
   cancelText = "Cancel",
   isLoading = false
 }: DeleteConfirmationModalProps) {
-  if (!isOpen) return null;
+  const [shouldRender, setShouldRender] = useState(isOpen);
+  const [isClosing, setIsClosing] = useState(false);
+  const [visibleContent, setVisibleContent] = useState({ title, message });
+
+  useEffect(() => {
+    if (isOpen) {
+      setVisibleContent({ title, message });
+      setShouldRender(true);
+      setIsClosing(false);
+      return;
+    }
+
+    if (!shouldRender) return;
+
+    setIsClosing(true);
+    const timer = window.setTimeout(() => {
+      setShouldRender(false);
+      setIsClosing(false);
+    }, 200);
+
+    return () => window.clearTimeout(timer);
+  }, [isOpen, message, shouldRender, title]);
+
+  if (!shouldRender) return null;
 
   const handleConfirm = () => {
     onConfirm();
@@ -31,18 +54,33 @@ export default function DeleteConfirmationModal({
   return (
     <>
       {/* Backdrop */}
-      <div className="fixed inset-0 backdrop-blur-sm z-50 transition-all duration-300" onClick={onClose} />
+      <div
+        className={`fixed inset-0 z-50 bg-black/40 backdrop-blur-sm ${
+          isClosing
+            ? "animate-modal-backdrop-out"
+            : "animate-modal-backdrop-in"
+        }`}
+        onClick={onClose}
+      />
       
       {/* Modal */}
       <div className="fixed inset-0 z-[60] flex items-center justify-center p-4">
-        <div className="bg-white rounded-lg shadow-xl max-w-md w-full">
+        <div
+          className={`bg-white rounded-lg shadow-xl max-w-md w-full ${
+            isClosing
+              ? "animate-modal-content-out"
+              : "animate-modal-content-in"
+          }`}
+        >
           {/* Header */}
           <div className="flex items-center justify-between p-6 border-b border-gray-200">
             <div className="flex items-center gap-3">
               <div className="flex items-center justify-center w-8 h-8 bg-red-100 rounded-full">
                 <AlertTriangle className="w-4 h-4 text-red-600" />
               </div>
-              <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+              <h3 className="text-lg font-semibold text-gray-900">
+                {visibleContent.title}
+              </h3>
             </div>
             <button
               onClick={onClose}
@@ -55,14 +93,14 @@ export default function DeleteConfirmationModal({
 
           {/* Content */}
           <div className="p-6">
-            <p className="text-gray-600">{message}</p>
+            <p className="text-gray-600">{visibleContent.message}</p>
           </div>
 
           {/* Actions */}
           <div className="flex items-center justify-end gap-3 p-6 border-t border-gray-200">
             <button
               onClick={onClose}
-              className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md transition-colors"
+              className="btn btn-outline"
               disabled={isLoading}
             >
               {cancelText}
@@ -70,7 +108,7 @@ export default function DeleteConfirmationModal({
             <button
               onClick={handleConfirm}
               disabled={isLoading}
-              className="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed rounded-md transition-colors"
+              className="btn btn-error"
             >
               {isLoading ? "Deleting..." : confirmText}
             </button>

--- a/client/app/routes/workflows.tsx
+++ b/client/app/routes/workflows.tsx
@@ -49,6 +49,7 @@ import PinnedItemsSection from "~/components/common/PinnedItemsSection";
 import PinButton from "~/components/common/PinButton";
 import WorkflowEditModal from "~/components/modals/WorkflowEditModal";
 import WorkflowExportModal from "~/components/modals/WorkflowExportModal";
+import DeleteConfirmationModal from "~/components/modals/DeleteConfirmationModal";
 
 const ErrorMessageBlock = ({
   error,
@@ -1196,29 +1197,14 @@ function WorkflowsLayout() {
         </div>
       </main>
 
-      {/* Delete Confirm Modal */}
-      <dialog
-        open={showDeleteConfirm}
-        className="modal modal-bottom sm:modal-middle"
-      >
-        <div className="modal-box">
-          <h3 className="font-bold text-lg">Delete Workflow</h3>
-          <p className="py-4">
-            Are you sure you want to delete "{workflowToDelete?.name}"?
-          </p>
-          <div className="modal-action">
-            <button className="btn btn-outline" onClick={handleCancelDelete}>
-              Cancel
-            </button>
-            <button
-              className="btn btn-error"
-              onClick={handleFinalDeleteConfirm}
-            >
-              Delete
-            </button>
-          </div>
-        </div>
-      </dialog>
+      <DeleteConfirmationModal
+        isOpen={showDeleteConfirm}
+        onClose={handleCancelDelete}
+        onConfirm={handleFinalDeleteConfirm}
+        title="Delete Workflow"
+        message={`Are you sure you want to delete "${workflowToDelete?.name}"?`}
+        isLoading={isDeleting === workflowToDelete?.id}
+      />
 
       {/* DISABLED Modals
       { Remove External Workflow Confirm Modal }


### PR DESCRIPTION
## What changed

- Replaced the workflow page's native delete dialog with the shared `DeleteConfirmationModal`.
- Added fade and scale transitions for the confirmation content and backdrop on open and close.
- Preserved the existing destructive button styling and modal content during the closing animation.
- Added reduced-motion handling for users who disable animations.

## Why

Opening the native dialog caused parts of the workflows page to shift. The newer confirmation UI also lost the gradual backdrop/content transitions from the previous experience.

## Impact

Deleting a workflow now opens without shifting the background page. Cancel, close, and backdrop actions dismiss the dialog smoothly, while the Delete button retains its previous color.

## Validation

- `npm.cmd run build` (passed)
- `npm.cmd run typecheck` (blocked by pre-existing unrelated type errors in node field visibility and credential `helpText` definitions)
- Targeted ESLint (blocked by the repository's existing AJV/ESLint dependency incompatibility)
