### PR TITLE
feat: add context menu action to remove node connections

### DIFF
--- a/client/app/components/canvas/FlowCanvas.tsx
+++ b/client/app/components/canvas/FlowCanvas.tsx
@@ -1257,6 +1257,27 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
     [setNodes, enqueueSnackbar]
   );
 
+  const removeNodeConnections = useCallback(
+    (nodeId: string) => {
+      const hasConnections = edges.some(
+        (edge) => edge.source === nodeId || edge.target === nodeId
+      );
+
+      if (!hasConnections) {
+        enqueueSnackbar("No connections to remove", { variant: "warning", autoHideDuration: 2000 });
+        setContextMenu(null);
+        return;
+      }
+
+      setEdges((currentEdges) =>
+        currentEdges.filter((edge) => edge.source !== nodeId && edge.target !== nodeId)
+      );
+      enqueueSnackbar("Node connections removed", { variant: "info", autoHideDuration: 2000 });
+      setContextMenu(null);
+    },
+    [edges, setEdges, enqueueSnackbar]
+  );
+
   // Auto-save function
   const handleAutoSave = useCallback(async () => {
     if (!autoSaveEnabled || !hasUnsavedChanges || !currentWorkflow) {
@@ -2175,6 +2196,7 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
               y={contextMenu.y}
               nodeId={contextMenu.nodeId}
               onDuplicate={duplicateNode}
+              onRemoveConnections={removeNodeConnections}
               onClose={() => setContextMenu(null)}
             />
           )}

--- a/client/app/components/canvas/NodeContextMenu.tsx
+++ b/client/app/components/canvas/NodeContextMenu.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useRef } from "react";
-import { Copy } from "lucide-react";
+import { Copy, Unlink } from "lucide-react";
 
 interface NodeContextMenuProps {
     x: number;
     y: number;
     nodeId: string;
     onDuplicate: (nodeId: string) => void;
+    onRemoveConnections: (nodeId: string) => void;
     onClose: () => void;
 }
 
@@ -14,6 +15,7 @@ const NodeContextMenu: React.FC<NodeContextMenuProps> = ({
     y,
     nodeId,
     onDuplicate,
+    onRemoveConnections,
     onClose,
 }) => {
     const menuRef = useRef<HTMLDivElement>(null);
@@ -51,6 +53,15 @@ const NodeContextMenu: React.FC<NodeContextMenuProps> = ({
                 >
                     <Copy size={16} className="text-cyan-400" />
                     <span className="font-medium">Clone Node</span>
+                </button>
+                <button
+                    onClick={() => {
+                        onRemoveConnections(nodeId);
+                    }}
+                    className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-cyan-50 hover:bg-white/10 transition-colors bg-transparent border-none cursor-pointer text-left focus:outline-none"
+                >
+                    <Unlink size={16} className="text-cyan-400" />
+                    <span className="font-medium">Remove Connections</span>
                 </button>
             </div>
         </div>


### PR DESCRIPTION
- Add a `Remove Connections` action with the `Unlink` icon to `NodeContextMenu` for clearing all edges connected to the selected node.
- Implement `removeNodeConnections` in `FlowCanvas` to remove both incoming and outgoing edges associated with the target node ID.
- Check for existing node connections before removal to display the appropriate snackbar message (`No connections to remove` or `Node connections removed`).
- Prevent duplicate snackbar notifications in React StrictMode by evaluating the connection state before invoking the `setEdges` state updater.
- Standardize context menu dismissal behavior between `NodeContextMenu` and `FlowCanvas`.