### PR TITLE
fix: remove all connections from a node

### DIFF
--- a/client/app/components/canvas/FlowCanvas.tsx
+++ b/client/app/components/canvas/FlowCanvas.tsx
@@ -1257,6 +1257,17 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
     [setNodes, enqueueSnackbar]
   );
 
+  const removeNodeConnections = useCallback(
+    (nodeId: string) => {
+      setEdges((currentEdges) =>
+        currentEdges.filter((edge) => edge.source !== nodeId && edge.target !== nodeId)
+      );
+      enqueueSnackbar("Node connections removed", { variant: "info", autoHideDuration: 2000 });
+      setContextMenu(null);
+    },
+    [setEdges, enqueueSnackbar]
+  );
+
   // Auto-save function
   const handleAutoSave = useCallback(async () => {
     if (!autoSaveEnabled || !hasUnsavedChanges || !currentWorkflow) {
@@ -2175,6 +2186,7 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
               y={contextMenu.y}
               nodeId={contextMenu.nodeId}
               onDuplicate={duplicateNode}
+              onRemoveConnections={removeNodeConnections}
               onClose={() => setContextMenu(null)}
             />
           )}

--- a/client/app/components/canvas/NodeContextMenu.tsx
+++ b/client/app/components/canvas/NodeContextMenu.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useRef } from "react";
-import { Copy } from "lucide-react";
+import { Copy, Unlink } from "lucide-react";
 
 interface NodeContextMenuProps {
     x: number;
     y: number;
     nodeId: string;
     onDuplicate: (nodeId: string) => void;
+    onRemoveConnections: (nodeId: string) => void;
     onClose: () => void;
 }
 
@@ -14,6 +15,7 @@ const NodeContextMenu: React.FC<NodeContextMenuProps> = ({
     y,
     nodeId,
     onDuplicate,
+    onRemoveConnections,
     onClose,
 }) => {
     const menuRef = useRef<HTMLDivElement>(null);
@@ -51,6 +53,16 @@ const NodeContextMenu: React.FC<NodeContextMenuProps> = ({
                 >
                     <Copy size={16} className="text-cyan-400" />
                     <span className="font-medium">Clone Node</span>
+                </button>
+                <button
+                    onClick={() => {
+                        onRemoveConnections(nodeId);
+                        onClose();
+                    }}
+                    className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-cyan-50 hover:bg-white/10 transition-colors bg-transparent border-none cursor-pointer text-left focus:outline-none"
+                >
+                    <Unlink size={16} className="text-cyan-400" />
+                    <span className="font-medium">Remove Connections</span>
                 </button>
             </div>
         </div>


### PR DESCRIPTION
## What changed

- Added a **Remove Connections** action below **Clone Node** in the node context menu.
- Removed every incoming and outgoing edge for the selected node while preserving the node and its configuration.
- Added a confirmation snackbar after the action completes.

## Why

Users previously had to remove each edge individually when they wanted to disconnect a configured node without deleting it.

## Impact

Right-clicking a node now provides a single action to isolate it from the workflow without changing its settings.

## Root cause

The node context menu only exposed node cloning and did not provide an operation for filtering edges associated with the selected node.

## Validation

- `npm.cmd run build` (passed)
- `git diff --check` (passed)
- Project-wide typecheck remains blocked by pre-existing type errors in node field components and credential definitions.
- Targeted ESLint remains blocked by the existing AJV/ESLint configuration error.
