### PR TITLE
feat: run selected node from configure panel

### DIFF
--- a/backend/app/api/workflows.py
+++ b/backend/app/api/workflows.py
@@ -579,6 +579,8 @@ class AdhocExecuteRequest(BaseModel):
     session_id: Optional[str] = None
     chatflow_id: Optional[str] = None  # Yeni eklenen alan
     workflow_id: Optional[str] = None  # Execution kaydı için workflow_id
+    node_id: Optional[str] = None
+    node_outputs: Optional[Dict[str, Any]] = None
 
 
 # Use centralized JSON serialization utility
@@ -665,6 +667,58 @@ async def get_dashboard_stats(
             for day in sorted(day_stats.keys())
         ]
     return stats
+
+@router.post("/execute-node")
+async def execute_node(
+    req: AdhocExecuteRequest,
+    current_user: User = Depends(get_current_user_or_master_api_key),
+    db: AsyncSession = Depends(get_db_session),
+):
+    """Execute only the selected node without creating a workflow execution."""
+    if not req.workflow_id or not req.flow_data or not req.node_id:
+        raise HTTPException(status_code=400, detail="Workflow ID, flow data and node ID are required")
+
+    try:
+        workflow_id = uuid.UUID(req.workflow_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid workflow ID")
+
+    workflow_result = await db.execute(select(Workflow).filter(Workflow.id == workflow_id))
+    workflow = workflow_result.scalar_one_or_none()
+    if not workflow:
+        raise HTTPException(status_code=404, detail=f"Workflow {req.workflow_id} not found")
+    if workflow.user_id != current_user.id and not workflow.is_public:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    executor = get_workflow_executor()
+    session_id = executor.get_canvas_session_id(current_user.id, workflow_id)
+    user_context = executor.prepare_user_context(
+        user=current_user,
+        session_id=session_id,
+        workflow_id=workflow_id,
+        owner_id=workflow.user_id,
+    )
+
+    try:
+        build_result = executor.workflow_enhancer.enhanced_build(
+            flow_data=req.flow_data,
+            user_context=user_context,
+        )
+        engine = build_result[2]
+        result = await engine.base_builder.execute_node(
+            node_id=req.node_id,
+            inputs={"input": req.input_text},
+            session_id=session_id,
+            user_id=user_context["user_id"],
+            owner_id=user_context["owner_id"],
+            workflow_id=req.workflow_id,
+            node_outputs=req.node_outputs,
+        )
+        return make_json_serializable(result)
+    except Exception as exc:
+        logger.error(f"Node execution failed: {exc}", exc_info=True)
+        raise HTTPException(status_code=400, detail=f"Failed to run node: {exc}")
+
 
 @router.post("/execute")
 async def execute_adhoc_workflow(

--- a/backend/app/core/graph_builder/__init__.py
+++ b/backend/app/core/graph_builder/__init__.py
@@ -866,6 +866,94 @@ class GraphBuilder:
     # Execution methods - preserved for backward compatibility
     # ---------------------------------------------------------------------
 
+    async def execute_node(
+        self,
+        node_id: str,
+        inputs: Dict[str, Any],
+        session_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        owner_id: Optional[str] = None,
+        workflow_id: Optional[str] = None,
+        node_outputs: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Execute one node directly without running the compiled workflow graph."""
+        if node_id not in self.nodes:
+            raise ValueError(f"Node '{node_id}' not found in workflow.")
+
+        initial_input = inputs.get("input", "")
+        init_state = FlowState(
+            current_input=initial_input,
+            last_output=initial_input,
+            session_id=session_id or str(uuid.uuid4()),
+            user_id=user_id,
+            owner_id=owner_id,
+            workflow_id=workflow_id,
+            variables=inputs,
+            node_outputs=node_outputs or {},
+        )
+
+        from app.core.templating import register_global_registry, unregister_global_registry
+        register_global_registry(init_state.session_id, self.nodes)
+
+        gnode = self.nodes[node_id]
+        node_name = (
+            gnode.user_data.get("name")
+            or gnode.node_instance.metadata.display_name
+            or gnode.type
+        )
+
+        try:
+            def run_node() -> Dict[str, Any]:
+                connections = getattr(gnode.node_instance, "_input_connections", {})
+                for connection in connections.values():
+                    connection_items = connection if isinstance(connection, list) else [connection]
+                    for connection_item in connection_items:
+                        source_id = connection_item.get("source_node_id") if isinstance(connection_item, dict) else None
+                        source_node = self.nodes.get(source_id) if source_id else None
+                        if (
+                            source_node
+                            and source_node.node_instance.metadata.node_type.value == "processor"
+                            and source_id not in init_state.node_outputs
+                        ):
+                            init_state.node_outputs[source_id] = {}
+
+                gnode.node_instance.user_data.update(gnode.user_data)
+                self.node_executor.setup_node_session(gnode, init_state, node_id)
+                if gnode.node_instance.metadata.node_type.value in ("processor", "terminator"):
+                    return self.node_executor.execute_processor_node(gnode, init_state, node_id)
+                return self.node_executor.execute_standard_node(gnode, init_state, node_id)
+
+            result = await asyncio.to_thread(run_node)
+            node_output = init_state.node_outputs.get(node_id)
+            if node_output is None and isinstance(result, dict):
+                node_output = result.get(f"output_{node_id}", result)
+
+            return {
+                "success": True,
+                "node_id": node_id,
+                "output": node_output,
+                "node_outputs": {node_id: node_output},
+                "executed_nodes": [node_id],
+                "session_id": init_state.session_id,
+            }
+        except Exception as exc:
+            error_message = f"Node '{node_name}' ({node_id}) failed: {exc}"
+            node_output = init_state.node_outputs.get(node_id) or {
+                "success": False,
+                "error": {"message": error_message},
+            }
+            return {
+                "success": False,
+                "node_id": node_id,
+                "error": error_message,
+                "output": node_output,
+                "node_outputs": {node_id: node_output},
+                "executed_nodes": [node_id],
+                "session_id": init_state.session_id,
+            }
+        finally:
+            unregister_global_registry(init_state.session_id)
+
     async def execute(
         self,
         inputs: Dict[str, Any],

--- a/client/app/components/canvas/FlowCanvas.tsx
+++ b/client/app/components/canvas/FlowCanvas.tsx
@@ -51,7 +51,7 @@ import AutoSaveSettingsModal from "../modals/AutoSaveSettingsModal";
 import FullscreenNodeModal from "../common/FullscreenNodeModal";
 import { TutorialButton } from "../tutorial";
 import LogPanel from "./LogPanel";
-import { executeWorkflowStream, getExecution } from "~/services/executionService";
+import { executeNode, executeWorkflowStream, getExecution } from "~/services/executionService";
 import GenericNode from "../node";
 
 // Import config components
@@ -1658,6 +1658,78 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
     ]
   );
 
+  const handleSelectedNodeExecution = useCallback(
+    async (nodeId: string, configValues: Record<string, unknown>) => {
+      if (!currentWorkflow) {
+        enqueueSnackbar("No workflow selected", { variant: "error" });
+        return;
+      }
+
+      const selectedNode = nodes.find((node) => node.id === nodeId);
+      if (!selectedNode) {
+        enqueueSnackbar("Selected node not found", { variant: "error" });
+        return;
+      }
+      const nodeName = String(selectedNode.data?.name || selectedNode.type || nodeId);
+
+      const executionNodes = nodes.map((node) =>
+        node.id === nodeId
+          ? { ...node, data: { ...node.data, ...configValues } }
+          : node
+      );
+
+      setNodeStatus((status) => ({ ...status, [nodeId]: "pending" }));
+      enqueueSnackbar("Executing node...", { variant: "info" });
+
+      try {
+        const result = await executeNode({
+          workflow_id: currentWorkflow.id,
+          flow_data: {
+            nodes: executionNodes as WorkflowNode[],
+            edges: edges as WorkflowEdge[],
+            settings: currentWorkflow.flow_data?.settings,
+          },
+          node_id: nodeId,
+          node_outputs: currentExecution?.result?.node_outputs,
+        });
+        const completedAt = new Date().toISOString();
+
+        setCurrentExecutionForWorkflow(currentWorkflow.id, {
+          id: `node-${nodeId}-${Date.now()}`,
+          workflow_id: currentWorkflow.id,
+          status: result.success ? "completed" : "failed",
+          started_at: completedAt,
+          completed_at: completedAt,
+          result: {
+            result: result.output,
+            executed_nodes: [nodeId],
+            node_outputs: {
+              ...(currentExecution?.result?.node_outputs || {}),
+              ...(result.node_outputs || { [nodeId]: result.output }),
+            },
+            session_id: result.session_id,
+            status: result.success ? "completed" : "failed",
+          },
+        } as any);
+        setNodeStatus((status) => ({
+          ...status,
+          [nodeId]: result.success ? "success" : "failed",
+        }));
+        enqueueSnackbar(
+          result.success
+            ? "Node executed successfully"
+            : result.error || `Could not run "${nodeName}" (${nodeId}). No error details were returned.`,
+          { variant: result.success ? "success" : "error" }
+        );
+      } catch (error: any) {
+        setNodeStatus((status) => ({ ...status, [nodeId]: "failed" }));
+        const errorMessage = error?.message || "Check the node configuration and required connections.";
+        enqueueSnackbar(`Could not run "${nodeName}" (${nodeId}): ${errorMessage}`, { variant: "error" });
+      }
+    },
+    [currentExecution, currentWorkflow, edges, enqueueSnackbar, nodes, setCurrentExecutionForWorkflow]
+  );
+
   // Error handling functions
   const handleErrorRetry = useCallback(() => {
     if (errorNodeId && currentWorkflow) {
@@ -2282,8 +2354,8 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
             onConfigChange={handleNodeConfigChange}
             historyRevision={historyRevision}
             configFlushRef={configFlushRef}
-            onExecute={() =>
-              handleStartNodeExecution(fullscreenModal.nodeData?.id || "")
+            onExecute={(values) =>
+              handleSelectedNodeExecution(fullscreenModal.nodeData?.id || "", values)
             }
             ConfigComponent={fullscreenModal.configComponent}
             executionData={{

--- a/client/app/components/common/FullscreenNodeModal.tsx
+++ b/client/app/components/common/FullscreenNodeModal.tsx
@@ -67,7 +67,7 @@ interface FullscreenNodeModalProps {
   onConfigChange?: (values: any) => void;
   historyRevision?: number;
   configFlushRef?: React.MutableRefObject<(() => void) | null>;
-  onExecute?: () => void; // New execute function
+  onExecute?: (values: any) => void; // New execute function
   ConfigComponent: React.ComponentType<{
     configData: any;
     onSave: (values: any) => void;
@@ -804,12 +804,12 @@ export default function FullscreenNodeModal({
               </div>
               {onExecute && nodeMetadata.node_type === "processor" && (
                 <button
-                  onClick={onExecute}
+                  onClick={() => onExecute({ ...(pendingConfigValuesRef.current ?? configValues), name: nodeAliasRef.current })}
                   className="flex items-center gap-2 px-4 py-2 rounded-lg bg-green-600 hover:bg-green-500 text-white text-sm font-medium transition-colors"
-                  title="Execute this processor node"
+                  title="Run only this processor node"
                 >
                   <Play className="w-4 h-4" />
-                  Execute
+                  Run Node
                 </button>
               )}
               <button

--- a/client/app/lib/config.ts
+++ b/client/app/lib/config.ts
@@ -95,6 +95,7 @@ export const API_ENDPOINTS = {
     DELETE: (id: string) => `/workflows/${id}`,
     VALIDATE: '/workflows/validate',
     EXECUTE: '/workflows/execute',
+    EXECUTE_NODE: '/workflows/execute-node',
     PUBLIC: '/workflows/public/',
     SEARCH: '/workflows/search/',
     DUPLICATE: (id: string) => `/workflows/${id}/duplicate`,

--- a/client/app/services/executionService.ts
+++ b/client/app/services/executionService.ts
@@ -46,6 +46,16 @@ export const executeWorkflow = async (workflow_id: string, executionData: {
   return response;
 };
 
+export const executeNode = async (executionData: {
+  workflow_id: string;
+  flow_data: any;
+  node_id: string;
+  input_text?: string;
+  node_outputs?: Record<string, any>;
+}) => {
+  return apiClient.post<any>(API_ENDPOINTS.WORKFLOWS.EXECUTE_NODE, executionData);
+};
+
 export const deleteExecution = async (execution_id: string) => {
   return apiClient.delete(`/executions/${execution_id}`);
 };


### PR DESCRIPTION
## What changed

- Change the Configure panel action label from **Execute** to **Run Node**.
- Run only the currently selected processor node instead of starting the whole workflow.
- Send the current Configure values, including unsaved edits.
- Display the selected node output through the existing Output Data panel.
- Include the node name, node ID, and underlying cause in node-run error messages.
- Remove all example workflow files so the PR contains only selected-node execution code.

## Why

The Configure panel action used the workflow start handler, so testing one node executed the full workflow and could trigger unrelated nodes or side effects. The new path calls the existing node executor directly for the selected node.

## Supported nodes

The **Run Node** action is shown for nodes whose metadata type is processor:

- Agent
- HTTP Client
- Code Node
- Condition
- Parser
- Cryptography
- Kafka Producer
- String Input
- Document Loader
- Web Scraper
- Document Chunk Splitter
- Vector Store Orchestrator
- LLM Red Team Scanner
- Agentic Red Team Scanner
- Custom Red Team Scanner

Provider, memory, trigger, terminator, and decorative nodes are not included.

## Impact

- Normal workflow execution remains unchanged.
- Upstream and downstream processor nodes are not executed.
- Existing node outputs may be reused as input context.
- No workflow execution record is created for a single-node run.

## Checks

- npm run build
- python -m py_compile app/api/workflows.py app/core/graph_builder/__init__.py
- git diff --check