### PR TITLE
fix: prevent workflow delete modal layout shift

### DIFF
--- a/client/app/routes/workflows.tsx
+++ b/client/app/routes/workflows.tsx
@@ -1197,11 +1197,10 @@ function WorkflowsLayout() {
       </main>
 
       {/* Delete Confirm Modal */}
-      <dialog
-        open={showDeleteConfirm}
-        className="modal modal-bottom sm:modal-middle"
+      <div
+        className={`modal modal-bottom sm:modal-middle ${showDeleteConfirm ? "!pointer-events-auto !visible !opacity-100 !bg-black/40" : ""}`}
       >
-        <div className="modal-box">
+        <div className={`modal-box ${showDeleteConfirm ? "!opacity-100 !translate-y-0 !scale-100" : ""}`}>
           <h3 className="font-bold text-lg">Delete Workflow</h3>
           <p className="py-4">
             Are you sure you want to delete "{workflowToDelete?.name}"?
@@ -1218,7 +1217,7 @@ function WorkflowsLayout() {
             </button>
           </div>
         </div>
-      </dialog>
+      </div>
 
       {/* DISABLED Modals
       { Remove External Workflow Confirm Modal }


### PR DESCRIPTION
## What changed

- Kept the existing DaisyUI delete confirmation modal and its transitions.
- Replaced the native `dialog open` trigger with state-controlled visibility classes.

## Why

DaisyUI applies `overflow: hidden` and `scrollbar-gutter: stable` to the root element whenever it detects `.modal[open]`. That global scrollbar change caused parts of the workflows page to shift behind the confirmation modal.

## Impact

The delete confirmation keeps its existing opening and closing effect without shifting the background page.

## Scope

- Only `client/app/routes/workflows.tsx` changed.
- No changes to `app.css` or `DeleteConfirmationModal.tsx`.

## Validation

- `npm.cmd run build` (passed)
- `git diff --check` (passed)
