### PR TITLE
feat: implement dynamic single-node execution and partial graph resolution

### DIFF
--- a/backend/app/api/workflows.py
+++ b/backend/app/api/workflows.py
@@ -579,6 +579,8 @@ class AdhocExecuteRequest(BaseModel):
     session_id: Optional[str] = None
     chatflow_id: Optional[str] = None  # Yeni eklenen alan
     workflow_id: Optional[str] = None  # Execution kaydı için workflow_id
+    node_id: Optional[str] = None
+    node_outputs: Optional[Dict[str, Any]] = None
 
 
 # Use centralized JSON serialization utility
@@ -665,6 +667,58 @@ async def get_dashboard_stats(
             for day in sorted(day_stats.keys())
         ]
     return stats
+
+@router.post("/execute-node")
+async def execute_node(
+    req: AdhocExecuteRequest,
+    current_user: User = Depends(get_current_user_or_master_api_key),
+    db: AsyncSession = Depends(get_db_session),
+):
+    """Execute only the selected node without creating a workflow execution."""
+    if not req.workflow_id or not req.flow_data or not req.node_id:
+        raise HTTPException(status_code=400, detail="Workflow ID, flow data and node ID are required")
+
+    try:
+        workflow_id = uuid.UUID(req.workflow_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid workflow ID")
+
+    workflow_result = await db.execute(select(Workflow).filter(Workflow.id == workflow_id))
+    workflow = workflow_result.scalar_one_or_none()
+    if not workflow:
+        raise HTTPException(status_code=404, detail=f"Workflow {req.workflow_id} not found")
+    if workflow.user_id != current_user.id and not workflow.is_public:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    executor = get_workflow_executor()
+    session_id = executor.get_canvas_session_id(current_user.id, workflow_id)
+    user_context = executor.prepare_user_context(
+        user=current_user,
+        session_id=session_id,
+        workflow_id=workflow_id,
+        owner_id=workflow.user_id,
+    )
+
+    try:
+        build_result = executor.workflow_enhancer.enhanced_build(
+            flow_data=req.flow_data,
+            user_context=user_context,
+        )
+        engine = build_result[2]
+        result = await engine.base_builder.execute_node(
+            node_id=req.node_id,
+            inputs={"input": req.input_text},
+            session_id=session_id,
+            user_id=user_context["user_id"],
+            owner_id=user_context["owner_id"],
+            workflow_id=req.workflow_id,
+            node_outputs=req.node_outputs,
+        )
+        return make_json_serializable(result)
+    except Exception as exc:
+        logger.error(f"Node execution failed: {exc}", exc_info=True)
+        raise HTTPException(status_code=400, detail=f"Failed to run node: {exc}")
+
 
 @router.post("/execute")
 async def execute_adhoc_workflow(

--- a/backend/app/core/enhanced_logging.py
+++ b/backend/app/core/enhanced_logging.py
@@ -234,6 +234,18 @@ log_history = deque(maxlen=MAX_HISTORY)
 # Set to store connected subscribers' (queue, loop) tuples
 log_subscribers = set()
 
+def _push_log_to_subscriber(queue, msg):
+    """Safely push log message to subscriber queue, dropping oldest if full to avoid QueueFull exceptions."""
+    try:
+        if queue.full():
+            try:
+                queue.get_nowait()
+            except Exception:
+                pass
+        queue.put_nowait(msg)
+    except Exception:
+        pass
+
 class UIStreamWrapper:
     """Wrapper around stdout and stderr that captures everything written to the terminal
     and broadcasts it to connected UI clients.
@@ -248,7 +260,7 @@ class UIStreamWrapper:
             log_history.append(msg)
             for queue, loop in list(log_subscribers):
                 try:
-                    loop.call_soon_threadsafe(queue.put_nowait, msg)
+                    loop.call_soon_threadsafe(_push_log_to_subscriber, queue, msg)
                 except Exception:
                     pass
 
@@ -267,7 +279,7 @@ class GlobalLogHandler(logging.Handler):
             log_history.append(msg)
             for queue, loop in list(log_subscribers):
                 try:
-                    loop.call_soon_threadsafe(queue.put_nowait, msg)
+                    loop.call_soon_threadsafe(_push_log_to_subscriber, queue, msg)
                 except Exception:
                     pass
         except Exception:

--- a/backend/app/core/graph_builder/__init__.py
+++ b/backend/app/core/graph_builder/__init__.py
@@ -331,7 +331,7 @@ class GraphBuilder:
             # them to the virtual EndNode. ErrorTrigger-only workflows must still run.
             all_node_ids = {n["id"] for n in nodes if n.get("id")}
             all_sources = {e["source"] for e in edges}
-            last_nodes = all_node_ids - all_sources - start_node_ids - end_node_ids
+            last_nodes = all_node_ids - all_sources - start_node_ids - end_node_ids - {"virtual-end-node"}
 
             # SAFE: Add virtual edges to working copy
             for node_id in last_nodes:
@@ -576,6 +576,56 @@ class GraphBuilder:
             import time
             start_time = time.time()
             try:
+                # -------------------------------------------------------------
+                # Partial Execution / Dependency Resolution Logic (n8n Style)
+                # -------------------------------------------------------------
+                if isinstance(state, dict):
+                    variables = state.get("variables", {})
+                    node_outputs = state.get("node_outputs", {})
+                    executed_nodes = state.get("executed_nodes", [])
+                else:
+                    variables = getattr(state, "variables", {}) or {}
+                    node_outputs = getattr(state, "node_outputs", {}) or {}
+                    executed_nodes = getattr(state, "executed_nodes", []) or []
+
+                target_node_id = variables.get("target_node_id")
+                if target_node_id:
+                    # Determine ancestors cache
+                    ancestors = variables.get("ancestors_cache")
+                    if ancestors is None:
+                        # Fallback if not computed
+                        ancestors = list(self._get_upstream_nodes(target_node_id))
+                        variables["ancestors_cache"] = ancestors
+
+                    # If this node is not in the ancestor path, bypass execution completely
+                    if node_id not in ancestors:
+                        logger.info(f"[PARTIAL] Bypassing node {node_id} (not an ancestor of target {target_node_id})")
+                        return {
+                            f"output_{node_id}": node_outputs.get(node_id),
+                            "executed_nodes": executed_nodes,
+                            "node_outputs": node_outputs
+                        }
+                    
+                    # If this node is in the ancestor path, but it is already in node_outputs
+                    # AND it is not the target node itself
+                    # AND it is not marked as dirty
+                    dirty_node_ids = variables.get("dirty_node_ids", [])
+                    if node_id in node_outputs and node_id != target_node_id and node_id not in dirty_node_ids:
+                        logger.info(f"[PARTIAL] Reusing cached output for ancestor node {node_id}")
+                        # Ensure node_id is marked as executed if it wasn't
+                        from app.core.state import merge_executed_nodes
+                        new_executed = merge_executed_nodes(executed_nodes, [node_id])
+                        return {
+                            f"output_{node_id}": node_outputs.get(node_id),
+                            "executed_nodes": new_executed,
+                            "node_outputs": node_outputs
+                        }
+
+                    logger.info(f"[PARTIAL] Executing required ancestor/target node: {node_id}")
+                # -------------------------------------------------------------
+                # End of Partial Execution Logic
+                # -------------------------------------------------------------
+
                 logger.info(f"EXECUTING: {node_id} ({gnode.type}) with NodeExecutor")
                 
                 # Inject nodes registry into state so that nodes can resolve Jinja variables with friendly names
@@ -862,9 +912,197 @@ class GraphBuilder:
                     graph.add_edge(last_node, END)
                     logger.debug(f"{last_node} -> END")
 
+    def _get_upstream_nodes(self, target_id: str) -> Set[str]:
+        """Traverse backwards from target_id along visual edges to find all ancestors."""
+        ancestors = {target_id}
+        queue = [target_id]
+        while queue:
+            current = queue.pop(0)
+            for edge in self.visual_edges:
+                if edge.get("target") == current:
+                    source = edge.get("source")
+                    if source and source not in ancestors:
+                        ancestors.add(source)
+                        queue.append(source)
+        return ancestors
+
+    def is_trigger_node(self, node_id: str, gnode: GraphNodeInstance) -> bool:
+        """Dynamically determine if a node is a trigger node using metadata, class, or topology."""
+        # 1. Metadata category check
+        metadata = getattr(gnode.node_instance, "metadata", None)
+        if metadata:
+            category = getattr(metadata, "category", "")
+            if category.lower() in ("triggers", "trigger", "start"):
+                return True
+                
+        # 2. Class name and node type string check
+        class_name = gnode.node_instance.__class__.__name__.lower()
+        node_type = gnode.type.lower()
+        if "trigger" in class_name or "trigger" in node_type or "start" in class_name or "start" in node_type:
+            return True
+            
+        # 3. Topology check: if the node has no incoming connections, it's a starting point (trigger-like)
+        incoming_edges = [edge for edge in self.visual_edges if edge.get("target") == node_id]
+        if not incoming_edges:
+            return True
+            
+        return False
+
     # ---------------------------------------------------------------------
     # Execution methods - preserved for backward compatibility
     # ---------------------------------------------------------------------
+
+    async def execute_node(
+        self,
+        node_id: str,
+        inputs: Dict[str, Any],
+        session_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        owner_id: Optional[str] = None,
+        workflow_id: Optional[str] = None,
+        node_outputs: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Execute one node using the compiled graph in partial execution mode."""
+        if not self.graph:
+            raise ValueError("Graph has not been built. Call build_from_flow() first.")
+            
+        if node_id not in self.nodes:
+            raise ValueError(f"Node '{node_id}' not found in workflow.")
+
+        # Prepare state variables for partial execution
+        inputs = inputs or {}
+        inputs["target_node_id"] = node_id
+        inputs["dirty_node_ids"] = inputs.get("dirty_node_ids", [])
+        
+        # Build ancestors cache using visual edges
+        ancestors = self._get_upstream_nodes(node_id)
+        inputs["ancestors_cache"] = list(ancestors)
+
+        initial_input = inputs.get("input", "")
+        init_state = FlowState(
+            current_input=initial_input,
+            last_output=initial_input,
+            session_id=session_id or str(uuid.uuid4()),
+            user_id=user_id,
+            owner_id=owner_id,
+            workflow_id=workflow_id,
+            variables=inputs,
+            node_outputs=node_outputs or {},
+        )
+
+        # Pre-inject trigger node outputs so they are available in node_outputs
+        for trigger_id, gnode in self.nodes.items():
+            if self.is_trigger_node(trigger_id, gnode) and trigger_id not in init_state.node_outputs:
+                try:
+                    # 1. Custom handling for StartNode to support initial query text
+                    if gnode.type == "StartNode" or gnode.node_instance.__class__.__name__ == "StartNode":
+                        output_dict = {
+                            "output": initial_input or "Workflow started"
+                        }
+                    else:
+                        # 2. Dynamic execution of trigger
+                        output_dict = {}
+                        import inspect
+                        if hasattr(gnode.node_instance, "_execute") and callable(getattr(gnode.node_instance, "_execute")):
+                            execute_method = gnode.node_instance._execute
+                            sig = inspect.signature(execute_method)
+                            if len(sig.parameters) >= 1:
+                                output_dict = execute_method(init_state)
+                            else:
+                                output_dict = execute_method()
+                        elif hasattr(gnode.node_instance, "execute") and callable(getattr(gnode.node_instance, "execute")):
+                            execute_method = gnode.node_instance.execute
+                            sig = inspect.signature(execute_method)
+                            if "inputs" in sig.parameters:
+                                output_dict = execute_method(inputs=inputs)
+                            elif not sig.parameters:
+                                output_dict = execute_method()
+                            else:
+                                output_dict = execute_method()
+
+                    from app.core.json_utils import format_standard_node_output
+                    standard_output = format_standard_node_output(
+                        node_id=trigger_id,
+                        node_type=gnode.type,
+                        success=True,
+                        status_code=200,
+                        execution_time_ms=0.0,
+                        inputs=gnode.user_data,
+                        output=output_dict,
+                        node_instance=gnode.node_instance
+                    )
+                    init_state.set_node_output(trigger_id, standard_output)
+                    logger.info(f"[TRIGGER] Pre-injected standardized output for {gnode.type}: {trigger_id}")
+                except Exception as trigger_err:
+                    logger.warning(f"Failed to pre-inject trigger output for {trigger_id}: {trigger_err}")
+
+        config = {"configurable": {"thread_id": init_state.session_id}}
+
+        from app.core.templating import register_global_registry, unregister_global_registry
+        register_global_registry(init_state.session_id, self.nodes)
+        if workflow_id:
+            register_global_registry(workflow_id, self.nodes)
+
+        gnode = self.nodes[node_id]
+        node_name = (
+            gnode.user_data.get("name")
+            or gnode.node_instance.metadata.display_name
+            or gnode.type
+        )
+
+        try:
+            result_state = await self.graph.ainvoke(init_state, config=config)
+            
+            # Extract output of the target node
+            if isinstance(result_state, dict):
+                node_outputs_final = result_state.get("node_outputs", {})
+                executed_nodes_final = result_state.get("executed_nodes", [])
+            else:
+                node_outputs_final = getattr(result_state, "node_outputs", {})
+                executed_nodes_final = getattr(result_state, "executed_nodes", [])
+                
+            target_output = node_outputs_final.get(node_id)
+            if target_output is None:
+                dyn_key = f"output_{node_id}"
+                if isinstance(result_state, dict):
+                    target_output = result_state.get(dyn_key)
+                else:
+                    target_output = getattr(result_state, dyn_key, None)
+            
+            success = True
+            error_message = None
+            
+            if isinstance(target_output, dict) and not target_output.get("success", True):
+                success = False
+                error_message = target_output.get("error", {}).get("message") or "Node execution failed"
+
+            return {
+                "success": success,
+                "node_id": node_id,
+                "output": target_output,
+                "node_outputs": node_outputs_final,
+                "executed_nodes": executed_nodes_final,
+                "session_id": init_state.session_id,
+                "error": error_message
+            }
+        except Exception as exc:
+            error_message = f"Node '{node_name}' ({node_id}) execution failed: {exc}"
+            logger.error(error_message, exc_info=True)
+            node_output = init_state.node_outputs.get(node_id) or {
+                "success": False,
+                "error": {"message": error_message},
+            }
+            return {
+                "success": False,
+                "node_id": node_id,
+                "error": error_message,
+                "output": node_output,
+                "node_outputs": init_state.node_outputs,
+                "executed_nodes": init_state.executed_nodes,
+                "session_id": init_state.session_id,
+            }
+        finally:
+            unregister_global_registry(init_state.session_id)
 
     async def execute(
         self,
@@ -906,24 +1144,16 @@ class GraphBuilder:
         listener_id = inputs.get("listener_id")
         
         # Pre-inject trigger node outputs so they are available in node_outputs (and downstream nodes)
-        from app.nodes.base import NodeType
         for node_id, gnode in self.nodes.items():
-            node_type_val = None
-            try:
-                node_type_val = gnode.node_instance.metadata.node_type
-            except Exception:
-                pass
-                
-            is_trigger = False
-            if gnode.type in ("StartNode", "WebhookTrigger", "KafkaConsumer", "KafkaTrigger", "TimerStartNode", "TimerStart", "ErrorTriggerNode"):
-                is_trigger = True
-            elif node_type_val == NodeType.TERMINATOR and gnode.type not in ("EndNode", "RespondToWebhook"):
-                is_trigger = True
-                
-            if is_trigger:
+            if self.is_trigger_node(node_id, gnode):
                 try:
-                    # 1. Webhook Trigger Node
-                    if "webhook" in gnode.type.lower() or gnode.node_instance.__class__.__name__ == "WebhookTriggerNode":
+                    # 1. Custom handling for StartNode
+                    if gnode.type == "StartNode" or gnode.node_instance.__class__.__name__ == "StartNode":
+                        output_dict = {
+                            "output": initial_input or "Workflow started"
+                        }
+                    # 2. Custom handling for WebhookTrigger
+                    elif "webhook" in gnode.type.lower() or gnode.node_instance.__class__.__name__ == "WebhookTriggerNode":
                         if webhook_data:
                             payload = webhook_data.get("data", webhook_data)
                             gnode.node_instance.user_data["webhook_payload"] = payload
@@ -938,62 +1168,14 @@ class GraphBuilder:
                                     "source": "mock",
                                     "event_type": "webhook.received"
                                 }
-                                
-                        from app.core.json_utils import format_standard_node_output
-                        standard_output = format_standard_node_output(
-                            node_id=node_id,
-                            node_type=gnode.type,
-                            success=True,
-                            status_code=200,
-                            execution_time_ms=0.0,
-                            inputs=gnode.user_data,
-                            output=output_dict,
-                            node_instance=gnode.node_instance
-                        )
-                        init_state.set_node_output(node_id, standard_output)
-                        logger.info(f"[TRIGGER] Pre-injected standardized output for webhook: {node_id}")
-                        
-                    # 2. Kafka Trigger Node
+                    # 3. Custom handling for KafkaTrigger
                     elif "kafka" in gnode.type.lower() or gnode.node_instance.__class__.__name__ == "KafkaTriggerNode":
                         k_data = kafka_data or inputs.get("kafka_data") or {}
                         output_dict = {
                             "kafka_data": k_data,
                             "output": k_data.get("value", "Kafka trigger message")
                         }
-                        from app.core.json_utils import format_standard_node_output
-                        standard_output = format_standard_node_output(
-                            node_id=node_id,
-                            node_type=gnode.type,
-                            success=True,
-                            status_code=200,
-                            execution_time_ms=0.0,
-                            inputs=gnode.user_data,
-                            output=output_dict,
-                            node_instance=gnode.node_instance
-                        )
-                        init_state.set_node_output(node_id, standard_output)
-                        logger.info(f"[TRIGGER] Pre-injected standardized output for kafka: {node_id}")
-                        
-                    # 3. Start Node
-                    elif gnode.type == "StartNode" or gnode.node_instance.__class__.__name__ == "StartNode":
-                        output_dict = {
-                            "output": initial_input or "Workflow started"
-                        }
-                        from app.core.json_utils import format_standard_node_output
-                        standard_output = format_standard_node_output(
-                            node_id=node_id,
-                            node_type=gnode.type,
-                            success=True,
-                            status_code=200,
-                            execution_time_ms=0.0,
-                            inputs=gnode.user_data,
-                            output=output_dict,
-                            node_instance=gnode.node_instance
-                        )
-                        init_state.set_node_output(node_id, standard_output)
-                        logger.info(f"[TRIGGER] Pre-injected standardized output for start node: {node_id}")
-                        
-                    # 4. Timer Start Node
+                    # 4. Custom handling for TimerStart
                     elif gnode.type in ("TimerStart", "TimerStartNode") or gnode.node_instance.__class__.__name__ == "TimerStartNode":
                         from datetime import datetime, timezone
                         output_dict = {
@@ -1006,19 +1188,40 @@ class GraphBuilder:
                             },
                             "output": "Timer triggered"
                         }
-                        from app.core.json_utils import format_standard_node_output
-                        standard_output = format_standard_node_output(
-                            node_id=node_id,
-                            node_type=gnode.type,
-                            success=True,
-                            status_code=200,
-                            execution_time_ms=0.0,
-                            inputs=gnode.user_data,
-                            output=output_dict,
-                            node_instance=gnode.node_instance
-                        )
-                        init_state.set_node_output(node_id, standard_output)
-                        logger.info(f"[TRIGGER] Pre-injected standardized output for timer: {node_id}")
+                    # 5. Generic Fallback trigger
+                    else:
+                        output_dict = {}
+                        import inspect
+                        if hasattr(gnode.node_instance, "_execute") and callable(getattr(gnode.node_instance, "_execute")):
+                            execute_method = gnode.node_instance._execute
+                            sig = inspect.signature(execute_method)
+                            if len(sig.parameters) >= 1:
+                                output_dict = execute_method(init_state)
+                            else:
+                                output_dict = execute_method()
+                        elif hasattr(gnode.node_instance, "execute") and callable(getattr(gnode.node_instance, "execute")):
+                            execute_method = gnode.node_instance.execute
+                            sig = inspect.signature(execute_method)
+                            if "inputs" in sig.parameters:
+                                output_dict = execute_method(inputs=inputs)
+                            elif not sig.parameters:
+                                output_dict = execute_method()
+                            else:
+                                output_dict = execute_method()
+
+                    from app.core.json_utils import format_standard_node_output
+                    standard_output = format_standard_node_output(
+                        node_id=node_id,
+                        node_type=gnode.type,
+                        success=True,
+                        status_code=200,
+                        execution_time_ms=0.0,
+                        inputs=gnode.user_data,
+                        output=output_dict,
+                        node_instance=gnode.node_instance
+                    )
+                    init_state.set_node_output(node_id, standard_output)
+                    logger.info(f"[TRIGGER] Pre-injected standardized output for {gnode.type}: {node_id}")
                 except Exception as trigger_err:
                     logger.warning(f"Failed to pre-inject trigger output for {node_id}: {trigger_err}")
 

--- a/client/app/components/canvas/FlowCanvas.tsx
+++ b/client/app/components/canvas/FlowCanvas.tsx
@@ -51,7 +51,7 @@ import AutoSaveSettingsModal from "../modals/AutoSaveSettingsModal";
 import FullscreenNodeModal from "../common/FullscreenNodeModal";
 import { TutorialButton } from "../tutorial";
 import LogPanel from "./LogPanel";
-import { executeWorkflowStream, getExecution } from "~/services/executionService";
+import { executeNode, executeWorkflowStream, getExecution } from "~/services/executionService";
 import GenericNode from "../node";
 
 // Import config components
@@ -1679,6 +1679,78 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
     ]
   );
 
