### PR TITLE
fix: prevent modal layout shift and stabilize node alias validation

### DIFF
--- a/client/app/components/common/FullscreenNodeModal.tsx
+++ b/client/app/components/common/FullscreenNodeModal.tsx
@@ -117,7 +117,7 @@ export default function FullscreenNodeModal({
   const pendingConfigValuesRef = useRef<Record<string, unknown> | null>(null);
   const prevHistoryRevisionRef = useRef(historyRevision);
   const nodeAliasRef = useRef(
-    configData?.name || nodeMetadata.display_name || nodeMetadata.name
+    configData?.name ?? nodeMetadata.display_name ?? nodeMetadata.name
   );
   const [nodeAlias, setNodeAlias] = useState(nodeAliasRef.current);
   const [nodeAliasError, setNodeAliasError] = useState<string | null>(null);
@@ -648,10 +648,10 @@ export default function FullscreenNodeModal({
   useEffect(() => {
     setConfigValues(configData);
     const alias =
-      configData?.name || nodeMetadata.display_name || nodeMetadata.name;
+      configData?.name ?? nodeMetadata.display_name ?? nodeMetadata.name;
     nodeAliasRef.current = alias;
     setNodeAlias(alias);
-    setNodeAliasError(null);
+    setNodeAliasError(validateNodeAlias(alias));
     // Sync workflow state into the form after undo/redo or when configData changes externally (e.g., import).
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [historyRevision, configData]);
@@ -774,7 +774,7 @@ export default function FullscreenNodeModal({
                     {nodeMetadata.display_name || nodeMetadata.name}
                   </h1>
                 </div>
-                <div className="mt-2">
+                <div className="mt-2 relative">
                   <label className="block text-xs text-gray-400 mb-1">
                     Specify the node name for using node output.
                   </label>
@@ -790,11 +790,11 @@ export default function FullscreenNodeModal({
                     }
                   />
                   {nodeAliasError && (
-                      <div className="mt-1 text-xs text-yellow-400">
-                        {nodeAliasError}
-                      </div>
-                    )}
-                  </div>
+                    <div className="absolute top-full left-0 mt-0.5 text-xs text-yellow-400 whitespace-nowrap z-10">
+                      {nodeAliasError}
+                    </div>
+                  )}
+                </div>
                 </div>
               </div>
 


### PR DESCRIPTION
- Position the `nodeAliasError` validation message absolutely beneath the `nodeAlias` input container to prevent modal header height changes.
- Eliminate vertical movement of the modal title, icon, and action buttons when alias validation messages appear or disappear.
- Re-run `validateNodeAlias(alias)` in `useEffect` whenever `configData` changes to keep validation messages synchronized and prevent flickering.
- Replace logical OR (`||`) with nullish coalescing (`??`) for node display name fallbacks in `FullscreenNodeModal.tsx`.