### PR TITLE
fix: Keep invalid node name warning visible

### DIFF
--- a/client/app/components/common/FullscreenNodeModal.tsx
+++ b/client/app/components/common/FullscreenNodeModal.tsx
@@ -117,7 +117,7 @@ export default function FullscreenNodeModal({
   const pendingConfigValuesRef = useRef<Record<string, unknown> | null>(null);
   const prevHistoryRevisionRef = useRef(historyRevision);
   const nodeAliasRef = useRef(
-    configData?.name || nodeMetadata.display_name || nodeMetadata.name
+    configData?.name ?? nodeMetadata.display_name ?? nodeMetadata.name
   );
   const [nodeAlias, setNodeAlias] = useState(nodeAliasRef.current);
   const [nodeAliasError, setNodeAliasError] = useState<string | null>(null);
@@ -648,10 +648,10 @@ export default function FullscreenNodeModal({
   useEffect(() => {
     setConfigValues(configData);
     const alias =
-      configData?.name || nodeMetadata.display_name || nodeMetadata.name;
+      configData?.name ?? nodeMetadata.display_name ?? nodeMetadata.name;
     nodeAliasRef.current = alias;
     setNodeAlias(alias);
-    setNodeAliasError(null);
+    setNodeAliasError(validateNodeAlias(alias));
     // Sync workflow state into the form after undo/redo or when configData changes externally (e.g., import).
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [historyRevision, configData]);


### PR DESCRIPTION
## What changed

- Preserve an explicitly empty node alias instead of replacing it with the node's default display name.
- Revalidate the synchronized alias so validation warnings remain visible until the name is corrected.

## Why

The alias synchronization used boolean fallback logic. An empty string was treated as missing, so the default node name returned immediately and cleared the validation warning.

## Impact

When a node name is deleted or otherwise invalid, the entered value remains unchanged and the warning stays visible. Valid node names continue to synchronize normally.

## Scope

Only three lines in `FullscreenNodeModal.tsx` changed. Lines 118, 119, and 649 were not modified.

## Validation

- `npm.cmd run build` (passed)
- `git diff --check` (passed)