+  const handleSelectedNodeExecution = useCallback(
+    async (nodeId: string, configValues: Record<string, unknown>) => {
+      if (!currentWorkflow) {
+        enqueueSnackbar("No workflow selected", { variant: "error" });
+        return;
+      }
+
+      const selectedNode = nodes.find((node) => node.id === nodeId);
+      if (!selectedNode) {
+        enqueueSnackbar("Selected node not found", { variant: "error" });
+        return;
+      }
+      const nodeName = String(selectedNode.data?.name || selectedNode.type || nodeId);
+
+      const executionNodes = nodes.map((node) =>
+        node.id === nodeId
+          ? { ...node, data: { ...node.data, ...configValues } }
+          : node
+      );
+
+      setNodeStatus((status) => ({ ...status, [nodeId]: "pending" }));
+      enqueueSnackbar("Executing node...", { variant: "info" });
+
+      try {
+        const result = await executeNode({
+          workflow_id: currentWorkflow.id,
+          flow_data: {
+            nodes: executionNodes as WorkflowNode[],
+            edges: edges as WorkflowEdge[],
+            settings: currentWorkflow.flow_data?.settings,
+          },
+          node_id: nodeId,
+          node_outputs: currentExecution?.result?.node_outputs,
+        });
+        const completedAt = new Date().toISOString();
+
+        setCurrentExecutionForWorkflow(currentWorkflow.id, {
+          id: `node-${nodeId}-${Date.now()}`,
+          workflow_id: currentWorkflow.id,
+          status: result.success ? "completed" : "failed",
+          started_at: completedAt,
+          completed_at: completedAt,
+          result: {
+            result: result.output,
+            executed_nodes: [nodeId],
+            node_outputs: {
+              ...(currentExecution?.result?.node_outputs || {}),
+              ...(result.node_outputs || { [nodeId]: result.output }),
+            },
+            session_id: result.session_id,
+            status: result.success ? "completed" : "failed",
+          },
+        } as any);
+        setNodeStatus((status) => ({
+          ...status,
+          [nodeId]: result.success ? "success" : "failed",
+        }));
+        enqueueSnackbar(
+          result.success
+            ? "Node executed successfully"
+            : result.error || `Could not run "${nodeName}" (${nodeId}). No error details were returned.`,
+          { variant: result.success ? "success" : "error" }
+        );
+      } catch (error: any) {
+        setNodeStatus((status) => ({ ...status, [nodeId]: "failed" }));
+        const errorMessage = error?.message || "Check the node configuration and required connections.";
+        enqueueSnackbar(`Could not run "${nodeName}" (${nodeId}): ${errorMessage}`, { variant: "error" });
+      }
+    },
+    [currentExecution, currentWorkflow, edges, enqueueSnackbar, nodes, setCurrentExecutionForWorkflow]
+  );
+
   // Error handling functions
   const handleErrorRetry = useCallback(() => {
     if (errorNodeId && currentWorkflow) {
@@ -2304,8 +2376,8 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
             onConfigChange={handleNodeConfigChange}
             historyRevision={historyRevision}
             configFlushRef={configFlushRef}
-            onExecute={() =>
-              handleStartNodeExecution(fullscreenModal.nodeData?.id || "")
+            onExecute={(values) =>
+              handleSelectedNodeExecution(fullscreenModal.nodeData?.id || "", values)
             }
             ConfigComponent={fullscreenModal.configComponent}
             executionData={{

--- a/client/app/components/common/FullscreenNodeModal.tsx
+++ b/client/app/components/common/FullscreenNodeModal.tsx
@@ -67,7 +67,7 @@ interface FullscreenNodeModalProps {
   onConfigChange?: (values: any) => void;
   historyRevision?: number;
   configFlushRef?: React.MutableRefObject<(() => void) | null>;
-  onExecute?: () => void; // New execute function
+  onExecute?: (values: any) => void; // New execute function
   ConfigComponent: React.ComponentType<{
     configData: any;
     onSave: (values: any) => void;
@@ -804,12 +804,12 @@ export default function FullscreenNodeModal({
               </div>
               {onExecute && nodeMetadata.node_type === "processor" && (
                 <button
-                  onClick={onExecute}
+                  onClick={() => onExecute({ ...(pendingConfigValuesRef.current ?? configValues), name: nodeAliasRef.current })}
                   className="flex items-center gap-2 px-4 py-2 rounded-lg bg-green-600 hover:bg-green-500 text-white text-sm font-medium transition-colors"
-                  title="Execute this processor node"
+                  title="Run only this processor node"
                 >
                   <Play className="w-4 h-4" />
-                  Execute
+                  Run Node
                 </button>
               )}
               <button

--- a/client/app/lib/config.ts
+++ b/client/app/lib/config.ts
@@ -95,6 +95,7 @@ export const API_ENDPOINTS = {
     DELETE: (id: string) => `/workflows/${id}`,
     VALIDATE: '/workflows/validate',
     EXECUTE: '/workflows/execute',
+    EXECUTE_NODE: '/workflows/execute-node',
     PUBLIC: '/workflows/public/',
     SEARCH: '/workflows/search/',
     DUPLICATE: (id: string) => `/workflows/${id}/duplicate`,

--- a/client/app/services/executionService.ts
+++ b/client/app/services/executionService.ts
@@ -46,6 +46,16 @@ export const executeWorkflow = async (workflow_id: string, executionData: {
   return response;
 };
 
+export const executeNode = async (executionData: {
+  workflow_id: string;
+  flow_data: any;
+  node_id: string;
+  input_text?: string;
+  node_outputs?: Record<string, any>;
+}) => {
+  return apiClient.post<any>(API_ENDPOINTS.WORKFLOWS.EXECUTE_NODE, executionData);
+};
+
 export const deleteExecution = async (execution_id: string) => {
   return apiClient.delete(`/executions/${execution_id}`);
 };


### PR DESCRIPTION
- Replace the thread-mocking execution flow in `execute_node` with native compiled LangGraph partial graph invocation.
- Add the `_get_upstream_nodes` helper to dynamically resolve upstream canvas dependencies while excluding downstream and unrelated nodes.
- Implement metadata-driven `is_trigger_node` detection using node categories, class introspection, and graph topology, eliminating hardcoded node type checks.
- Add dynamic trigger execution through `_execute` and `execute` method signature introspection to support future trigger node implementations without engine changes.
- Fix a circular dependency issue in `GraphBuilder` that incorrectly connected the `virtual-end-node` to itself when workflows contained no explicit terminal node.
- Prevent recursive `asyncio.queues.QueueFull` failures in `enhanced_logging.py` by safely discarding the oldest log messages when subscriber queues reach capacity.