### PR TITLE
feat: add postgres tool node

### DIFF
--- a/backend/app/api/nodes.py
+++ b/backend/app/api/nodes.py
@@ -1,13 +1,19 @@
-
 import logging
 from typing import Dict, Any
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
+from pydantic import BaseModel
 
 from app.core.node_registry import node_registry
+from app.auth.dependencies import get_current_user
+from app.core.credential_provider import credential_provider
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
+
+class NodeOptionsRequest(BaseModel):
+    property_name: str
+    values: Dict[str, Any] = {}
 
 @router.get("")
 async def get_all_nodes():
@@ -260,3 +266,61 @@ async def search_nodes(query: str):
     # Sort by relevance
     results.sort(key=lambda x: x["relevance_score"], reverse=True)
     return results[:10]  # Return top 10 results
+
+@router.post("/{node_type}/options")
+async def get_node_property_options(
+    node_type: str,
+    request: NodeOptionsRequest,
+    current_user=Depends(get_current_user),
+):
+    """
+    Fill a dynamic field.
+
+    The node declares `optionsMethod` on the property; this endpoint calls that
+    method with the values currently entered in the panel and returns the list.
+    """
+    node_class = node_registry.get_node(node_type)
+    if not node_class:
+        raise HTTPException(status_code=404, detail=f"Node type '{node_type}' not found")
+
+    try:
+        instance = node_class()
+    except Exception as e:
+        logger.error(f"Could not create node {node_type}: {e}")
+        raise HTTPException(status_code=500, detail="Node could not be created")
+
+    prop = next(
+        (p for p in instance._metadata.get("properties", []) if p.name == request.property_name),
+        None,
+    )
+    if prop is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Property '{request.property_name}' not found on {node_type}",
+        )
+
+    method_name = getattr(prop, "optionsMethod", None)
+    if not method_name:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Property '{request.property_name}' does not load options dynamically",
+        )
+
+    loader = getattr(instance, method_name, None)
+    if not callable(loader):
+        raise HTTPException(
+            status_code=500,
+            detail=f"Node {node_type} has no method named '{method_name}'",
+        )
+
+    try:
+        instance.credentials = credential_provider.get_credentials_sync(current_user.id)
+    except Exception as e:
+        logger.warning(f"Could not load credentials for options request: {e}")
+        instance.credentials = []
+
+    try:
+        return {"options": loader(request.values)}
+    except Exception as e:
+        logger.error(f"Loading options for {node_type}.{request.property_name} failed: {e}")
+        raise HTTPException(status_code=400, detail=str(e))

--- a/backend/app/nodes/base.py
+++ b/backend/app/nodes/base.py
@@ -119,6 +119,9 @@ class NodePropertyType(str, Enum):
     DATETIME = "datetime"
     CODE_EDITOR = "code-editor"
     SESSION_ID = "session-id"
+    DYNAMIC_SELECT = "dynamic-select"
+    COLUMN_MAPPER = "column-mapper"
+    CONDITION_BUILDER = "condition-builder"
 
 
 class NodeProperty(BaseModel):
@@ -234,6 +237,22 @@ class NodeProperty(BaseModel):
     minLength: Optional[int] = Field(
         default=None,
         description="Minimum length of the input"
+    )
+    optionsMethod: Optional[str] = Field(
+        default=None,
+        description="Name of the method on the node that returns the option list",
+        alias="optionsMethod"
+    )
+
+    optionsDependsOn: Optional[List[str]] = Field(
+        default=None,
+        description="Fields that trigger a refetch of the option list when they change",
+        alias="optionsDependsOn"
+    )
+
+    multiple: Optional[bool] = Field(
+        default=None,
+        description="Allow more than one value to be selected"
     )
     
     colSpan: Optional[int] = Field(

--- a/backend/app/nodes/processing/postgres_node.py
+++ b/backend/app/nodes/processing/postgres_node.py
@@ -1,0 +1,1511 @@
+"""
+PostgreSQL Node
+===============
+
+Performs database operations against a PostgreSQL server: running raw SQL,
+selecting rows, inserting, updating, upserting and deleting.
+
+Design notes
+------------
+- Values are always passed as query parameters, never interpolated into the SQL
+  string. This is what prevents SQL injection.
+- Identifiers (schema, table, column names) cannot be parameterized by the
+  driver, so they are validated and quoted through ``psycopg2.sql`` instead.
+- Connections are opened per execution and always closed in a ``finally`` block.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+import uuid as uuid_module
+import logging
+from datetime import date, datetime, time as time_type, timedelta
+from decimal import Decimal
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+import psycopg2
+from psycopg2 import sql
+from psycopg2.extras import RealDictCursor, execute_values
+
+from ..base import (
+    ProcessorNode,
+    NodeInput,
+    NodeOutput,
+    NodeType,
+    NodeProperty,
+    NodePropertyType,
+    NodePosition,
+)
+
+logger = logging.getLogger(__name__)
+
+# Identifiers must be plain names. Anything else is rejected before it reaches
+# the database, so a crafted table name cannot break out of its context.
+IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+# Operations that change data. Used by read-only mode.
+WRITE_OPERATIONS = {"insert", "update", "upsert", "delete"}
+
+# Statements that change data or structure. A statement starting with any of
+# these is refused while read-only mode is on.
+WRITE_KEYWORDS = {
+    "insert", "update", "delete", "truncate", "drop", "create", "alter",
+    "grant", "revoke", "comment", "merge", "copy", "vacuum", "reindex",
+    "refresh", "call", "do",
+}
+
+# Comparison operators exposed in the condition builder, mapped to SQL.
+# Equality on text ignores case, so a filter written in lower case still finds
+# rows stored with capitals.
+CASE_FOLDED_OPERATORS = {"equals", "not_equals"}
+
+CONDITION_OPERATORS = {
+    "equals": "=",
+    "not_equals": "!=",
+    "greater_than": ">",
+    "greater_or_equal": ">=",
+    "less_than": "<",
+    "less_or_equal": "<=",
+    "like": "LIKE",
+    "ilike": "ILIKE",
+    "is_null": "IS NULL",
+    "is_not_null": "IS NOT NULL",
+}
+
+
+class PostgresNode(ProcessorNode):
+    """Runs SQL statements and table operations against a PostgreSQL database."""
+
+    def __init__(self):
+        super().__init__()
+        self._metadata = {
+            "name": "PostgresNode",
+            "display_name": "PostgreSQL",
+            "description": (
+                "Run queries and manage rows in a PostgreSQL database. Supports raw SQL, "
+                "select, insert, update, upsert and delete with parameterized values."
+            ),
+            "category": "Databases",
+            "node_type": NodeType.PROCESSOR,
+            "icon": {
+                "name": "postgresql_vectorstore",
+                "path": "icons/postgresql_vectorstore.svg",
+                "alt": "PostgreSQL",
+            },
+            "colors": ["indigo-500", "purple-600"],
+            "inputs": [
+                NodeInput(
+                    name="input",
+                    type="any",
+                    description="Incoming data. Used as row values when the Data field is left empty.",
+                    is_connection=True,
+                    direction=NodePosition.LEFT,
+                    required=False,
+                ),
+            ],
+            "outputs": [
+                NodeOutput(
+                    name="output",
+                    displayName="Output",
+                    type="dict",
+                    description=(
+                        "Result of the operation: the rows it returned, how many were affected "
+                        "and how long it took."
+                    ),
+                    is_connection=True,
+                    direction=NodePosition.RIGHT,
+                ),
+                NodeOutput(
+                    name="success",
+                    type="boolean",
+                    description="Whether the operation completed without an error.",
+                ),
+                NodeOutput(
+                    name="error",
+                    type="string",
+                    description="Error message when the operation failed.",
+                ),
+            ],
+            "properties": [
+                # ----------------------------------------------------------
+                # Basic
+                # ----------------------------------------------------------
+                NodeProperty(
+                    name="credential_id",
+                    displayName="Credential",
+                    type=NodePropertyType.CREDENTIAL_SELECT,
+                    description="PostgreSQL connection to use.",
+                    placeholder="Select Credential",
+                    required=True,
+                    serviceType="postgresql_vectorstore",
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="operation",
+                    displayName="Operation",
+                    type=NodePropertyType.SELECT,
+                    description="The database operation to perform.",
+                    required=True,
+                    default="select",
+                    options=[
+                        {"label": "Execute Query", "value": "execute_query"},
+                        {"label": "Select", "value": "select"},
+                        {"label": "Insert", "value": "insert"},
+                        {"label": "Update", "value": "update"},
+                        {"label": "Insert or Update", "value": "upsert"},
+                        {"label": "Delete", "value": "delete"},
+                    ],
+                    tabName="basic",
+                ),
+
+                # --- Execute Query -----------------------------------------
+                NodeProperty(
+                    name="query",
+                    displayName="Query",
+                    type=NodePropertyType.CODE_EDITOR,
+                    description=(
+                        "SQL statement to run. Use $1, $2 placeholders for values and supply "
+                        "them in Query Parameters so they are escaped safely."
+                    ),
+                    placeholder="SELECT * FROM customers WHERE city = $1;",
+                    required=False,
+                    default="",
+                    rows=8,
+                    maxLength=20000,
+                    displayOptions={"show": {"operation": "execute_query"}},
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="query_parameters",
+                    displayName="Query Parameters",
+                    type=NodePropertyType.JSON_EDITOR,
+                    description=(
+                        "Values for the $1, $2 placeholders, in order. Given as a JSON array, "
+                        "for example: [\"aksesuar\", 2000]"
+                    ),
+                    placeholder='["value1", 100]',
+                    required=False,
+                    default="[]",
+                    displayOptions={"show": {"operation": "execute_query"}},
+                    tabName="basic",
+                ),
+
+                # --- Table targeting ---------------------------------------
+                NodeProperty(
+                    name="schema_name",
+                    displayName="Schema",
+                    type=NodePropertyType.DYNAMIC_SELECT,
+                    description=(
+                        "Schema that contains the table. Pick one from the list or type a name, "
+                        "which also accepts a template."
+                    ),
+                    placeholder="Select or type a schema",
+                    required=False,
+                    default="public",
+                    optionsMethod="load_schemas",
+                    optionsDependsOn=["credential_id"],
+                    displayOptions={"show": {"operation": ["select", "insert", "update", "upsert", "delete"]}},
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="table_name",
+                    displayName="Table",
+                    type=NodePropertyType.DYNAMIC_SELECT,
+                    description=(
+                        "Table to operate on. Pick one from the list or type a name, which also "
+                        "accepts a template."
+                    ),
+                    placeholder="Select or type a table",
+                    required=False,
+                    default="",
+                    optionsMethod="load_tables",
+                    optionsDependsOn=["credential_id", "schema_name"],
+                    displayOptions={"show": {"operation": ["select", "insert", "update", "upsert", "delete"], "schema_name": "*"}},
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="columns",
+                    displayName="Columns",
+                    type=NodePropertyType.DYNAMIC_SELECT,
+                    description="Columns to return. Leave empty for all of them.",
+                    placeholder="All columns",
+                    required=False,
+                    default="",
+                    multiple=True,
+                    optionsMethod="load_columns",
+                    optionsDependsOn=["credential_id", "schema_name", "table_name"],
+                    displayOptions={"show": {"operation": "select", "table_name": "*"}},
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="return_all",
+                    displayName="Return All",
+                    type=NodePropertyType.CHECKBOX,
+                    description="Return every matching row. Turn off to apply a limit.",
+                    required=False,
+                    default=True,
+                    displayOptions={"show": {"operation": "select", "table_name": "*"}},
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="limit",
+                    displayName="Limit",
+                    type=NodePropertyType.NUMBER,
+                    description="Maximum number of rows to return.",
+                    required=False,
+                    default=50,
+                    min=1,
+                    max=10000,
+                    displayOptions={"show": {"operation": "select", "return_all": False}},
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="sort_column",
+                    displayName="Sort Column",
+                    type=NodePropertyType.DYNAMIC_SELECT,
+                    description="Column the results are ordered by. Leave empty for no ordering.",
+                    placeholder="No ordering",
+                    required=False,
+                    default="",
+                    optionsMethod="load_columns",
+                    optionsDependsOn=["credential_id", "schema_name", "table_name"],
+                    displayOptions={"show": {"operation": "select", "table_name": "*"}},
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="sort_direction",
+                    displayName="Sort Direction",
+                    type=NodePropertyType.SELECT,
+                    description="Order direction for the sort column.",
+                    required=False,
+                    default="ASC",
+                    options=[
+                        {"label": "Ascending", "value": "ASC"},
+                        {"label": "Descending", "value": "DESC"},
+                    ],
+                    displayOptions={"show": {"operation": "select", "sort_column": "*"}},
+                    tabName="basic",
+                ),
+
+                # --- Conditions --------------------------------------------
+                # --- Conditions (Select and Delete) --------------------------
+                NodeProperty(
+                    name="delete_command",
+                    displayName="Command",
+                    type=NodePropertyType.SELECT,
+                    description="How the data should be removed.",
+                    required=False,
+                    default="delete",
+                    options=[
+                        {"label": "Delete - remove matching rows", "value": "delete"},
+                        {"label": "Truncate - remove all rows, keep the table", "value": "truncate"},
+                    ],
+                    hint=(
+                        "Truncate is much faster than Delete but empties the whole table; "
+                        "any filter below is ignored."
+                    ),
+                    displayOptions={"show": {"operation": "delete", "table_name": "*"}},
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="restart_sequences",
+                    displayName="Restart Sequences",
+                    type=NodePropertyType.CHECKBOX,
+                    description="Reset auto incrementing columns back to their starting value.",
+                    required=False,
+                    default=False,
+                    displayOptions={"show": {"operation": "delete", "delete_command": "truncate"}},
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="cascade",
+                    displayName="Cascade",
+                    type=NodePropertyType.CHECKBOX,
+                    description="Also truncate tables that reference this one through a foreign key.",
+                    required=False,
+                    default=False,
+                    displayOptions={"show": {"operation": "delete", "delete_command": "truncate"}},
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="filter_column",
+                    displayName="Filter Column",
+                    type=NodePropertyType.DYNAMIC_SELECT,
+                    description=(
+                        "Column the rows are matched on. Leave empty to match every row, which "
+                        "for Delete means the whole table."
+                    ),
+                    placeholder="No filter, match every row",
+                    required=False,
+                    default="",
+                    optionsMethod="load_columns",
+                    optionsDependsOn=["credential_id", "schema_name", "table_name"],
+                    displayOptions={"show": {"operation": ["select", "update", "delete"], "table_name": "*"}},
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="filter_operator",
+                    displayName="Filter Operator",
+                    type=NodePropertyType.SELECT,
+                    description=(
+                        "How the column is compared to the value. Text comparisons ignore "
+                        "capitalisation, so 'bursa' also matches 'Bursa' and 'BURSA'."
+                    ),
+                    required=False,
+                    default="equals",
+                    options=[
+                        {"label": "is equal to", "value": "equals"},
+                        {"label": "is not equal to", "value": "not_equals"},
+                        {"label": "is greater than", "value": "greater_than"},
+                        {"label": "is greater than or equal to", "value": "greater_or_equal"},
+                        {"label": "is less than", "value": "less_than"},
+                        {"label": "is less than or equal to", "value": "less_or_equal"},
+                        {"label": "contains", "value": "ilike"},
+                        {"label": "contains (case sensitive)", "value": "like"},
+                        {"label": "is empty", "value": "is_null"},
+                        {"label": "is not empty", "value": "is_not_null"},
+                    ],
+                    displayOptions={"show": {"operation": ["select", "update", "delete"], "filter_column": "*"}},
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="filter_value",
+                    displayName="Filter Value",
+                    type=NodePropertyType.TEXT,
+                    description=(
+                        "Value the column is compared to. Not needed for the empty and not empty "
+                        "operators."
+                    ),
+                    placeholder="e.g. Istanbul",
+                    required=False,
+                    default="",
+                    displayOptions={"show": {"operation": ["select", "update", "delete"], "filter_column": "*", "filter_operator": ["equals", "not_equals", "greater_than", "greater_or_equal", "less_than", "less_or_equal", "like", "ilike"]}},
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="where_conditions",
+                    displayName="Extra Conditions",
+                    type=NodePropertyType.JSON_EDITOR,
+                    description=(
+                        "Further conditions as a JSON array, for cases the single filter above "
+                        "cannot express. Each entry takes column, operator and value."
+                    ),
+                    placeholder='[{"column": "is_active", "operator": "equals", "value": true}]',
+                    required=False,
+                    default="[]",
+                    hint=(
+                        "Operators: equals, not_equals, greater_than, greater_or_equal, "
+                        "less_than, less_or_equal, like, ilike, is_null, is_not_null"
+                    ),
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="combine_conditions",
+                    displayName="Combine Conditions",
+                    type=NodePropertyType.SELECT,
+                    description="How multiple conditions are joined together.",
+                    required=False,
+                    default="AND",
+                    options=[
+                        {"label": "AND - all must match", "value": "AND"},
+                        {"label": "OR - any may match", "value": "OR"},
+                    ],
+                    tabName="basic",
+                ),
+
+                # --- Column mapping (Insert, Update, Upsert) ------------------
+                NodeProperty(
+                    name="mapping_mode",
+                    displayName="Mapping Column Mode",
+                    type=NodePropertyType.SELECT,
+                    description="How column names are matched to the incoming data.",
+                    required=False,
+                    default="manual",
+                    options=[
+                        {
+                            "label": "Map Each Column Manually",
+                            "value": "manual",
+                            "hint": "Write the column values yourself.",
+                        },
+                        {
+                            "label": "Map Automatically",
+                            "value": "auto",
+                            "hint": "Take the values from the incoming data. Field names must match the column names.",
+                        },
+                    ],
+                    displayOptions={"show": {"operation": ["insert", "update", "upsert"], "table_name": "*"}},
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="match_columns",
+                    displayName="Columns to Match On",
+                    type=NodePropertyType.DYNAMIC_SELECT,
+                    description=(
+                        "Columns used to find the existing row. Their values are read from the "
+                        "data, so they must be present there."
+                    ),
+                    placeholder="Select a column",
+                    required=False,
+                    default="",
+                    multiple=True,
+                    optionsMethod="load_columns",
+                    optionsDependsOn=["credential_id", "schema_name", "table_name"],
+                    hint=(
+                        "For Insert or Update the column has to carry a unique constraint. "
+                        "Pick more than one to match on a composite key."
+                    ),
+                    displayOptions={"show": {"operation": ["update", "upsert"], "table_name": "*"}},
+                    tabName="basic",
+                ),
+
+                NodeProperty(
+                    name="data",
+                    displayName="Values to Send",
+                    type=NodePropertyType.COLUMN_MAPPER,
+                    description=(
+                        "Value for each column of the selected table. Columns can be left out; "
+                        "the database then applies its own default."
+                    ),
+                    required=False,
+                    default="{}",
+                    optionsMethod="load_column_schema",
+                    optionsDependsOn=["credential_id", "schema_name", "table_name"],
+                    hint=(
+                        "Switch Mapping Column Mode to Map Automatically to take the values from "
+                        "the incoming data instead."
+                    ),
+                    displayOptions={"show": {"operation": ["insert", "update", "upsert"], "mapping_mode": "manual"}},
+                    tabName="basic",
+                ),
+
+                # ----------------------------------------------------------
+                # Advanced
+                # ----------------------------------------------------------
+                NodeProperty(
+                    name="read_only",
+                    displayName="Read Only",
+                    type=NodePropertyType.CHECKBOX,
+                    description=(
+                        "Allow reading only. Insert, update, upsert and delete are refused, and "
+                        "raw statements that would change data are rejected before they run. "
+                        "Useful when the node is reachable by an agent."
+                    ),
+                    required=False,
+                    default=False,
+                    tabName="advanced",
+                ),
+                NodeProperty(
+                    name="return_columns",
+                    displayName="Output Columns",
+                    type=NodePropertyType.DYNAMIC_SELECT,
+                    description=(
+                        "Columns to return after a write. Leave empty to return every column of "
+                        "the affected rows."
+                    ),
+                    placeholder="All columns",
+                    required=False,
+                    default="",
+                    multiple=True,
+                    optionsMethod="load_columns",
+                    optionsDependsOn=["credential_id", "schema_name", "table_name"],
+                    displayOptions={"show": {"operation": ["insert", "update", "upsert", "delete"]}},
+                    tabName="advanced",
+                ),
+                NodeProperty(
+                    name="use_transaction",
+                    displayName="Use Transaction",
+                    type=NodePropertyType.CHECKBOX,
+                    description=(
+                        "Wrap the operation in a transaction so a failure rolls back every change. "
+                        "Turn off to commit each statement on its own."
+                    ),
+                    required=False,
+                    default=True,
+                    tabName="advanced",
+                ),
+                NodeProperty(
+                    name="skip_on_conflict",
+                    displayName="Skip on Conflict",
+                    type=NodePropertyType.CHECKBOX,
+                    description=(
+                        "Ignore rows that violate a unique constraint instead of raising an error."
+                    ),
+                    required=False,
+                    default=False,
+                    displayOptions={"show": {"operation": "insert"}},
+                    tabName="advanced",
+                ),
+                NodeProperty(
+                    name="replace_empty_with_null",
+                    displayName="Replace Empty Strings with NULL",
+                    type=NodePropertyType.CHECKBOX,
+                    description=(
+                        "Store empty text values as NULL. Useful for data exported from spreadsheets."
+                    ),
+                    required=False,
+                    default=False,
+                    displayOptions={"show": {"operation": ["insert", "update", "upsert"]}},
+                    tabName="advanced",
+                ),
+                NodeProperty(
+                    name="numbers_as_text",
+                    displayName="Return Numbers as Text",
+                    type=NodePropertyType.CHECKBOX,
+                    description=(
+                        "Return NUMERIC and DECIMAL columns as text to keep every digit. "
+                        "Turn this on for money amounts and other values where rounding is "
+                        "not acceptable."
+                    ),
+                    required=False,
+                    default=False,
+                    tabName="advanced",
+                ),
+                NodeProperty(
+                    name="connection_timeout",
+                    displayName="Connection Timeout (seconds)",
+                    type=NodePropertyType.NUMBER,
+                    description="How long to wait for the database to accept the connection.",
+                    required=False,
+                    default=30,
+                    min=1,
+                    max=300,
+                    tabName="advanced",
+                ),
+                NodeProperty(
+                    name="statement_timeout",
+                    displayName="Statement Timeout (seconds)",
+                    type=NodePropertyType.NUMBER,
+                    description="Cancel the query if it runs longer than this. Set 0 to disable.",
+                    required=False,
+                    default=60,
+                    min=0,
+                    max=3600,
+                    tabName="advanced",
+                ),
+                NodeProperty(
+                    name="continue_on_error",
+                    displayName="Continue on Error",
+                    type=NodePropertyType.CHECKBOX,
+                    description=(
+                        "Let the workflow carry on when the query fails. The error is reported in "
+                        "the output instead of stopping the run."
+                    ),
+                    required=False,
+                    default=False,
+                    tabName="advanced",
+                ),
+            ],
+        }
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _validate_identifier(value: str, label: str) -> str:
+        """Reject anything that is not a plain SQL identifier."""
+        value = (value or "").strip()
+        if not value:
+            raise ValueError(f"{label} is required.")
+        if not IDENTIFIER_PATTERN.match(value):
+            raise ValueError(
+                f"{label} '{value}' is not a valid identifier. "
+                "Use letters, digits and underscores, starting with a letter or underscore."
+            )
+        return value
+
+    @classmethod
+    def _split_columns(cls, raw: str) -> List[str]:
+        """Turn a comma separated column list into validated identifiers."""
+        if not raw or not raw.strip():
+            return []
+        return [cls._validate_identifier(part, "Column") for part in raw.split(",") if part.strip()]
+
+    @staticmethod
+    def _coerce_json(value: Any, fallback: Any) -> Any:
+        """Accept either an already parsed structure or a JSON string."""
+        if value is None or value == "":
+            return fallback
+        if isinstance(value, (dict, list)):
+            return value
+        if isinstance(value, str):
+            import json
+            try:
+                return json.loads(value)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"Could not parse JSON value: {exc}") from exc
+        return fallback
+
+    def _build_connection_string(self, credential_id: Optional[str]) -> str:
+        """Read the credential and assemble a libpq connection string."""
+        if not credential_id:
+            raise ValueError("A PostgreSQL credential is required.")
+
+        credential = self.get_credential(credential_id)
+        if not credential or not credential.get("secret"):
+            raise ValueError(
+                "The selected credential could not be read. It may have been created with a "
+                "different encryption key; try recreating it."
+            )
+
+        secret = credential["secret"]
+        host = secret.get("host", "localhost")
+        port = secret.get("port", 5432)
+        database = secret.get("database", "postgres")
+        username = secret.get("username", "postgres")
+        password = secret.get("password", "")
+
+        if username and password:
+            return f"postgresql://{username}:{password}@{host}:{port}/{database}"
+        return f"postgresql://{host}:{port}/{database}"
+
+    # ------------------------------------------------------------------
+    # Option loaders
+    #
+    # Called by the node options endpoint when a dynamic dropdown needs to be
+    # filled. Each one receives the values currently entered in the panel.
+    # ------------------------------------------------------------------
+
+    def _fetch_one_column(self, credential_id: str, statement: str, params: tuple = ()) -> List[str]:
+        """Open a short-lived connection and read a single column."""
+        connection = None
+        try:
+            connection = psycopg2.connect(
+                self._build_connection_string(credential_id), connect_timeout=10
+            )
+            with connection.cursor() as cursor:
+                cursor.execute("SET statement_timeout = 5000")
+                cursor.execute(statement, params or None)
+                return [row[0] for row in cursor.fetchall()]
+        finally:
+            if connection is not None:
+                connection.close()
+
+    def load_schemas(self, values: Dict[str, Any]) -> List[Dict[str, str]]:
+        """List the schemas the credential can see."""
+        names = self._fetch_one_column(
+            values.get("credential_id"),
+            """
+            SELECT schema_name
+            FROM information_schema.schemata
+            WHERE schema_name NOT IN ('information_schema', 'pg_catalog', 'pg_toast')
+              AND schema_name NOT LIKE 'pg_temp%'
+              AND schema_name NOT LIKE 'pg_toast_temp%'
+            ORDER BY schema_name
+            """,
+        )
+        return [{"label": name, "value": name} for name in names]
+
+    def load_tables(self, values: Dict[str, Any]) -> List[Dict[str, str]]:
+        """List the tables and views in the selected schema."""
+        schema = (values.get("schema_name") or "public").strip()
+        names = self._fetch_one_column(
+            values.get("credential_id"),
+            """
+            SELECT table_name
+            FROM information_schema.tables
+            WHERE table_schema = %s
+              AND table_type IN ('BASE TABLE', 'VIEW')
+            ORDER BY table_name
+            """,
+            (schema,),
+        )
+        return [{"label": name, "value": name} for name in names]
+
+    def load_columns(self, values: Dict[str, Any]) -> List[Dict[str, str]]:
+        """List the columns of the selected table."""
+        schema = (values.get("schema_name") or "public").strip()
+        table = (values.get("table_name") or "").strip()
+        if not table:
+            return []
+        names = self._fetch_one_column(
+            values.get("credential_id"),
+            """
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_schema = %s AND table_name = %s
+            ORDER BY ordinal_position
+            """,
+            (schema, table),
+        )
+        return [{"label": name, "value": name} for name in names]
+
+    # Postgres data types mapped to the input the panel should show.
+    WIDGET_BY_TYPE = {
+        "boolean": "checkbox",
+        "smallint": "number", "integer": "number", "bigint": "number",
+        "numeric": "number", "real": "number", "double precision": "number",
+        "date": "datetime",
+        "timestamp with time zone": "datetime",
+        "timestamp without time zone": "datetime",
+        "json": "json", "jsonb": "json",
+    }
+
+    def load_column_schema(self, values: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """
+        Describe the columns of the selected table.
+
+        Each entry carries the input the panel should render, whether a value is
+        required and whether the database fills one in on its own.
+        """
+        schema = (values.get("schema_name") or "public").strip()
+        table = (values.get("table_name") or "").strip()
+        if not table:
+            return []
+
+        connection = None
+        try:
+            connection = psycopg2.connect(
+                self._build_connection_string(values.get("credential_id")), connect_timeout=10
+            )
+            with connection.cursor() as cursor:
+                cursor.execute("SET statement_timeout = 5000")
+                cursor.execute(
+                    """
+                    SELECT column_name, data_type, is_nullable, column_default
+                    FROM information_schema.columns
+                    WHERE table_schema = %s AND table_name = %s
+                    ORDER BY ordinal_position
+                    """,
+                    (schema, table),
+                )
+                rows = cursor.fetchall()
+        finally:
+            if connection is not None:
+                connection.close()
+
+        columns: List[Dict[str, Any]] = []
+        for name, data_type, is_nullable, default in rows:
+            columns.append({
+                "label": name,
+                "value": name,
+                "name": name,
+                "type": data_type,
+                "widget": self.WIDGET_BY_TYPE.get(data_type, "text"),
+                "required": is_nullable == "NO" and default is None,
+                "hasDefault": default is not None,
+            })
+        return columns
+
+    def _collect_conditions(self, inputs: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """
+        Gather the row filter.
+
+        The three simple fields cover the common case of one comparison. Anything
+        beyond that goes in Extra Conditions, and the two are combined.
+        """
+        conditions: List[Dict[str, Any]] = []
+
+        column = (inputs.get("filter_column") or "").strip()
+        if column:
+            operator = str(inputs.get("filter_operator") or "equals").strip()
+            condition: Dict[str, Any] = {"column": column, "operator": operator}
+            if operator not in ("is_null", "is_not_null"):
+                condition["value"] = inputs.get("filter_value")
+            conditions.append(condition)
+
+        extra = self._coerce_json(inputs.get("where_conditions"), [])
+        if isinstance(extra, dict):
+            extra = [extra]
+        if isinstance(extra, list):
+            conditions.extend(entry for entry in extra if isinstance(entry, dict) and entry)
+
+        return conditions
+
+    def _collect_conditions(self, inputs: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """
+        Gather the row filter.
+
+        The three filter fields cover the common case of a single comparison and
+        are picked from lists rather than typed. Anything more involved goes in
+        Extra Conditions as JSON. Both are merged here, so the rest of the code
+        only ever sees one list.
+        """
+        conditions: List[Dict[str, Any]] = []
+
+        column = (inputs.get("filter_column") or "").strip()
+        if column:
+            operator = (inputs.get("filter_operator") or "equals").strip()
+            condition: Dict[str, Any] = {"column": column, "operator": operator}
+            if operator not in ("is_null", "is_not_null"):
+                condition["value"] = inputs.get("filter_value", "")
+            conditions.append(condition)
+
+        extra = self._coerce_json(inputs.get("where_conditions"), [])
+        if isinstance(extra, list):
+            conditions.extend(entry for entry in extra if isinstance(entry, dict) and entry)
+
+        return conditions
+
+    @staticmethod
+    def _prepare_condition_value(operator: str, value: Any) -> Any:
+        """
+        Shape a value for the operator it will be used with.
+
+        The contains operators run on LIKE, which treats a plain string as an
+        exact match. Wrapping it in wildcards is what someone picking "contains"
+        expects. A value that already carries a wildcard is left alone, so a
+        deliberate pattern still works.
+        """
+        if operator not in ("like", "ilike"):
+            return value
+        if not isinstance(value, str) or not value:
+            return value
+        if "%" in value or "_" in value:
+            return value
+        return f"%{value}%"
+
+    def _build_where_clause(
+        self, conditions: List[Dict[str, Any]], combiner: str
+    ) -> Tuple[Optional[sql.Composed], List[Any]]:
+        """Compose a WHERE clause and collect its parameter values."""
+        if not conditions:
+            return None, []
+
+        joiner = " AND " if str(combiner).upper() != "OR" else " OR "
+        fragments: List[sql.Composed] = []
+        values: List[Any] = []
+
+        for condition in conditions:
+            if not isinstance(condition, dict):
+                raise ValueError("Each condition must be an object with column, operator and value.")
+
+            column = self._validate_identifier(condition.get("column", ""), "Condition column")
+            operator_key = str(condition.get("operator", "equals")).lower()
+
+            if operator_key not in CONDITION_OPERATORS:
+                raise ValueError(
+                    f"Unknown operator '{operator_key}'. "
+                    f"Supported operators: {', '.join(CONDITION_OPERATORS)}"
+                )
+
+            operator_sql = CONDITION_OPERATORS[operator_key]
+
+            # NULL checks take no value on the right hand side.
+            if operator_key in ("is_null", "is_not_null"):
+                fragments.append(
+                    sql.SQL("{} {}").format(sql.Identifier(column), sql.SQL(operator_sql))
+                )
+            else:
+                value = self._prepare_condition_value(operator_key, condition.get("value"))
+
+                # Equality on text is compared without regard to case. Someone
+                # filtering on "bursa" means the rows holding "Bursa" and "BURSA"
+                # as well; a plain = would quietly pass over them. The cast keeps
+                # this safe on columns that are not text.
+                if operator_key in CASE_FOLDED_OPERATORS and isinstance(value, str):
+                    fragments.append(
+                        sql.SQL("LOWER({}::text) {} LOWER(%s)").format(
+                            sql.Identifier(column), sql.SQL(operator_sql)
+                        )
+                    )
+                else:
+                    fragments.append(
+                        sql.SQL("{} {} %s").format(
+                            sql.Identifier(column), sql.SQL(operator_sql)
+                        )
+                    )
+
+                values.append(value)
+
+        return sql.SQL(joiner).join(fragments), values
+
+    # Trigger nodes wrap the payload, sometimes more than once. A webhook, for
+    # instance, nests the request body under webhook_data.payload.
+    ENVELOPE_KEYS = ("webhook_data", "payload", "body", "json", "data", "result", "rows")
+
+    @classmethod
+    def _unwrap_payload(cls, value: Any, depth: int = 4) -> Any:
+        """
+        Reach the row inside a trigger's envelope.
+
+        A trigger hands over its whole context, with the row sitting alongside
+        timestamps, identifiers and configuration. Recognised wrapper keys are
+        peeled off one at a time until the row itself is reached.
+        """
+        if depth <= 0 or not isinstance(value, dict):
+            return value
+
+        for key in cls.ENVELOPE_KEYS:
+            inner = value.get(key)
+            if isinstance(inner, dict) and inner:
+                return cls._unwrap_payload(inner, depth - 1)
+            if isinstance(inner, list) and inner and isinstance(inner[0], dict):
+                return inner
+
+        return value
+
+    def _table_columns(self, inputs: Dict[str, Any]) -> List[str]:
+        """Read the column names of the target table, or an empty list on failure."""
+        try:
+            schema = self._validate_identifier(inputs.get("schema_name", "public"), "Schema")
+            table = self._validate_identifier(inputs.get("table_name", ""), "Table")
+        except ValueError:
+            return []
+
+        try:
+            return self._fetch_one_column(
+                inputs.get("credential_id"),
+                """
+                SELECT column_name
+                FROM information_schema.columns
+                WHERE table_schema = %s AND table_name = %s
+                ORDER BY ordinal_position
+                """,
+                (schema, table),
+            )
+        except Exception as exc:
+            logger.warning(f"Could not read the columns of {table}: {exc}")
+            return []
+
+    def _resolve_rows(
+        self,
+        raw_data: Any,
+        connected_nodes: Dict[str, Any],
+        replace_empty: bool,
+        inputs: Optional[Dict[str, Any]] = None,
+    ) -> List[Dict[str, Any]]:
+        """
+        Collect the rows to write.
+
+        Accepts a single object or an array, taken either from the Data field or
+        from the input connection. Always returns a list so one row and many rows
+        can be handled the same way.
+
+        Data arriving on the connection is filtered down to the table's own
+        columns. A trigger usually sends more than the row itself, and passing
+        those extras through would only produce an error the author cannot act
+        on.
+        """
+        data = self._coerce_json(raw_data, None)
+        from_connection = False
+
+        if not data:
+            data = self._unwrap_payload(connected_nodes.get("input"))
+            from_connection = True
+
+        if isinstance(data, dict):
+            rows = [data]
+        elif isinstance(data, list):
+            rows = [row for row in data if isinstance(row, dict) and row]
+        else:
+            rows = []
+
+        if not rows:
+            raise ValueError(
+                "No column values were supplied. Fill in the Data field or connect a node that "
+                "produces an object or a list of objects."
+            )
+
+        # Only the table's own columns survive when the data comes off a wire.
+        known: Optional[Set[str]] = None
+        if from_connection and inputs is not None:
+            columns = self._table_columns(inputs)
+            if columns:
+                known = {name.lower() for name in columns}
+
+        cleaned: List[Dict[str, Any]] = []
+        for row in rows:
+            if known is not None:
+                row = {key: value for key, value in row.items() if str(key).lower() in known}
+                if not row:
+                    raise ValueError(
+                        "None of the incoming fields match a column of the table. "
+                        "Check the field names, or switch to Map Each Column Manually."
+                    )
+
+            if replace_empty:
+                row = {key: (None if value == "" else value) for key, value in row.items()}
+
+            # Column names come from user data, so they are validated too.
+            cleaned.append(
+                {self._validate_identifier(key, "Column"): value for key, value in row.items()}
+            )
+
+        # Every row has to describe the same columns for a single statement to work.
+        first_columns = set(cleaned[0].keys())
+        for index, row in enumerate(cleaned[1:], start=2):
+            if set(row.keys()) != first_columns:
+                raise ValueError(
+                    f"Row {index} does not have the same columns as the first row. "
+                    "Every row must carry the same set of columns."
+                )
+
+        return cleaned
+
+    @classmethod
+    def _split_match_columns(cls, raw: Any) -> List[str]:
+        """Read the match column selection, which may be a string or a list."""
+        if not raw:
+            return []
+        if isinstance(raw, str):
+            parts = [part.strip() for part in raw.split(",")]
+        elif isinstance(raw, (list, tuple)):
+            parts = [str(part).strip() for part in raw]
+        else:
+            parts = [str(raw).strip()]
+        return [cls._validate_identifier(part, "Match column") for part in parts if part]
+
+    @staticmethod
+    def _guard_read_only(operation: str, query: str = "") -> None:
+        """Refuse anything that would change data while read-only mode is on."""
+        if operation in WRITE_OPERATIONS:
+            raise ValueError(
+                f"Read Only is enabled, so the '{operation}' operation is not allowed. "
+                "Turn Read Only off in the Advanced tab to write to the database."
+            )
+
+        if operation != "execute_query" or not query:
+            return
+
+        # A raw statement can hide a write behind a semicolon, so each statement
+        # is checked on its own.
+        for statement in query.split(";"):
+            statement = statement.strip()
+            if not statement:
+                continue
+            first_word = re.split(r"\s+", statement, maxsplit=1)[0].lower()
+            if first_word in WRITE_KEYWORDS:
+                raise ValueError(
+                    f"Read Only is enabled, so a statement starting with '{first_word.upper()}' "
+                    "is not allowed. Only read statements can run in this mode."
+                )
+
+    @classmethod
+    def _serialize_value(cls, value: Any, numbers_as_text: bool = False) -> Any:
+        """
+        Convert driver types into values that survive JSON serialization.
+
+        Execution results are stored as JSON, so ``Decimal``, ``datetime`` and
+        friends have to be converted before they leave the node.
+        """
+        if value is None or isinstance(value, (str, int, float, bool)):
+            return value
+        if isinstance(value, Decimal):
+            return str(value) if numbers_as_text else float(value)
+        if isinstance(value, (datetime, date, time_type)):
+            return value.isoformat()
+        if isinstance(value, timedelta):
+            return value.total_seconds()
+        if isinstance(value, uuid_module.UUID):
+            return str(value)
+        if isinstance(value, (bytes, bytearray, memoryview)):
+            return bytes(value).hex()
+        if isinstance(value, dict):
+            return {key: cls._serialize_value(item, numbers_as_text) for key, item in value.items()}
+        if isinstance(value, (list, tuple, set)):
+            return [cls._serialize_value(item, numbers_as_text) for item in value]
+        return str(value)
+
+    @classmethod
+    def _serialize_rows(
+        cls, rows: List[Dict[str, Any]], numbers_as_text: bool = False
+    ) -> List[Dict[str, Any]]:
+        """Apply value serialization across every returned row."""
+        return [
+            {key: cls._serialize_value(value, numbers_as_text) for key, value in row.items()}
+            for row in rows
+        ]
+
+    @staticmethod
+    def _returning_clause(columns: List[str]) -> sql.Composed:
+        """Build the RETURNING part of a write statement."""
+        if columns:
+            return sql.SQL(" RETURNING {}").format(
+                sql.SQL(", ").join(sql.Identifier(column) for column in columns)
+            )
+        return sql.SQL(" RETURNING *")
+
+    # ------------------------------------------------------------------
+    # Statement builders
+    # ------------------------------------------------------------------
+
+    def _build_select(self, inputs: Dict[str, Any]) -> Tuple[sql.Composed, List[Any]]:
+        schema = self._validate_identifier(inputs.get("schema_name", "public"), "Schema")
+        table = self._validate_identifier(inputs.get("table_name", ""), "Table")
+        columns = self._split_columns(inputs.get("columns", ""))
+
+        column_part = (
+            sql.SQL(", ").join(sql.Identifier(column) for column in columns)
+            if columns
+            else sql.SQL("*")
+        )
+
+        statement = sql.SQL("SELECT {} FROM {}.{}").format(
+            column_part, sql.Identifier(schema), sql.Identifier(table)
+        )
+        values: List[Any] = []
+
+        conditions = self._collect_conditions(inputs)
+        where_clause, where_values = self._build_where_clause(
+            conditions, inputs.get("combine_conditions", "AND")
+        )
+        if where_clause is not None:
+            statement = statement + sql.SQL(" WHERE ") + where_clause
+            values.extend(where_values)
+
+        sort_column = (inputs.get("sort_column") or "").strip()
+        if sort_column:
+            sort_column = self._validate_identifier(sort_column, "Sort column")
+            direction = "DESC" if str(inputs.get("sort_direction", "ASC")).upper() == "DESC" else "ASC"
+            statement = statement + sql.SQL(" ORDER BY {} {}").format(
+                sql.Identifier(sort_column), sql.SQL(direction)
+            )
+
+        if not inputs.get("return_all", True):
+            limit = int(inputs.get("limit", 50) or 50)
+            statement = statement + sql.SQL(" LIMIT %s")
+            values.append(limit)
+
+        return statement, values
+
+    def _build_insert(
+        self, inputs: Dict[str, Any], rows: List[Dict[str, Any]]
+    ) -> Tuple[sql.Composed, List[Any]]:
+        """Build a single INSERT that writes every supplied row."""
+        schema = self._validate_identifier(inputs.get("schema_name", "public"), "Schema")
+        table = self._validate_identifier(inputs.get("table_name", ""), "Table")
+
+        columns = list(rows[0].keys())
+        placeholder_group = sql.SQL("({})").format(
+            sql.SQL(", ").join(sql.Placeholder() * len(columns))
+        )
+
+        statement = sql.SQL("INSERT INTO {}.{} ({}) VALUES {}").format(
+            sql.Identifier(schema),
+            sql.Identifier(table),
+            sql.SQL(", ").join(sql.Identifier(column) for column in columns),
+            sql.SQL(", ").join([placeholder_group] * len(rows)),
+        )
+
+        if inputs.get("skip_on_conflict", False):
+            statement = statement + sql.SQL(" ON CONFLICT DO NOTHING")
+
+        statement = statement + self._returning_clause(
+            self._split_columns(inputs.get("return_columns", ""))
+        )
+
+        values: List[Any] = []
+        for row in rows:
+            values.extend(row[column] for column in columns)
+
+        return statement, values
+
+    def _build_update(
+        self, inputs: Dict[str, Any], rows: List[Dict[str, Any]]
+    ) -> Tuple[sql.Composed, List[Any]]:
+        """
+        Build an UPDATE statement.
+
+        Rows can be matched two ways. Naming match columns takes their values
+        from the data itself, which is how a row is usually identified. Writing
+        conditions instead gives a free-form filter.
+        """
+        if len(rows) > 1:
+            raise ValueError(
+                "Update writes one set of values to every matching row, so it accepts a single "
+                "object rather than a list. Use Insert or Update if each row needs its own values."
+            )
+        row = dict(rows[0])
+
+        schema = self._validate_identifier(inputs.get("schema_name", "public"), "Schema")
+        table = self._validate_identifier(inputs.get("table_name", ""), "Table")
+        match_columns = self._split_match_columns(inputs.get("match_columns"))
+
+        # Match columns identify the row, so they are removed from the SET list.
+        assignments_source = {
+            column: value for column, value in row.items() if column not in match_columns
+        }
+        if not assignments_source:
+            raise ValueError(
+                "Every column given is also a match column, so there is nothing left to update."
+            )
+
+        assignments = sql.SQL(", ").join(
+            sql.SQL("{} = %s").format(sql.Identifier(column)) for column in assignments_source
+        )
+        statement = sql.SQL("UPDATE {}.{} SET {}").format(
+            sql.Identifier(schema), sql.Identifier(table), assignments
+        )
+        values: List[Any] = list(assignments_source.values())
+
+        where_parts: List[sql.Composed] = []
+
+        for column in match_columns:
+            if column not in row:
+                raise ValueError(
+                    f"Match column '{column}' is missing from the data. "
+                    "Its value is read from there, so it has to be present."
+                )
+            where_parts.append(sql.SQL("{} = %s").format(sql.Identifier(column)))
+            values.append(row[column])
+
+        conditions = self._collect_conditions(inputs)
+        where_clause, where_values = self._build_where_clause(
+            conditions, inputs.get("combine_conditions", "AND")
+        )
+        if where_clause is not None:
+            where_parts.append(where_clause)
+            values.extend(where_values)
+
+        if where_parts:
+            statement = statement + sql.SQL(" WHERE ") + sql.SQL(" AND ").join(where_parts)
+
+        statement = statement + self._returning_clause(
+            self._split_columns(inputs.get("return_columns", ""))
+        )
+        return statement, values
+
+    def _build_upsert(
+        self, inputs: Dict[str, Any], rows: List[Dict[str, Any]]
+    ) -> Tuple[sql.Composed, List[Any]]:
+        """Build a single INSERT ... ON CONFLICT that writes every supplied row."""
+        schema = self._validate_identifier(inputs.get("schema_name", "public"), "Schema")
+        table = self._validate_identifier(inputs.get("table_name", ""), "Table")
+        match_columns = self._split_match_columns(inputs.get("match_columns"))
+
+        if not match_columns:
+            raise ValueError(
+                "Insert or Update needs at least one match column so an existing row can be found."
+            )
+
+        columns = list(rows[0].keys())
+        missing = [column for column in match_columns if column not in columns]
+        if missing:
+            raise ValueError(
+                f"Match column(s) {', '.join(missing)} are missing from the data. "
+                "They must be present so an existing row can be found."
+            )
+
+        updatable = [column for column in columns if column not in match_columns]
+        placeholder_group = sql.SQL("({})").format(
+            sql.SQL(", ").join(sql.Placeholder() * len(columns))
+        )
+
+        statement = sql.SQL("INSERT INTO {}.{} ({}) VALUES {} ON CONFLICT ({}) DO ").format(
+            sql.Identifier(schema),
+            sql.Identifier(table),
+            sql.SQL(", ").join(sql.Identifier(column) for column in columns),
+            sql.SQL(", ").join([placeholder_group] * len(rows)),
+            sql.SQL(", ").join(sql.Identifier(column) for column in match_columns),
+        )
+
+        if updatable:
+            statement = statement + sql.SQL("UPDATE SET ") + sql.SQL(", ").join(
+                sql.SQL("{} = EXCLUDED.{}").format(sql.Identifier(column), sql.Identifier(column))
+                for column in updatable
+            )
+        else:
+            statement = statement + sql.SQL("NOTHING")
+
+        statement = statement + self._returning_clause(
+            self._split_columns(inputs.get("return_columns", ""))
+        )
+
+        values: List[Any] = []
+        for row in rows:
+            values.extend(row[column] for column in columns)
+
+        return statement, values
+
+    def _build_delete(self, inputs: Dict[str, Any]) -> Tuple[sql.Composed, List[Any]]:
+        schema = self._validate_identifier(inputs.get("schema_name", "public"), "Schema")
+        table = self._validate_identifier(inputs.get("table_name", ""), "Table")
+        command = str(inputs.get("delete_command", "delete")).lower()
+
+        if command == "truncate":
+            statement = sql.SQL("TRUNCATE TABLE {}.{}").format(
+                sql.Identifier(schema), sql.Identifier(table)
+            )
+            if inputs.get("restart_sequences", False):
+                statement = statement + sql.SQL(" RESTART IDENTITY")
+            if inputs.get("cascade", False):
+                statement = statement + sql.SQL(" CASCADE")
+            return statement, []
+
+        statement = sql.SQL("DELETE FROM {}.{}").format(
+            sql.Identifier(schema), sql.Identifier(table)
+        )
+        values: List[Any] = []
+
+        conditions = self._collect_conditions(inputs)
+        where_clause, where_values = self._build_where_clause(
+            conditions, inputs.get("combine_conditions", "AND")
+        )
+        if where_clause is not None:
+            statement = statement + sql.SQL(" WHERE ") + where_clause
+            values.extend(where_values)
+
+        statement = statement + self._returning_clause(
+            self._split_columns(inputs.get("return_columns", ""))
+        )
+        return statement, values
+
+    @staticmethod
+    def _build_execute_query(inputs: Dict[str, Any]) -> Tuple[str, List[Any]]:
+        """Prepare a raw statement, converting $1 placeholders to driver placeholders."""
+        query = (inputs.get("query") or "").strip()
+        if not query:
+            raise ValueError("The Query field is empty.")
+
+        parameters = PostgresNode._coerce_json(inputs.get("query_parameters"), [])
+        if isinstance(parameters, dict):
+            parameters = list(parameters.values())
+        if not isinstance(parameters, list):
+            raise ValueError("Query Parameters must be a JSON array, for example: [\"value\", 10]")
+
+        # psycopg2 expects %s placeholders; $1 style is friendlier to write.
+        ordered: List[Any] = []
+        if parameters:
+            placeholders = sorted(
+                {int(match) for match in re.findall(r"\$(\d+)", query)}
+            )
+            for index in placeholders:
+                if index > len(parameters):
+                    raise ValueError(
+                        f"The query references ${index} but only {len(parameters)} "
+                        "parameter(s) were supplied."
+                    )
+                ordered.append(parameters[index - 1])
+            query = re.sub(r"\$\d+", "%s", query)
+
+        return query, ordered
+
+    # ------------------------------------------------------------------
+    # Execution
+    # ------------------------------------------------------------------
+
+    def execute(self, inputs: Dict[str, Any], connected_nodes: Dict[str, Any]) -> Dict[str, Any]:
+        started_at = time.time()
+        operation = str(inputs.get("operation", "select")).lower()
+        continue_on_error = bool(inputs.get("continue_on_error", False))
+        read_only = bool(inputs.get("read_only", False))
+        written_rows = 0
+
+        # Write operations are refused before a connection is even opened.
+        if read_only and operation in WRITE_OPERATIONS:
+            self._guard_read_only(operation)
+
+        logger.info("Executing PostgresNode operation=%s", operation)
+
+        connection = None
+        try:
+            connection_string = self._build_connection_string(inputs.get("credential_id"))
+            connect_timeout = int(inputs.get("connection_timeout", 30) or 30)
+
+            connection = psycopg2.connect(connection_string, connect_timeout=connect_timeout)
+            connection.autocommit = not bool(inputs.get("use_transaction", True))
+
+            statement_timeout = int(inputs.get("statement_timeout", 60) or 0)
+
+            with connection.cursor(cursor_factory=RealDictCursor) as cursor:
+                if statement_timeout > 0:
+                    cursor.execute("SET statement_timeout = %s", (statement_timeout * 1000,))
+
+                if operation == "execute_query":
+                    statement, values = self._build_execute_query(inputs)
+                    if read_only:
+                        self._guard_read_only(operation, statement)
+                elif operation == "select":
+                    statement, values = self._build_select(inputs)
+                elif operation in ("insert", "update", "upsert"):
+                    rows_in = self._resolve_rows(
+                        inputs.get("data"), connected_nodes,
+                        bool(inputs.get("replace_empty_with_null", False)),
+                        inputs,
+                    )
+                    written_rows = len(rows_in)
+                    if operation == "insert":
+                        statement, values = self._build_insert(inputs, rows_in)
+                    elif operation == "update":
+                        statement, values = self._build_update(inputs, rows_in)
+                    else:
+                        statement, values = self._build_upsert(inputs, rows_in)
+                elif operation == "delete":
+                    statement, values = self._build_delete(inputs)
+                else:
+                    raise ValueError(f"Unknown operation '{operation}'.")
+
+                cursor.execute(statement, values or None)
+
+                rows: List[Dict[str, Any]] = []
+                if cursor.description is not None:
+                    raw_rows = [dict(record) for record in cursor.fetchall()]
+                    rows = self._serialize_rows(
+                        raw_rows, bool(inputs.get("numbers_as_text", False))
+                    )
+
+                row_count = len(rows) if rows else max(cursor.rowcount, 0)
+
+            if not connection.autocommit:
+                connection.commit()
+
+            duration_ms = round((time.time() - started_at) * 1000, 2)
+            logger.info(
+                "PostgresNode finished operation=%s rows=%s duration=%sms",
+                operation, row_count, duration_ms,
+            )
+
+            return {
+                "output": {
+                    "rows": rows,
+                    "row_count": row_count,
+                    "rows_written": written_rows,
+                    "operation": operation,
+                    "duration_ms": duration_ms,
+                },
+                "success": True,
+                "error": None,
+            }
+
+        except psycopg2.Error as exc:
+            if connection is not None and not connection.autocommit:
+                connection.rollback()
+
+            # psycopg2 messages carry a trailing newline and often a DETAIL block.
+            message = str(exc).strip()
+            logger.error("PostgresNode database error operation=%s: %s", operation, message)
+
+            if not continue_on_error:
+                raise ValueError(f"PostgreSQL error: {message}") from exc
+
+            return {
+                "output": {
+                    "rows": [],
+                    "row_count": 0,
+                    "rows_written": 0,
+                    "operation": operation,
+                    "duration_ms": round((time.time() - started_at) * 1000, 2),
+                    "error": message,
+                },
+                "success": False,
+                "error": message,
+            }
+
+        except Exception as exc:
+            if connection is not None and not connection.autocommit:
+                connection.rollback()
+
+            message = str(exc)
+            logger.error("PostgresNode failed operation=%s: %s", operation, message)
+
+            if not continue_on_error:
+                raise
+
+            return {
+                "output": {
+                    "rows": [],
+                    "row_count": 0,
+                    "rows_written": 0,
+                    "operation": operation,
+                    "duration_ms": round((time.time() - started_at) * 1000, 2),
+                    "error": message,
+                },
+                "success": False,
+                "error": message,
+            }
+
+        finally:
+            if connection is not None:
+                connection.close()

--- a/backend/app/nodes/tools/postgres_tool.py
+++ b/backend/app/nodes/tools/postgres_tool.py
@@ -1,0 +1,825 @@
+"""
+PostgreSQL Tool
+===============
+
+Gives an agent a callable tool for working with a PostgreSQL database.
+
+Where the PostgreSQL node runs a statement the flow author wrote, this node
+hands the agent a tool and lets it compose the statement itself. That is a good
+deal more power, so the node is built around deciding how much of it to grant:
+
+- Reading, inserting, updating and deleting are enabled one by one. Nothing but
+  reading is on to begin with.
+- An allow list can narrow the tool down to named tables.
+- Updates and deletes can be required to carry a WHERE clause, which is what
+  stops a single careless statement from rewriting a whole table.
+- Statements that change the schema are always refused.
+- Result sets are capped so a broad query cannot flood the agent's context.
+- The table layout can be described to the agent, which keeps it from guessing
+  column names that do not exist.
+"""
+
+from __future__ import annotations
+
+import re
+import logging
+from datetime import date, datetime, time as time_type, timedelta
+from decimal import Decimal
+from typing import Any, Dict, List, Optional, Set
+
+import psycopg2
+from psycopg2.extras import RealDictCursor
+from langchain_core.tools import Tool
+
+from ..base import (
+    ProviderNode,
+    NodeOutput,
+    NodeType,
+    NodeProperty,
+    NodePropertyType,
+    NodePosition,
+)
+
+logger = logging.getLogger(__name__)
+
+IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+# Leading keywords grouped by the permission that covers them.
+READ_KEYWORDS = {"select", "with", "show", "explain", "table", "values"}
+INSERT_KEYWORDS = {"insert"}
+UPDATE_KEYWORDS = {"update"}
+DELETE_KEYWORDS = {"delete", "truncate"}
+
+# Schema changes and administrative commands are never granted. Data can be
+# read and written; the shape of the database cannot be altered.
+FORBIDDEN_KEYWORDS = {
+    "drop", "create", "alter", "grant", "revoke", "comment", "vacuum",
+    "reindex", "cluster", "copy", "call", "do", "listen", "notify",
+    "prepare", "execute", "deallocate", "set", "reset", "begin", "commit",
+    "rollback", "savepoint", "lock", "refresh", "analyze", "checkpoint",
+}
+
+# Tables named in a statement, read off the clauses that introduce one.
+TABLE_REFERENCE_PATTERN = re.compile(
+    r"\b(?:from|join|into|update|table)\s+"
+    r"(?:only\s+)?"
+    r"([A-Za-z_][A-Za-z0-9_]*)(?:\.([A-Za-z_][A-Za-z0-9_]*))?",
+    re.IGNORECASE,
+)
+
+# Common table expressions name themselves and are not real tables.
+CTE_PATTERN = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*)\s+as\s*\(", re.IGNORECASE)
+
+# A quoted value compared inside a WHERE clause. PostgreSQL compares text letter
+# for letter, so 'ankara' would pass over a row holding 'Ankara'.
+QUOTED_COMPARISON_PATTERN = re.compile(
+    r"([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)?)\s*(=|!=|<>)\s*('(?:[^']|'')*')"
+)
+
+# The same thing written as a list.
+QUOTED_IN_PATTERN = re.compile(
+    r"([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)?)\s+(NOT\s+IN|IN)\s*\(\s*"
+    r"((?:'(?:[^']|'')*'\s*,\s*)*'(?:[^']|'')*')\s*\)",
+    re.IGNORECASE,
+)
+
+
+class PostgresToolNode(ProviderNode):
+    """Exposes a scoped PostgreSQL tool to an agent."""
+
+    def __init__(self):
+        super().__init__()
+        self._metadata = {
+            "name": "PostgresTool",
+            "display_name": "PostgreSQL Tool",
+            "description": (
+                "Let an agent read from and write to a PostgreSQL database. Each kind of "
+                "operation is granted separately, and the tool can be limited to named tables."
+            ),
+            "category": "Tool",
+            "node_type": NodeType.PROVIDER,
+            "icon": {
+                "name": "postgresql_vectorstore",
+                "path": "icons/postgresql_vectorstore.svg",
+                "alt": "PostgreSQL",
+            },
+            "colors": ["indigo-500", "purple-600"],
+            "inputs": [],
+            "outputs": [
+                NodeOutput(
+                    name="sql_tool",
+                    displayName="SQL Tool",
+                    type="BaseTool",
+                    description="A database tool the agent can call.",
+                    is_connection=True,
+                    direction=NodePosition.TOP,
+                ),
+            ],
+            "properties": [
+                # ----------------------------------------------------------
+                # Basic
+                # ----------------------------------------------------------
+                NodeProperty(
+                    name="credential_id",
+                    displayName="Credential",
+                    type=NodePropertyType.CREDENTIAL_SELECT,
+                    description="PostgreSQL connection the tool will use.",
+                    placeholder="Select Credential",
+                    required=True,
+                    serviceType="postgresql_vectorstore",
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="schema_name",
+                    displayName="Schema",
+                    type=NodePropertyType.DYNAMIC_SELECT,
+                    description="Schema the tool works in.",
+                    placeholder="Select or type a schema",
+                    required=True,
+                    default="public",
+                    optionsMethod="load_schemas",
+                    optionsDependsOn=["credential_id"],
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="allowed_tables",
+                    displayName="Allowed Tables",
+                    type=NodePropertyType.DYNAMIC_SELECT,
+                    description=(
+                        "Tables the tool may touch. Leave empty to allow every table in the "
+                        "schema."
+                    ),
+                    placeholder="All tables in the schema",
+                    required=True,
+                    default="",
+                    multiple=True,
+                    optionsMethod="load_tables",
+                    optionsDependsOn=["credential_id", "schema_name"],
+                    hint=(
+                        "Naming the tables keeps the agent away from anything it has no business "
+                        "reading, and shortens the description it has to work through."
+                    ),
+                    tabName="basic",
+                ),
+
+                # --- Permissions ------------------------------------------
+                NodeProperty(
+                    name="return_all",
+                    displayName="Return All Rows",
+                    type=NodePropertyType.CHECKBOX,
+                    description=(
+                        "Return every row a read produces. Turn this off to cap the number, "
+                        "which keeps a broad query from filling the agent's context."
+                    ),
+                    required=True,
+                    default=False,
+                    hint="Leaving this off is safer; the agent can always narrow its query.",
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="max_rows",
+                    displayName="Maximum Rows",
+                    type=NodePropertyType.NUMBER,
+                    description="Largest number of rows a single read may return.",
+                    required=True,
+                    default=50,
+                    min=1,
+                    max=500,
+                    displayOptions={"show": {"return_all": False}},
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="permissions_title",
+                    displayName="Permissions",
+                    type=NodePropertyType.TITLE,
+                    description="What the agent is allowed to do with the database.",
+                    required=True,
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="allow_read",
+                    displayName="Allow Read",
+                    type=NodePropertyType.CHECKBOX,
+                    description="Let the agent run SELECT and other read statements.",
+                    required=True,
+                    default=True,
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="allow_insert",
+                    displayName="Allow Insert",
+                    type=NodePropertyType.CHECKBOX,
+                    description="Let the agent add rows.",
+                    required=True,
+                    default=False,
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="allow_update",
+                    displayName="Allow Update",
+                    type=NodePropertyType.CHECKBOX,
+                    description="Let the agent change existing rows.",
+                    required=True,
+                    default=False,
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="allow_delete",
+                    displayName="Allow Delete",
+                    type=NodePropertyType.CHECKBOX,
+                    description="Let the agent remove rows.",
+                    required=True,
+                    default=False,
+                    tabName="basic",
+                ),
+
+                # ----------------------------------------------------------
+                # Advanced
+                # ----------------------------------------------------------
+                NodeProperty(
+                    name="describe_schema",
+                    displayName="Describe Tables to the Agent",
+                    type=NodePropertyType.CHECKBOX,
+                    description=(
+                        "Include the table and column layout in the tool description. Without it "
+                        "the agent has to guess the names, and usually guesses wrong."
+                    ),
+                    required=False,
+                    default=True,
+                    tabName="advanced",
+                ),
+                NodeProperty(
+                    name="tool_name",
+                    displayName="Tool Name",
+                    type=NodePropertyType.TEXT,
+                    description="Name the agent will see. Letters, digits and underscores only.",
+                    placeholder="postgres_database",
+                    required=False,
+                    default="postgres_database",
+                    tabName="advanced",
+                ),
+                NodeProperty(
+                    name="tool_description",
+                    displayName="Tool Description",
+                    type=NodePropertyType.TEXT_AREA,
+                    description=(
+                        "Replaces the generated description. Leave empty to let the node write "
+                        "one from the settings above."
+                    ),
+                    required=False,
+                    default="",
+                    rows=4,
+                    tabName="advanced",
+                ),
+                NodeProperty(
+                    name="statement_timeout",
+                    displayName="Statement Timeout (seconds)",
+                    type=NodePropertyType.NUMBER,
+                    description="Cancel a statement that runs longer than this.",
+                    required=False,
+                    default=15,
+                    min=1,
+                    max=120,
+                    tabName="advanced",
+                ),
+                NodeProperty(
+                    name="numbers_as_text",
+                    displayName="Return Numbers as Text",
+                    type=NodePropertyType.CHECKBOX,
+                    description=(
+                        "Return NUMERIC and DECIMAL values as text to keep every digit. Useful "
+                        "for money amounts."
+                    ),
+                    required=False,
+                    default=False,
+                    tabName="advanced",
+                ),
+            ],
+        }
+
+    # ------------------------------------------------------------------
+    # Connection helpers
+    # ------------------------------------------------------------------
+
+    def _build_connection_string(self, credential_id: Optional[str]) -> str:
+        """Read the credential and assemble a libpq connection string."""
+        if not credential_id:
+            raise ValueError("A PostgreSQL credential is required.")
+
+        credential = self.get_credential(credential_id)
+        if not credential or not credential.get("secret"):
+            raise ValueError(
+                "The selected credential could not be read. It may have been created with a "
+                "different encryption key; try recreating it."
+            )
+
+        secret = credential["secret"]
+        host = secret.get("host", "localhost")
+        port = secret.get("port", 5432)
+        database = secret.get("database", "postgres")
+        username = secret.get("username", "postgres")
+        password = secret.get("password", "")
+
+        if username and password:
+            return f"postgresql://{username}:{password}@{host}:{port}/{database}"
+        return f"postgresql://{host}:{port}/{database}"
+
+    def _fetch_one_column(
+        self, credential_id: str, statement: str, params: tuple = ()
+    ) -> List[str]:
+        """Open a short-lived connection and read a single column."""
+        connection = None
+        try:
+            connection = psycopg2.connect(
+                self._build_connection_string(credential_id), connect_timeout=10
+            )
+            with connection.cursor() as cursor:
+                cursor.execute("SET statement_timeout = 5000")
+                cursor.execute(statement, params or None)
+                return [row[0] for row in cursor.fetchall()]
+        finally:
+            if connection is not None:
+                connection.close()
+
+    def load_schemas(self, values: Dict[str, Any]) -> List[Dict[str, str]]:
+        """Fill the schema dropdown."""
+        names = self._fetch_one_column(
+            values.get("credential_id"),
+            """
+            SELECT schema_name
+            FROM information_schema.schemata
+            WHERE schema_name NOT IN ('information_schema', 'pg_catalog', 'pg_toast')
+              AND schema_name NOT LIKE 'pg_temp%'
+              AND schema_name NOT LIKE 'pg_toast_temp%'
+            ORDER BY schema_name
+            """,
+        )
+        return [{"label": name, "value": name} for name in names]
+
+    def load_tables(self, values: Dict[str, Any]) -> List[Dict[str, str]]:
+        """Fill the allowed tables dropdown."""
+        schema = (values.get("schema_name") or "public").strip()
+        names = self._fetch_one_column(
+            values.get("credential_id"),
+            """
+            SELECT table_name
+            FROM information_schema.tables
+            WHERE table_schema = %s AND table_type IN ('BASE TABLE', 'VIEW')
+            ORDER BY table_name
+            """,
+            (schema,),
+        )
+        return [{"label": name, "value": name} for name in names]
+
+    # ------------------------------------------------------------------
+    # Guards
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _parse_list(raw: Any) -> List[str]:
+        """Read a comma separated selection into lower-cased identifiers."""
+        if not raw:
+            return []
+        parts = raw if isinstance(raw, (list, tuple)) else str(raw).split(",")
+        names = []
+        for part in parts:
+            name = str(part).strip()
+            if name and IDENTIFIER_PATTERN.match(name):
+                names.append(name.lower())
+        return names
+
+    @staticmethod
+    def _split_statements(query: str) -> List[str]:
+        """Split on semicolons, keeping only the parts that hold a statement."""
+        return [part.strip() for part in query.split(";") if part.strip()]
+
+    @staticmethod
+    def _leading_keyword(statement: str) -> str:
+        """Read the keyword that decides what a statement does."""
+        return re.split(r"\s+", statement.strip(), maxsplit=1)[0].lower()
+
+    def _guard_permissions(self, statement: str, granted: Set[str]) -> None:
+        """Refuse a statement the tool has not been granted."""
+        keyword = self._leading_keyword(statement)
+
+        if keyword in FORBIDDEN_KEYWORDS:
+            raise ValueError(
+                f"'{keyword.upper()}' is never allowed through this tool. It can read and write "
+                "rows, but cannot change the database structure or session state."
+            )
+
+        if keyword in READ_KEYWORDS:
+            needed = "read"
+        elif keyword in INSERT_KEYWORDS:
+            needed = "insert"
+        elif keyword in UPDATE_KEYWORDS:
+            needed = "update"
+        elif keyword in DELETE_KEYWORDS:
+            needed = "delete"
+        else:
+            raise ValueError(
+                f"'{keyword.upper()}' is not a statement this tool recognises. "
+                "Use SELECT, INSERT, UPDATE or DELETE."
+            )
+
+        if needed not in granted:
+            allowed = ", ".join(sorted(granted)) if granted else "nothing"
+            raise ValueError(
+                f"This tool is not allowed to {needed}. It may only: {allowed}."
+            )
+
+    @staticmethod
+    def _guard_where_clause(statement: str) -> None:
+        """Refuse an update or delete that would touch every row."""
+        keyword = re.split(r"\s+", statement.strip(), maxsplit=1)[0].lower()
+        if keyword not in {"update", "delete", "truncate"}:
+            return
+
+        if keyword == "truncate":
+            raise ValueError(
+                "TRUNCATE empties the whole table and cannot be filtered. "
+                "Use DELETE with a WHERE clause instead."
+            )
+
+        if not re.search(r"\bwhere\b", statement, re.IGNORECASE):
+            raise ValueError(
+                f"A {keyword.upper()} without a WHERE clause would affect every row. "
+                "Add a WHERE clause that picks out the rows you mean."
+            )
+
+    @classmethod
+    def _fold_case_in_filter(cls, statement: str) -> str:
+        """
+        Rewrite the filter so a difference in capitalisation cannot hide a row.
+
+        PostgreSQL compares text letter for letter, which means a filter written
+        as city = 'bursa' passes over the rows holding 'Bursa' and 'BURSA'. Rows
+        that should have been read, updated or deleted are then quietly missed,
+        and nothing in the result says so.
+
+        Both sides are folded to lower case instead, so every spelling matches.
+        The cast to text keeps this working on columns that hold numbers, dates
+        or booleans, where a comparison behaves exactly as before.
+
+        Only the filter is touched. Values being written in a SET clause or an
+        INSERT keep the capitalisation they were given.
+        """
+        where = re.search(r"\bwhere\b", statement, re.IGNORECASE)
+        if not where:
+            return statement
+
+        head, clause = statement[: where.end()], statement[where.end() :]
+
+        def one(match: "re.Match") -> str:
+            column, operator, literal = match.group(1), match.group(2), match.group(3)
+            return f"LOWER({column}::text) {operator} LOWER({literal})"
+
+        def many(match: "re.Match") -> str:
+            column, operator, literals = match.group(1), match.group(2), match.group(3)
+            folded = ", ".join(
+                f"LOWER({item.strip()})" for item in re.findall(r"'(?:[^']|'')*'", literals)
+            )
+            return f"LOWER({column}::text) {operator} ({folded})"
+
+        clause = QUOTED_IN_PATTERN.sub(many, clause)
+        clause = QUOTED_COMPARISON_PATTERN.sub(one, clause)
+        return head + clause
+
+    def _guard_allowed_tables(self, statement: str, allowed: List[str]) -> None:
+        """Refuse a statement that names a table outside the allow list."""
+        if not allowed:
+            return
+
+        referenced = set()
+        for match in TABLE_REFERENCE_PATTERN.finditer(statement):
+            # A qualified name puts the table in the second group.
+            referenced.add((match.group(2) or match.group(1)).lower())
+
+        for match in CTE_PATTERN.finditer(statement):
+            referenced.discard(match.group(1).lower())
+
+        blocked = sorted(referenced - set(allowed))
+        if blocked:
+            raise ValueError(
+                f"This tool may only touch: {', '.join(sorted(allowed))}. "
+                f"The statement named {', '.join(blocked)}."
+            )
+
+    # ------------------------------------------------------------------
+    # Result shaping
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def _serialize(cls, value: Any, numbers_as_text: bool = False) -> Any:
+        """Turn driver types into something that reads well in a reply."""
+        if value is None:
+            return None
+        if isinstance(value, (str, int, float, bool)):
+            return value
+        if isinstance(value, Decimal):
+            return str(value) if numbers_as_text else float(value)
+        if isinstance(value, (datetime, date, time_type)):
+            return value.isoformat()
+        if isinstance(value, timedelta):
+            return value.total_seconds()
+        if isinstance(value, (bytes, bytearray, memoryview)):
+            return "<binary>"
+        if isinstance(value, dict):
+            return {key: cls._serialize(item, numbers_as_text) for key, item in value.items()}
+        if isinstance(value, (list, tuple, set)):
+            return [cls._serialize(item, numbers_as_text) for item in value]
+        return str(value)
+
+    @classmethod
+    def _format_rows(
+        cls, rows: List[Dict[str, Any]], truncated: bool, numbers_as_text: bool
+    ) -> str:
+        """Render rows as a compact table the model can read."""
+        if not rows:
+            return "The statement ran and matched no rows."
+
+        columns = list(rows[0].keys())
+        cell = lambda row, column: str(cls._serialize(row[column], numbers_as_text))
+
+        widths = {
+            column: max(len(column), *(len(cell(row, column)) for row in rows))
+            for column in columns
+        }
+
+        lines = [
+            " | ".join(column.ljust(widths[column]) for column in columns),
+            "-+-".join("-" * widths[column] for column in columns),
+        ]
+        lines += [
+            " | ".join(cell(row, column).ljust(widths[column]) for column in columns)
+            for row in rows
+        ]
+        lines += ["", f"{len(rows)} row(s)."]
+
+        if truncated:
+            lines.append(
+                "The result was cut short. Narrow the query or aggregate in SQL to see the rest."
+            )
+        return "\n".join(lines)
+
+    # ------------------------------------------------------------------
+    # Tool description
+    # ------------------------------------------------------------------
+
+    def _describe_tables(self, credential_id: str, schema: str, allowed: List[str]) -> str:
+        """Summarise the table layout so the agent stops guessing column names."""
+        connection = None
+        try:
+            connection = psycopg2.connect(
+                self._build_connection_string(credential_id), connect_timeout=10
+            )
+            with connection.cursor() as cursor:
+                cursor.execute("SET statement_timeout = 5000")
+                if allowed:
+                    cursor.execute(
+                        """
+                        SELECT table_name, column_name, data_type, is_nullable
+                        FROM information_schema.columns
+                        WHERE table_schema = %s AND table_name = ANY(%s)
+                        ORDER BY table_name, ordinal_position
+                        """,
+                        (schema, allowed),
+                    )
+                else:
+                    cursor.execute(
+                        """
+                        SELECT table_name, column_name, data_type, is_nullable
+                        FROM information_schema.columns
+                        WHERE table_schema = %s
+                        ORDER BY table_name, ordinal_position
+                        """,
+                        (schema,),
+                    )
+                rows = cursor.fetchall()
+        except Exception as exc:
+            logger.warning(f"Could not describe the tables: {exc}")
+            return ""
+        finally:
+            if connection is not None:
+                connection.close()
+
+        if not rows:
+            return ""
+
+        tables: Dict[str, List[str]] = {}
+        for table_name, column_name, data_type, is_nullable in rows:
+            marker = "" if is_nullable == "YES" else " NOT NULL"
+            tables.setdefault(table_name, []).append(f"{column_name} {data_type}{marker}")
+
+        lines = ["", "Tables:"]
+        for table_name, columns in tables.items():
+            lines.append(f"  {table_name}({', '.join(columns)})")
+        return "\n".join(lines)
+
+    def _build_description(
+        self,
+        custom: str,
+        schema: str,
+        allowed: List[str],
+        granted: Set[str],
+        max_rows: int,
+        layout: str,
+    ) -> str:
+        """Write what the agent reads before deciding to call the tool."""
+        if custom and custom.strip():
+            return custom.strip()
+
+        verbs = {
+            "read": "read rows with SELECT",
+            "insert": "add rows with INSERT",
+            "update": "change rows with UPDATE",
+            "delete": "remove rows with DELETE",
+        }
+        can_do = [verbs[name] for name in ("read", "insert", "update", "delete") if name in granted]
+        scope = ", ".join(allowed) if allowed else f"any table in the {schema} schema"
+
+        parts = [
+            "Work with a PostgreSQL database by passing one complete SQL statement as the input.",
+            f"You can {'; '.join(can_do)}." if can_do else "This tool currently grants nothing.",
+            f"Scope: {scope}.",
+            (
+                f"Reads return at most {max_rows} rows, so filter and aggregate in SQL "
+                f"rather than asking for everything."
+                if max_rows
+                else "Reads return every matching row, so keep queries narrow."
+            ),
+        ]
+
+        if "update" in granted or "delete" in granted:
+            parts.append(
+                "An UPDATE or DELETE must carry a WHERE clause that names the rows you mean; "
+                "one without a filter is refused."
+            )
+
+        parts.append(
+            "Filters are matched without regard to capitalisation, so WHERE city = 'ankara' "
+            "finds Ankara, ANKARA and ankara alike. Write the value however it comes to you."
+        )
+
+        parts.append(
+            "Statements that change the database structure, such as CREATE, ALTER or DROP, "
+            "are refused."
+        )
+
+        return " ".join(parts) + layout
+
+    # ------------------------------------------------------------------
+    # Execution
+    # ------------------------------------------------------------------
+
+    def _setting(self, kwargs: Dict[str, Any], name: str, fallback: Any) -> Any:
+        """Read a setting from the call or from the stored configuration."""
+        if name in kwargs and kwargs[name] is not None:
+            return kwargs[name]
+        stored = getattr(self, "user_data", {}) or {}
+        if name in stored and stored[name] is not None:
+            return stored[name]
+        return fallback
+
+    def execute(self, **kwargs) -> Dict[str, Any]:
+        """Build the tool the agent will call."""
+        credential_id = self._setting(kwargs, "credential_id", None)
+        schema = str(self._setting(kwargs, "schema_name", "public")).strip() or "public"
+        allowed = self._parse_list(self._setting(kwargs, "allowed_tables", ""))
+        return_all = bool(self._setting(kwargs, "return_all", False))
+        max_rows = 0 if return_all else int(self._setting(kwargs, "max_rows", 50))
+        timeout = int(self._setting(kwargs, "statement_timeout", 15))
+        describe = bool(self._setting(kwargs, "describe_schema", True))
+        numbers_as_text = bool(self._setting(kwargs, "numbers_as_text", False))
+        tool_name = str(self._setting(kwargs, "tool_name", "postgres_database")).strip()
+        custom_description = str(self._setting(kwargs, "tool_description", "") or "")
+
+        granted: Set[str] = set()
+        if bool(self._setting(kwargs, "allow_read", True)):
+            granted.add("read")
+        if bool(self._setting(kwargs, "allow_insert", False)):
+            granted.add("insert")
+        if bool(self._setting(kwargs, "allow_update", False)):
+            granted.add("update")
+        if bool(self._setting(kwargs, "allow_delete", False)):
+            granted.add("delete")
+
+        if not granted:
+            raise ValueError(
+                "No permission is granted, so the tool would refuse every statement. "
+                "Turn on at least Allow Read."
+            )
+
+        if not IDENTIFIER_PATTERN.match(tool_name):
+            raise ValueError(
+                f"Tool name '{tool_name}' is not usable. "
+                "Use letters, digits and underscores, starting with a letter or underscore."
+            )
+
+        if not IDENTIFIER_PATTERN.match(schema):
+            raise ValueError(f"Schema '{schema}' is not a valid identifier.")
+
+        connection_string = self._build_connection_string(credential_id)
+
+        logger.info(
+            "PostgresTool ready: schema=%s tables=%s granted=%s max_rows=%s",
+            schema, allowed or "all", sorted(granted), max_rows,
+        )
+
+        def run_sql(query: str) -> str:
+            """Called by the agent. Returns rows as text, or an explanation."""
+            query = (query or "").strip()
+            if not query:
+                return "No statement was supplied."
+
+            statements = self._split_statements(query)
+            if not statements:
+                return "No statement was supplied."
+            if len(statements) > 1:
+                return (
+                    "Only one statement can be run per call. "
+                    "Send them one at a time so each result can be checked."
+                )
+
+            statement = statements[0]
+
+            try:
+                self._guard_permissions(statement, granted)
+                self._guard_allowed_tables(statement, allowed)
+                # Always enforced: a statement without a filter would rewrite or
+                # empty the whole table, and the agent cannot undo that.
+                self._guard_where_clause(statement)
+            except ValueError as exc:
+                # Returned as text so the agent can correct itself and retry.
+                return f"Refused: {exc}"
+
+            keyword = self._leading_keyword(statement)
+            writes = keyword not in READ_KEYWORDS
+
+            # Filters are matched without regard to case, so the agent does not
+            # have to guess how a value was capitalised when it was stored.
+            statement = self._fold_case_in_filter(statement)
+
+            connection = None
+            try:
+                connection = psycopg2.connect(connection_string, connect_timeout=10)
+                # A write runs inside a transaction so a failure leaves nothing behind.
+                connection.autocommit = not writes
+
+                with connection.cursor(cursor_factory=RealDictCursor) as cursor:
+                    cursor.execute("SET statement_timeout = %s", (timeout * 1000,))
+                    cursor.execute(f"SET search_path TO {schema}")
+                    cursor.execute(statement)
+
+                    if cursor.description is None:
+                        affected = max(cursor.rowcount, 0)
+                        if writes:
+                            connection.commit()
+                        return f"{keyword.upper()} ran. {affected} row(s) affected."
+
+                    if max_rows:
+                        # One row past the cap tells us whether anything was left behind.
+                        rows = [dict(record) for record in cursor.fetchmany(max_rows + 1)]
+                        truncated = len(rows) > max_rows
+                        rows = rows[:max_rows]
+                    else:
+                        rows = [dict(record) for record in cursor.fetchall()]
+                        truncated = False
+                    body = self._format_rows(rows, truncated, numbers_as_text)
+
+                if writes:
+                    connection.commit()
+                return body
+
+            except psycopg2.Error as exc:
+                if connection is not None and writes:
+                    connection.rollback()
+                message = str(exc).strip()
+                logger.warning(f"PostgresTool statement failed: {message}")
+                return f"The database rejected the statement: {message}"
+            except Exception as exc:
+                if connection is not None and writes:
+                    connection.rollback()
+                logger.error(f"PostgresTool failed: {exc}")
+                return f"The statement could not be run: {exc}"
+            finally:
+                if connection is not None:
+                    connection.close()
+
+        layout = self._describe_tables(credential_id, schema, allowed) if describe else ""
+        description = self._build_description(
+            custom_description, schema, allowed, granted, max_rows, layout
+        )
+
+        return {
+            "sql_tool": {
+                "tool": Tool(name=tool_name, description=description, func=run_sql)
+            }
+        }
+
+    def get_required_packages(self) -> List[str]:
+        """Packages this node needs."""
+        return ["psycopg2-binary>=2.9.0", "langchain-core>=0.1.0"]
+
+
+__all__ = ["PostgresToolNode"]

--- a/client/app/components/node/GenericNodeForm.tsx
+++ b/client/app/components/node/GenericNodeForm.tsx
@@ -20,6 +20,8 @@ import { FieldLabel, getFieldHelpText } from "./fields/FieldLabel";
 import TabNavigation from "../common/TabNavigation";
 import { useState, useRef, useEffect } from "react";
 import { Settings, Plus, X, ChevronDown } from "lucide-react";
+import { NodeDynamicSelect } from "./fields/NodeDynamicSelect";
+import { NodeColumnMapper } from "./fields/NodeColumnMapper";
 
 interface GenericNodeFormProps {
   initialValues?: GenericData;
@@ -87,6 +89,8 @@ export default function GenericNodeForm({
   onChange,
 }: GenericNodeFormProps) {
   const properties = configData?.metadata?.properties || [];
+  const nodeType =
+    configData?.metadata?.name || configData?.name || configData?.type;
 
   const tabs = properties.reduce((acc: any[], property: NodeProperty) => {
     const tabId = property.tabName || "basic";
@@ -236,7 +240,26 @@ export default function GenericNodeForm({
               // Check display options
               if (property.displayOptions?.show) {
                 const shouldShow = Object.entries(property.displayOptions.show).every(
-                  ([key, value]) => values[key] === value
+                  ([key, value]) => {
+                    const matches = (name: string, expected: any) => {
+                      const current = values[name];
+                      // "*" means the field only has to be filled in.
+                      if (expected === "*") {
+                        return current !== undefined && current !== null && current !== "";
+                      }
+                      return Array.isArray(expected)
+                        ? expected.includes(current)
+                        : current === expected;
+                    };
+
+                    // "_any" holds alternatives; matching one of them is enough.
+                    if (key === "_any" && value && typeof value === "object") {
+                      return Object.entries(value).some(([name, expected]) =>
+                        matches(name, expected)
+                      );
+                    }
+                    return matches(key, value);
+                  }
                 );
                 if (!shouldShow) return null;
               }
@@ -256,6 +279,23 @@ export default function GenericNodeForm({
                     );
                   case "select":
                     return <NodeSelect property={fullWidthProperty} values={values} />;
+
+                  case "dynamic-select":
+                    return (
+                      <NodeDynamicSelect
+                        property={fullWidthProperty}
+                        values={values}
+                        nodeType={nodeType}
+                      />
+                    );
+                  case "column-mapper":
+                    return (
+                      <NodeColumnMapper
+                        property={fullWidthProperty}
+                        values={values}
+                        nodeType={nodeType}
+                      />
+                    );
                   case "credential-select":
                     return (
                       <NodeCredentialSelect
@@ -392,7 +432,14 @@ export default function GenericNodeForm({
               }
 
               return (
-                <div key={property.name} className="col-span-2 bg-slate-800/50 border border-slate-600 rounded-lg px-4 py-3">
+                  <div
+                  key={property.name}
+                  className={
+                    property.type === "title"
+                      ? "col-span-2 pt-3 pb-1"
+                      : "col-span-2 bg-slate-800/50 border border-slate-600 rounded-lg px-4 py-3"
+                  }
+                >
                   {fieldComponent}
                 </div>
               );

--- a/client/app/components/node/fields/NodeCheckbox.tsx
+++ b/client/app/components/node/fields/NodeCheckbox.tsx
@@ -14,9 +14,21 @@ export const NodeCheckbox = ({ property, values }: NodeCheckboxProps) => {
   const show = displayOptions.show || {};
 
   if (Object.keys(show).length > 0) {
+    const compare = (name: string, expected: any) => {
+      const current = values[name];
+      if (expected === "*") {
+        return current !== undefined && current !== null && current !== "";
+      }
+      return Array.isArray(expected) ? expected.includes(current) : current === expected;
+    };
+
     for (const [dependencyName, validValue] of Object.entries(show)) {
-      const dependencyValue = values[dependencyName];
-      if (dependencyValue !== validValue) {
+      // "_any" holds alternatives; matching one of them is enough.
+      const matches =
+        dependencyName === "_any" && validValue && typeof validValue === "object"
+          ? Object.entries(validValue).some(([name, expected]) => compare(name, expected))
+          : compare(dependencyName, validValue);
+      if (!matches) {
         return null;
       }
     }

--- a/client/app/components/node/fields/NodeColumnMapper.tsx
+++ b/client/app/components/node/fields/NodeColumnMapper.tsx
@@ -1,0 +1,282 @@
+import { useField } from "formik";
+import { useState, useEffect, useCallback } from "react";
+import { RefreshCw, Trash2, Plus, AlertCircle } from "lucide-react";
+import type { NodeProperty } from "../types";
+import { apiClient } from "~/lib/api-client";
+import { FieldLabel, getFieldHelpText } from "./FieldLabel";
+
+interface NodeColumnMapperProps {
+  property: NodeProperty;
+  values: any;
+  nodeType?: string;
+}
+
+interface ColumnInfo {
+  name: string;
+  type: string;
+  widget: "text" | "number" | "checkbox" | "datetime" | "json";
+  required: boolean;
+  hasDefault: boolean;
+}
+
+/**
+ * Renders one input per column of the selected table.
+ *
+ * The column list and each column's data type come from the backend, so the
+ * panel shows a checkbox for a boolean column, a date picker for a timestamp
+ * and so on. The value is stored as a single object keyed by column name.
+ *
+ * Columns named as match columns are marked and cannot be removed, since their
+ * value is what identifies the row.
+ */
+export const NodeColumnMapper = ({ property, values, nodeType }: NodeColumnMapperProps) => {
+  const [field, , helpers] = useField(property.name);
+  const [columns, setColumns] = useState<ColumnInfo[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [removed, setRemoved] = useState<Set<string>>(new Set());
+
+  const dependsOn: string[] = property.optionsDependsOn || [];
+  const dependencyValues = dependsOn.map((name) => values[name]);
+  const missingDependency = dependsOn.find((name) => !values[name]);
+
+  // Match columns are read from the sibling field so they can be marked.
+  const matchColumns: string[] = (() => {
+    const raw = values.match_columns;
+    if (!raw) return [];
+    if (Array.isArray(raw)) return raw.map(String);
+    return String(raw)
+      .split(",")
+      .map((part) => part.trim())
+      .filter(Boolean);
+  })();
+
+  const currentData: Record<string, any> = (() => {
+    const raw = field.value;
+    if (!raw) return {};
+    if (typeof raw === "object" && !Array.isArray(raw)) return raw;
+    if (typeof raw === "string") {
+      try {
+        const parsed = JSON.parse(raw);
+        return typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+      } catch {
+        return {};
+      }
+    }
+    return {};
+  })();
+
+  const fetchColumns = useCallback(async () => {
+    if (!nodeType || !property.optionsMethod || missingDependency) {
+      setColumns([]);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      // The shared client carries the base URL, the auth header and refresh
+      // handling, so the request behaves like every other call in the app.
+      const response = await apiClient.post(`/nodes/${nodeType}/options`, {
+        property_name: property.name,
+        values,
+      });
+
+      setColumns(response?.options ?? []);
+    } catch (err: any) {
+      setError(err?.message ?? "Could not load the columns");
+      setColumns([]);
+    } finally {
+      setLoading(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [nodeType, property.name, ...dependencyValues]);
+
+  useEffect(() => {
+    fetchColumns();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [...dependencyValues]);
+
+  const setColumnValue = (name: string, value: any) => {
+    helpers.setValue({ ...currentData, [name]: value });
+  };
+
+  const removeColumn = (name: string) => {
+    const next = { ...currentData };
+    delete next[name];
+    helpers.setValue(next);
+    setRemoved((prev) => new Set(prev).add(name));
+  };
+
+  const restoreColumn = (name: string) => {
+    setRemoved((prev) => {
+      const next = new Set(prev);
+      next.delete(name);
+      return next;
+    });
+  };
+
+  const inputClass =
+    "w-full bg-[#10182c] border border-slate-600 rounded-lg px-3 py-2 text-sm text-white " +
+    "placeholder:text-slate-500 focus:border-blue-500 focus:outline-none transition-colors";
+
+  const renderInput = (column: ColumnInfo) => {
+    const value = currentData[column.name];
+
+    switch (column.widget) {
+      case "checkbox":
+        return (
+          <button
+            type="button"
+            onClick={() => setColumnValue(column.name, !value)}
+            className={`relative w-11 h-6 rounded-full transition-colors ${
+              value ? "bg-blue-500" : "bg-slate-600"
+            }`}
+          >
+            <span
+              className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform ${
+                value ? "translate-x-5" : ""
+              }`}
+            />
+          </button>
+        );
+
+      case "number":
+        return (
+          <input
+            type="number"
+            className={inputClass}
+            value={value ?? ""}
+            placeholder={column.hasDefault ? "Leave empty to use the default" : ""}
+            onChange={(e) =>
+              setColumnValue(column.name, e.target.value === "" ? null : Number(e.target.value))
+            }
+          />
+        );
+
+      case "datetime":
+        return (
+          <input
+            type="datetime-local"
+            className={inputClass}
+            value={value ?? ""}
+            onChange={(e) => setColumnValue(column.name, e.target.value || null)}
+          />
+        );
+
+      case "json":
+        return (
+          <textarea
+            rows={3}
+            className={`${inputClass} font-mono text-xs`}
+            value={typeof value === "string" ? value : value ? JSON.stringify(value, null, 2) : ""}
+            placeholder="{}"
+            onChange={(e) => setColumnValue(column.name, e.target.value)}
+          />
+        );
+
+      default:
+        return (
+          <input
+            type="text"
+            className={inputClass}
+            value={value ?? ""}
+            placeholder={column.hasDefault ? "Leave empty to use the default" : ""}
+            onChange={(e) => setColumnValue(column.name, e.target.value)}
+          />
+        );
+    }
+  };
+
+  const visibleColumns = columns.filter((column) => !removed.has(column.name));
+  const removedColumns = columns.filter((column) => removed.has(column.name));
+
+  return (
+    <div className={`${property?.colSpan ? `col-span-${property?.colSpan}` : "col-span-2"}`}>
+      <div className="flex items-center justify-between">
+        <FieldLabel label={property.displayName} helpText={getFieldHelpText(property)} />
+        <button
+          type="button"
+          title="Reload the columns"
+          onClick={fetchColumns}
+          disabled={loading || !!missingDependency}
+          className="text-slate-400 hover:text-blue-300 disabled:text-slate-600 disabled:cursor-not-allowed p-1"
+        >
+          <RefreshCw size={14} className={loading ? "animate-spin" : ""} />
+        </button>
+      </div>
+
+      {missingDependency && (
+        <div className="text-sm text-slate-400 py-3">
+          Select {missingDependency.replace(/_/g, " ")} first.
+        </div>
+      )}
+
+      {loading && <div className="text-sm text-slate-400 py-3">Loading the columns...</div>}
+
+      {error && (
+        <div className="flex items-start gap-1.5 py-2 text-xs text-amber-400">
+          <AlertCircle size={13} className="mt-0.5 shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {!loading && !missingDependency && !error && columns.length === 0 && (
+        <div className="text-sm text-slate-400 py-3">This table has no columns to show.</div>
+      )}
+
+      <div className="space-y-3 mt-1">
+        {visibleColumns.map((column) => {
+          const isMatch = matchColumns.includes(column.name);
+          return (
+            <div key={column.name} className="pl-3 border-l-2 border-slate-700">
+              <div className="flex items-center gap-2 mb-1.5">
+                {!isMatch && (
+                  <button
+                    type="button"
+                    title="Leave this column out"
+                    onClick={() => removeColumn(column.name)}
+                    className="text-slate-500 hover:text-red-400 transition-colors"
+                  >
+                    <Trash2 size={13} />
+                  </button>
+                )}
+                <span className="text-sm text-slate-200">{column.name}</span>
+                {isMatch && (
+                  <span className="text-xs text-blue-300">(using to match)</span>
+                )}
+                {column.required && !isMatch && (
+                  <span className="text-xs text-amber-400">required</span>
+                )}
+                <span className="text-xs text-slate-500 ml-auto">{column.type}</span>
+              </div>
+              {renderInput(column)}
+            </div>
+          );
+        })}
+      </div>
+
+      {removedColumns.length > 0 && (
+        <div className="mt-3 pt-3 border-t border-slate-700">
+          <div className="text-xs text-slate-500 mb-2">Columns left out</div>
+          <div className="flex flex-wrap gap-2">
+            {removedColumns.map((column) => (
+              <button
+                key={column.name}
+                type="button"
+                onClick={() => restoreColumn(column.name)}
+                className="flex items-center gap-1 px-2 py-1 text-xs text-slate-400 border border-slate-700 rounded hover:text-blue-300 hover:border-blue-500 transition-colors"
+              >
+                <Plus size={11} />
+                {column.name}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default NodeColumnMapper;

--- a/client/app/components/node/fields/NodeDynamicSelect.tsx
+++ b/client/app/components/node/fields/NodeDynamicSelect.tsx
@@ -1,0 +1,256 @@
+import { useField } from "formik";
+import { useState, useRef, useEffect, useCallback } from "react";
+import { ChevronDown, RefreshCw, AlertCircle, Check, X } from "lucide-react";
+import type { NodeProperty } from "../types";
+import { apiClient } from "~/lib/api-client";
+import { FieldLabel, getFieldHelpText } from "./FieldLabel";
+
+interface NodeDynamicSelectProps {
+  property: NodeProperty;
+  values: any;
+  nodeType?: string;
+}
+
+interface Option {
+  label: string;
+  value: string;
+}
+
+/**
+ * A field that offers values fetched from the backend while still letting the
+ * value be typed by hand.
+ *
+ * The node declares `optionsMethod` on the property; the backend calls that
+ * method and returns the list. `optionsDependsOn` names the fields that should
+ * trigger a refetch when they change, for example a credential or a schema
+ * selection.
+ *
+ * Typing filters the list without preventing a value outside it, which covers
+ * templates and tables the credential cannot list.
+ */
+export const NodeDynamicSelect = ({ property, values, nodeType }: NodeDynamicSelectProps) => {
+  const [field, , helpers] = useField(property.name);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [options, setOptions] = useState<Option[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const dependsOn: string[] = property.optionsDependsOn || [];
+  const dependencyValues = dependsOn.map((name) => values[name]);
+  const missingDependency = dependsOn.find((name) => !values[name]);
+
+  const isMultiple = Boolean(property.multiple);
+
+  const currentValue = field.value ?? property?.default ?? "";
+
+  // Multiple selection is stored as a comma separated string, which is what the
+  // backend already splits on.
+  const selectedValues: string[] = isMultiple
+    ? String(currentValue)
+        .split(",")
+        .map((part) => part.trim())
+        .filter(Boolean)
+    : [];
+
+  const toggleValue = (value: string) => {
+    const next = selectedValues.includes(value)
+      ? selectedValues.filter((entry) => entry !== value)
+      : [...selectedValues, value];
+    helpers.setValue(next.join(", "));
+  };
+
+  const fetchOptions = useCallback(async () => {
+    if (!nodeType || !property.optionsMethod || missingDependency) {
+      setOptions([]);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      // The shared client carries the base URL, the auth header and refresh
+      // handling, so the request behaves like every other call in the app.
+      const response = await apiClient.post(`/nodes/${nodeType}/options`, {
+        property_name: property.name,
+        values,
+      });
+
+      setOptions(response?.options ?? []);
+    } catch (err: any) {
+      setError(err?.message ?? "Could not load the list");
+      setOptions([]);
+    } finally {
+      setLoading(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [nodeType, property.name, ...dependencyValues]);
+
+  useEffect(() => {
+    fetchOptions();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [...dependencyValues]);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setDropdownOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  // Typing narrows the list without preventing a value outside it. In multiple
+  // mode the box holds the selection, so the list is never filtered by it.
+  const filtered =
+    !isMultiple && currentValue
+      ? options.filter((option) =>
+          option.label.toLowerCase().includes(String(currentValue).toLowerCase())
+        )
+      : options;
+
+  const helperText = (() => {
+    if (loading) return "Loading the list...";
+    if (missingDependency) {
+      const label = missingDependency.replace(/_/g, " ").replace(/ id$/, "");
+      return `Select ${label} to see the list. A name can still be typed.`;
+    }
+    if (error) return error;
+    if (isMultiple && selectedValues.length > 0) {
+      return `${selectedValues.length} of ${options.length} selected`;
+    }
+    if (options.length > 0) return `${options.length} available`;
+    return null;
+  })();
+
+  return (
+    <div
+      className={`${property?.colSpan ? `col-span-${property?.colSpan}` : "col-span-2"}`}
+      key={property.name}
+    >
+      <FieldLabel label={property.displayName} helpText={getFieldHelpText(property)} />
+
+      <div className="relative" ref={containerRef}>
+        <div className="flex gap-2">
+          <div className="relative flex-1">
+            {isMultiple ? (
+              <button
+                type="button"
+                onClick={() => setDropdownOpen(!dropdownOpen)}
+                onMouseDown={(e: any) => e.stopPropagation()}
+                className="w-full min-h-[46px] flex flex-wrap items-center gap-1.5 bg-[#10182c] border border-slate-600 rounded-lg pl-3 pr-10 py-2 text-left focus:border-blue-500 focus:outline-none transition-colors"
+              >
+                {selectedValues.length === 0 && (
+                  <span className="text-sm text-slate-500">
+                    {property.placeholder ?? "Select"}
+                  </span>
+                )}
+                {selectedValues.map((value) => (
+                  <span
+                    key={value}
+                    className="inline-flex items-center gap-1 px-2 py-0.5 rounded bg-blue-500/20 text-blue-300 text-xs"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      toggleValue(value);
+                    }}
+                  >
+                    {value}
+                    <X size={11} />
+                  </span>
+                ))}
+              </button>
+            ) : (
+              <input
+                type="text"
+                value={currentValue}
+                placeholder={property.placeholder ?? "Select or type"}
+                onChange={(e) => {
+                  helpers.setValue(e.target.value);
+                  setDropdownOpen(true);
+                }}
+                onFocus={() => setDropdownOpen(true)}
+                onMouseDown={(e: any) => e.stopPropagation()}
+                className="w-full bg-[#10182c] border border-slate-600 rounded-lg pl-4 pr-10 py-3 text-sm text-white placeholder:text-slate-500 focus:border-blue-500 focus:outline-none transition-colors"
+              />
+            )}
+            <button
+              type="button"
+              tabIndex={-1}
+              onClick={() => setDropdownOpen(!dropdownOpen)}
+              onMouseDown={(e: any) => e.stopPropagation()}
+              className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-slate-400 hover:text-slate-200"
+            >
+              <ChevronDown
+                size={16}
+                className={`transition-transform duration-200 ${dropdownOpen ? "rotate-180" : ""}`}
+              />
+            </button>
+          </div>
+
+          <button
+            type="button"
+            title="Reload the list"
+            disabled={loading || !!missingDependency}
+            onClick={fetchOptions}
+            onMouseDown={(e: any) => e.stopPropagation()}
+            className={`px-3 rounded-lg border transition-colors ${
+              loading || missingDependency
+                ? "border-slate-700 text-slate-600 cursor-not-allowed"
+                : "border-slate-600 text-slate-400 hover:text-blue-300 hover:border-blue-500"
+            }`}
+          >
+            <RefreshCw size={14} className={loading ? "animate-spin" : ""} />
+          </button>
+        </div>
+
+        {dropdownOpen && filtered.length > 0 && (
+          <div className="absolute z-50 mt-1 left-0 right-0 max-h-64 overflow-y-auto bg-slate-900 border border-slate-700 rounded-lg shadow-lg shadow-black/40">
+            {filtered.map((option) => {
+              const selected = isMultiple
+                ? selectedValues.includes(option.value)
+                : currentValue === option.value;
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => {
+                    if (isMultiple) {
+                      toggleValue(option.value);
+                    } else {
+                      helpers.setValue(option.value);
+                      setDropdownOpen(false);
+                    }
+                  }}
+                  onMouseDown={(e: any) => e.stopPropagation()}
+                  className={`w-full flex items-center justify-between gap-3 px-4 py-2.5 text-sm text-left transition-colors duration-150 ${
+                    selected
+                      ? "bg-blue-500/20 text-blue-300"
+                      : "text-slate-300 hover:bg-blue-500/20 hover:text-blue-300"
+                  }`}
+                >
+                  <span>{option.label}</span>
+                  {selected && <Check size={14} />}
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {helperText && (
+        <div
+          className={`flex items-start gap-1.5 mt-1.5 text-xs ${
+            error ? "text-amber-400" : "text-slate-500"
+          }`}
+        >
+          {error && <AlertCircle size={13} className="mt-0.5 shrink-0" />}
+          <span>{helperText}</span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default NodeDynamicSelect;

--- a/client/app/components/node/fields/NodeSelect.tsx
+++ b/client/app/components/node/fields/NodeSelect.tsx
@@ -31,7 +31,15 @@ export const NodeSelect = ({ property, values }: NodeSelectProps) => {
   if (Object.keys(show).length > 0) {
     for (const [dependencyName, validValue] of Object.entries(show)) {
       const dependencyValue = values[dependencyName];
-      if (dependencyValue !== validValue) {
+      const matches =
+        validValue === "*"
+          ? dependencyValue !== undefined &&
+            dependencyValue !== null &&
+            dependencyValue !== ""
+          : Array.isArray(validValue)
+            ? validValue.includes(dependencyValue)
+            : dependencyValue === validValue;
+      if (!matches) {
         return null;
       }
     }

--- a/client/app/components/node/fields/NodeText.tsx
+++ b/client/app/components/node/fields/NodeText.tsx
@@ -14,7 +14,15 @@ export const NodeText = ({ property, values }: NodeTextProps) => {
   if (Object.keys(show).length > 0) {
     for (const [dependencyName, validValue] of Object.entries(show)) {
       const dependencyValue = values[dependencyName];
-      if (dependencyValue !== validValue) {
+      const matches =
+        validValue === "*"
+          ? dependencyValue !== undefined &&
+            dependencyValue !== null &&
+            dependencyValue !== ""
+          : Array.isArray(validValue)
+            ? validValue.includes(dependencyValue)
+            : dependencyValue === validValue;
+      if (!matches) {
         return null;
       }
     }

--- a/client/app/lib/iconUtils.ts
+++ b/client/app/lib/iconUtils.ts
@@ -83,6 +83,8 @@ export function getNodeTypeIconPath(nodeType: string): string {
         PGVectorStore: "icons/postgresql_vectorstore.svg",
         VectorStoreOrchestrator: "icons/postgresql_vectorstore.svg",
         IntelligentVectorStore: "icons/postgresql_vectorstore.svg",
+        PostgresNode: "icons/postgresql_vectorstore.svg",
+        PostgresTool: "icons/postgresql_vectorstore.svg",
         MarkItDownTool: "icons/markitdown.svg",
 
         // Web & APIs


### PR DESCRIPTION
## Summary

- add the PostgreSQL tool node, a provider node that hands an agent a callable database tool
- grant reading, inserting, updating and deleting one at a time, with only reading on to begin with
- narrow the tool to an allow list of tables and cap the rows a single read returns
- describe the table layout in the tool description so the agent does not guess column names

## Depends on #547

This node builds on the field types and the options endpoint added there, so it should be reviewed and merged after that PR.

## Security

- an update or delete without a WHERE clause is refused, since one would rewrite or empty the whole table
- statements that change the database structure, such as CREATE, ALTER and DROP, are never allowed
- only one statement may run per call, so a write cannot hide behind a semicolon
- writes run inside a transaction and roll back when a constraint rejects them
- a refusal is returned as text rather than raised, so the agent can correct itself and the flow keeps running

## Validation

- 21 tool tests passed against a local Docker PostgreSQL server
- covered: every permission combination, the WHERE requirement, forbidden statements, the table allow list, the row cap, and case-insensitive filtering

Closes #541