### PR TITLE
feat: unify workflow status tracking, error attribution, and JSON imports

### DIFF
--- a/backend/app/core/error_normalization.py
+++ b/backend/app/core/error_normalization.py
@@ -1,0 +1,442 @@
+"""Normalize third-party execution errors into stable KAI-Flow error details."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import re
+from typing import Any, Iterable
+
+
+_STATUS_PATTERN = re.compile(
+    r"(?:error\s+code|status(?:\s+code)?|http)\s*[:=]?\s*(\d{3})",
+    re.IGNORECASE,
+)
+_MESSAGE_PATTERN = re.compile(
+    r"[\"'](?:message|detail|error_description)[\"']\s*:\s*[\"']([^\"']+)",
+    re.IGNORECASE,
+)
+_SECRET_PATTERNS = (
+    (
+        re.compile(r"(?i)(authorization\s*[:=]\s*bearer\s+)[^\s,;]+"),
+        r"\1[REDACTED]",
+    ),
+    (
+        re.compile(
+            r"(?i)((?:api[_ -]?key|access[_ -]?token|secret|password)"
+            r"\s*[:=]\s*)[^\s,;}]+"
+        ),
+        r"\1[REDACTED]",
+    ),
+    (
+        re.compile(r"\bsk-[A-Za-z0-9_-]{8,}\b"),
+        "[REDACTED_API_KEY]",
+    ),
+)
+
+
+@dataclass(frozen=True)
+class ExecutionErrorDetails:
+    """A stable public error identity plus preserved diagnostic context."""
+
+    code: str
+    category: str
+    title: str
+    description: str
+    resolution: str
+    raw_message: str
+    exception_type: str
+    status_code: int | None = None
+    provider_code: str | None = None
+    provider_message: str | None = None
+    retryable: bool = False
+
+    @property
+    def display_message(self) -> str:
+        status = f" (HTTP {self.status_code})" if self.status_code else ""
+        message = f"[{self.code}] {self.title}{status}: {self.description}"
+        if self.provider_message and self.provider_message not in message:
+            message += f" Provider detail: {self.provider_message}"
+        if self.resolution:
+            message += f" Action: {self.resolution}"
+        return message
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def sanitize_error_text(value: Any, *, limit: int = 2000) -> str:
+    """Remove common secret forms while retaining useful provider diagnostics."""
+    text = str(value or "").strip()
+    for pattern, replacement in _SECRET_PATTERNS:
+        text = pattern.sub(replacement, text)
+    if len(text) > limit:
+        return f"{text[:limit]}..."
+    return text
+
+
+def _iter_error_chain(error: BaseException) -> Iterable[BaseException]:
+    pending = [error]
+    visited: set[int] = set()
+
+    while pending:
+        current = pending.pop(0)
+        if id(current) in visited:
+            continue
+        visited.add(id(current))
+        yield current
+
+        for nested in (
+            getattr(current, "original_error", None),
+            getattr(current, "__cause__", None),
+            getattr(current, "__context__", None),
+        ):
+            if isinstance(nested, BaseException) and id(nested) not in visited:
+                pending.append(nested)
+
+
+def _coerce_status(value: Any) -> int | None:
+    try:
+        status = int(value)
+    except (TypeError, ValueError):
+        return None
+    return status if 100 <= status <= 599 else None
+
+
+def _extract_status(chain: list[BaseException]) -> int | None:
+    for error in chain:
+        for value in (
+            getattr(error, "status_code", None),
+            getattr(error, "http_status", None),
+            getattr(error, "status", None),
+            getattr(getattr(error, "response", None), "status_code", None),
+        ):
+            status = _coerce_status(value)
+            if status is not None:
+                return status
+
+        match = _STATUS_PATTERN.search(str(error))
+        if match:
+            return int(match.group(1))
+    return None
+
+
+def _extract_from_payload(payload: Any, keys: tuple[str, ...], depth: int = 0) -> Any:
+    if depth > 4:
+        return None
+
+    if isinstance(payload, dict):
+        for key in keys:
+            value = payload.get(key)
+            if value not in (None, "", [], {}):
+                if isinstance(value, (str, int, float)):
+                    return value
+                nested = _extract_from_payload(value, keys, depth + 1)
+                if nested is not None:
+                    return nested
+
+        for value in payload.values():
+            nested = _extract_from_payload(value, keys, depth + 1)
+            if nested is not None:
+                return nested
+
+    if isinstance(payload, (list, tuple)):
+        for value in payload:
+            nested = _extract_from_payload(value, keys, depth + 1)
+            if nested is not None:
+                return nested
+
+    return None
+
+
+def _payloads(chain: list[BaseException]) -> Iterable[Any]:
+    for error in chain:
+        for attribute in ("body", "error", "details"):
+            payload = getattr(error, attribute, None)
+            if payload is not None:
+                yield payload
+        for argument in getattr(error, "args", ()):
+            if isinstance(argument, (dict, list, tuple)):
+                yield argument
+
+
+def _extract_provider_detail(
+    chain: list[BaseException],
+) -> tuple[str | None, str | None]:
+    payloads = list(_payloads(chain))
+    message = None
+    provider_code = None
+
+    for payload in payloads:
+        if message is None:
+            message = _extract_from_payload(
+                payload,
+                ("message", "detail", "error_description", "description"),
+            )
+        if provider_code is None:
+            provider_code = _extract_from_payload(
+                payload,
+                ("code", "error_code", "type"),
+            )
+
+    if message is None:
+        for error in chain:
+            match = _MESSAGE_PATTERN.search(str(error))
+            if match:
+                message = match.group(1)
+                break
+
+    safe_message = (
+        sanitize_error_text(message, limit=500) if message is not None else None
+    )
+    safe_code = (
+        sanitize_error_text(provider_code, limit=100)
+        if provider_code is not None
+        else None
+    )
+    return safe_message, safe_code
+
+
+def _classification(
+    *,
+    status_code: int | None,
+    exception_names: str,
+    searchable: str,
+) -> tuple[str, str, str, str, str, bool]:
+    def result(
+        code: str,
+        category: str,
+        title: str,
+        description: str,
+        resolution: str,
+        retryable: bool = False,
+    ) -> tuple[str, str, str, str, str, bool]:
+        return code, category, title, description, resolution, retryable
+
+    if status_code == 401 or "authenticationerror" in exception_names:
+        return result(
+            "AUTHENTICATION_FAILED",
+            "authentication",
+            "Authentication failed",
+            "The provider rejected the selected credential.",
+            "Verify the API key, selected credential, account status, and endpoint access.",
+        )
+    if any(
+        phrase in searchable
+        for phrase in (
+            "invalid api key",
+            "incorrect api key",
+            "api key not valid",
+            "invalid x-api-key",
+            "invalid authentication credentials",
+            "unauthorized",
+        )
+    ):
+        return result(
+            "AUTHENTICATION_FAILED",
+            "authentication",
+            "Authentication failed",
+            "The provider rejected the selected credential.",
+            "Verify the API key, selected credential, account status, and endpoint access.",
+        )
+    if any(
+        phrase in searchable
+        for phrase in (
+            "insufficient_quota",
+            "quota exceeded",
+            "quota has been exceeded",
+            "billing hard limit",
+            "credit balance",
+        )
+    ):
+        return result(
+            "QUOTA_EXCEEDED",
+            "billing",
+            "Provider quota exhausted",
+            "The account has no remaining quota or billing capacity for this request.",
+            "Check provider billing, credits, usage limits, and organization or project selection.",
+        )
+    if any(
+        phrase in searchable
+        for phrase in (
+            "context_length_exceeded",
+            "maximum context length",
+            "too many tokens",
+            "token limit exceeded",
+        )
+    ):
+        return result(
+            "CONTEXT_LENGTH_EXCEEDED",
+            "input",
+            "Model context limit exceeded",
+            "The prompt, history, or tool output is larger than the model context window.",
+            "Reduce input size, trim history, or select a model with a larger context window.",
+        )
+    if "content_policy" in searchable or "content policy" in searchable:
+        return result(
+            "CONTENT_POLICY_BLOCKED",
+            "safety",
+            "Provider content policy blocked the request",
+            "The provider safety policy rejected the request or generated content.",
+            "Review the prompt and content policy details before retrying.",
+        )
+    if status_code == 403 or "permissiondenied" in exception_names:
+        return result(
+            "ACCESS_DENIED",
+            "authorization",
+            "Access denied",
+            "The credential is valid but does not have permission for this operation.",
+            "Grant the required role or scope and confirm model or resource access.",
+        )
+    if status_code == 404 or "notfounderror" in exception_names:
+        return result(
+            "RESOURCE_NOT_FOUND",
+            "configuration",
+            "Provider resource not found",
+            "The configured endpoint, model, deployment, or resource does not exist.",
+            "Check the base URL and the configured model or deployment name.",
+        )
+    if status_code == 413 or "request too large" in searchable:
+        return result(
+            "REQUEST_TOO_LARGE",
+            "input",
+            "Provider request is too large",
+            "The request payload exceeds the provider size limit.",
+            "Reduce attached files, document content, batch size, or prompt size.",
+        )
+    if status_code == 429 or "ratelimit" in exception_names:
+        return result(
+            "RATE_LIMITED",
+            "rate_limit",
+            "Provider rate limit reached",
+            "The provider rejected the request because its rate or quota limit was reached.",
+            "Check quota and billing, reduce request frequency, or retry after a delay.",
+            True,
+        )
+    if status_code in (408, 504) or "timeout" in exception_names or "timed out" in searchable:
+        return result(
+            "PROVIDER_TIMEOUT",
+            "timeout",
+            "Provider request timed out",
+            "The provider did not complete the request within the allowed time.",
+            "Check provider latency and increase timeout only if the operation normally takes longer.",
+            True,
+        )
+    if status_code is not None and status_code >= 500:
+        return result(
+            "PROVIDER_UNAVAILABLE",
+            "provider",
+            "Provider service unavailable",
+            "The provider returned a server-side failure.",
+            "Retry later and check the provider status page or server logs.",
+            True,
+        )
+    if status_code in (400, 409, 422) or any(
+        name in exception_names
+        for name in ("badrequest", "unprocessableentity")
+    ):
+        return result(
+            "PROVIDER_REQUEST_INVALID",
+            "request",
+            "Provider rejected the request",
+            "The request is incompatible with the selected provider, model, or parameters.",
+            "Review model capabilities, input data, and node parameters.",
+        )
+    if any(
+        phrase in searchable
+        for phrase in (
+            "no api key",
+            "missing api key",
+            "credential could not be found",
+            "credential has no",
+            "selected credential",
+        )
+    ):
+        return result(
+            "CREDENTIAL_CONFIGURATION_ERROR",
+            "configuration",
+            "Credential configuration is incomplete",
+            "The node cannot resolve a usable credential from its configuration.",
+            "Select an existing credential and make sure all required fields are populated.",
+        )
+    if any(
+        name in exception_names
+        for name in ("apiconnectionerror", "connectionerror", "connecterror")
+    ) or any(
+        phrase in searchable
+        for phrase in ("connection refused", "name resolution", "dns", "ssl")
+    ):
+        return result(
+            "PROVIDER_CONNECTION_FAILED",
+            "connection",
+            "Provider connection failed",
+            "KAI-Flow could not establish a valid connection to the provider.",
+            "Check the base URL, DNS, proxy, TLS certificate, and network reachability.",
+            True,
+        )
+    if "jsondecodeerror" in exception_names:
+        return result(
+            "INVALID_DATA_FORMAT",
+            "data",
+            "Invalid data format",
+            "The node received data that could not be parsed as the expected format.",
+            "Inspect the node input and the upstream output schema.",
+        )
+    if "typeerror" in exception_names:
+        return result(
+            "INVALID_NODE_INPUT",
+            "input",
+            "Invalid node input",
+            "The node received an unsupported argument shape or value type.",
+            "Check connected handles and the node input schema.",
+        )
+    if "valueerror" in exception_names:
+        return result(
+            "INVALID_NODE_CONFIGURATION",
+            "configuration",
+            "Invalid node configuration",
+            "A node setting or input value failed validation.",
+            "Review the node configuration and the provider detail below.",
+        )
+
+    return result(
+        "NODE_EXECUTION_FAILED",
+        "execution",
+        "Node execution failed",
+        "The node raised an execution error that has no specialized classification.",
+        "Use the provider detail and exception type to inspect the failing integration.",
+    )
+
+
+def normalize_execution_error(error: BaseException) -> ExecutionErrorDetails:
+    """Return a stable, actionable identity without discarding the original error."""
+    chain = list(_iter_error_chain(error))
+    raw_message = sanitize_error_text(error)
+    status_code = _extract_status(chain)
+    provider_message, provider_code = _extract_provider_detail(chain)
+    exception_names = " ".join(type(item).__name__.lower() for item in chain)
+    searchable = " ".join(str(item).lower() for item in chain)
+
+    code, category, title, description, resolution, retryable = _classification(
+        status_code=status_code,
+        exception_names=exception_names,
+        searchable=searchable,
+    )
+
+    if code == "NODE_EXECUTION_FAILED" and raw_message:
+        description = raw_message
+        if provider_message == raw_message:
+            provider_message = None
+
+    return ExecutionErrorDetails(
+        code=code,
+        category=category,
+        title=title,
+        description=description,
+        resolution=resolution,
+        raw_message=raw_message,
+        exception_type=type(error).__name__,
+        status_code=status_code,
+        provider_code=provider_code,
+        provider_message=provider_message,
+        retryable=retryable,
+    )

--- a/backend/app/core/execution_status.py
+++ b/backend/app/core/execution_status.py
@@ -1,0 +1,29 @@
+from collections.abc import Callable, Iterable, Mapping
+from typing import Literal
+
+ExecutionStatus = Literal["pending", "success", "failed"]
+
+
+def build_execution_edge_statuses(
+    node_statuses: Mapping[str, str],
+    transmitted_edge_ids: Iterable[str] = (),
+    *,
+    is_dependency_node: Callable[[str], bool],
+    outgoing_edge_ids_for_node: Callable[[str], Iterable[str]],
+) -> dict[str, ExecutionStatus]:
+    """Map runtime lifecycle data to canvas edges without naming heuristics."""
+    statuses: dict[str, ExecutionStatus] = {
+        str(edge_id): "success"
+        for edge_id in transmitted_edge_ids
+        if edge_id
+    }
+
+    for node_id, status in node_statuses.items():
+        if status not in {"pending", "success", "failed"}:
+            continue
+        if not is_dependency_node(node_id):
+            continue
+        for edge_id in outgoing_edge_ids_for_node(node_id):
+            statuses[str(edge_id)] = status
+
+    return statuses

--- a/backend/app/core/graph_builder/__init__.py
+++ b/backend/app/core/graph_builder/__init__.py
@@ -16,7 +16,8 @@ from langgraph.checkpoint.memory import MemorySaver
 from langchain_core.runnables import Runnable, RunnableConfig
 
 # Local imports - core
-from app.core.state import FlowState
+from app.core.state import FlowState, get_runtime_node_statuses
+from app.core.execution_status import build_execution_edge_statuses
 from app.nodes import BaseNode
 from app.core.tracing import get_workflow_tracer
 from app.core.node_handlers import node_handler_registry
@@ -30,7 +31,7 @@ from .types import (
 )
 from .exceptions import (
     WorkflowError, NodeExecutionError, ConnectionError, 
-    ValidationError, GraphCompilationError
+    ValidationError, GraphCompilationError, find_deepest_node_execution_error
 )
 from .connection_mapper import ConnectionMapper
 from .node_executor import NodeExecutor
@@ -262,12 +263,24 @@ class GraphBuilder:
         self,
         node_id: str,
         previous_node_id: Optional[str] = None,
+        completed_nodes: Optional[set] = None,
     ) -> List[str]:
-        """Return the canvas edge IDs that represent data entering node_id."""
+        """Return the canvas edge IDs that represent data entering node_id.
+
+        Uses completed_nodes set for branching graph support.
+        Falls back to previous_node_id for backward compatibility.
+        """
         incoming = self._incoming_visual_edges.get(node_id, [])
         if not incoming:
             return []
 
+        # For branching graphs: match edges from any completed parent node
+        if completed_nodes:
+            matched = [edge for edge in incoming if edge.get("source") in completed_nodes]
+            if matched:
+                return [edge.get("id") or self._fallback_edge_id(edge) for edge in matched]
+
+        # Fallback: single previous_node_id (linear graphs)
         if previous_node_id:
             matched = [edge for edge in incoming if edge.get("source") == previous_node_id]
             if matched:
@@ -279,11 +292,85 @@ class GraphBuilder:
         outgoing = self._outgoing_visual_edges.get(node_id, [])
         return [edge.get("id") or self._fallback_edge_id(edge) for edge in outgoing]
 
+    def _execution_role_for_node(self, node_id: str) -> str:
+        """Expose the graph's node role to execution-event consumers."""
+        return "dependency" if self._is_dependency_node(node_id) else "workflow"
+
+    def _edge_statuses_for_execution(
+        self,
+        node_statuses: Dict[str, str],
+        transmitted_edge_ids: Optional[set] = None,
+    ) -> Dict[str, str]:
+        return build_execution_edge_statuses(
+            node_statuses,
+            transmitted_edge_ids or set(),
+            is_dependency_node=self._is_dependency_node,
+            outgoing_edge_ids_for_node=self._visual_outgoing_edge_ids_for_node,
+        )
+
     @staticmethod
     def _fallback_edge_id(edge: Dict[str, Any]) -> str:
         source_handle = edge.get("sourceHandle") or "output"
         target_handle = edge.get("targetHandle") or "input"
         return f"{edge.get('source')}-{source_handle}-{edge.get('target')}-{target_handle}"
+
+    def _runtime_node_output(
+        self,
+        node_id: str,
+        status: str,
+        error_message: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Build a serializable detail-panel record for dependency lifecycle events."""
+        graph_node = self.nodes.get(node_id)
+        node_type = getattr(graph_node, "type", "Unknown")
+        failed = status == "failed"
+        return {
+            "success": not failed,
+            "statusCode": 500 if failed else 200,
+            "nodeId": node_id,
+            "nodeType": node_type,
+            "timestamp": datetime.datetime.now().isoformat(),
+            "executionTimeMs": 0.0,
+            "inputs": {},
+            "output": None,
+            "error": (
+                {
+                    "error_type": "execution",
+                    "error_message": error_message or "Node execution failed",
+                }
+                if failed
+                else None
+            ),
+        }
+
+    def _merge_runtime_node_outputs(
+        self,
+        node_outputs: Optional[Dict[str, Any]],
+        node_statuses: Dict[str, str],
+        failed_node_id: Optional[str] = None,
+        error_message: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Ensure every attempted node has a true/false execution detail record."""
+        merged = dict(node_outputs or {})
+        for node_id, status in node_statuses.items():
+            if status not in {"success", "failed"}:
+                continue
+            if node_id not in merged:
+                merged[node_id] = self._runtime_node_output(
+                    node_id,
+                    status,
+                    error_message if node_id == failed_node_id else None,
+                )
+            elif status == "failed" and isinstance(merged[node_id], dict):
+                failed_output = dict(merged[node_id])
+                failed_output["success"] = False
+                failed_output["statusCode"] = 500
+                failed_output["error"] = failed_output.get("error") or {
+                    "error_type": "execution",
+                    "error_message": error_message or "Node execution failed",
+                }
+                merged[node_id] = failed_output
+        return merged
 
     def _handle_start_end_nodes(self, workflow_data: Dict) -> Dict[str, Any]:
         """Handle StartNode, WebhookTrigger, KafkaConsumer/KafkaTrigger, and EndNode special cases."""
@@ -531,6 +618,34 @@ class GraphBuilder:
         build_duration = time.time() - start_time
         logger.info(f"Enhanced instantiation completed in {build_duration:.3f}s")
 
+    def _is_dependency_node(self, node_id: str) -> bool:
+        """Return whether a node is resolved by its consumer, not LangGraph."""
+        gnode = self.nodes.get(node_id)
+        node_instance = getattr(gnode, "node_instance", None)
+        metadata = getattr(node_instance, "metadata", None)
+
+        # Trigger nodes always participate in control flow. Some legacy trigger
+        # implementations were classified as providers, so metadata.node_type
+        # alone is not sufficient to decide whether a node is lazy.
+        concrete_type = str(getattr(gnode, "type", "")).lower()
+        class_name = str(getattr(getattr(node_instance, "__class__", None), "__name__", "")).lower()
+        category = str(getattr(metadata, "category", "")).lower()
+        if (
+            category in {"trigger", "triggers"}
+            or "trigger" in concrete_type
+            or "trigger" in class_name
+            or concrete_type in {"timerstart", "timerstartnode"}
+        ):
+            return False
+
+        raw_node_type = getattr(metadata, "node_type", "")
+        node_type = getattr(raw_node_type, "value", raw_node_type)
+        return str(node_type).lower() in {"provider", "memory"}
+
+    def _is_flow_node(self, node_id: str) -> bool:
+        """Return whether a node participates directly in workflow control flow."""
+        return node_id in self.nodes and not self._is_dependency_node(node_id)
+
     def _compile_final_graph(self) -> CompiledStateGraph:
         """Compile final LangGraph using all components."""
         logger.info("Compiling final LangGraph")
@@ -540,7 +655,8 @@ class GraphBuilder:
 
             # 1) Add regular nodes with enhanced node wrapper
             for node_id, gnode in self.nodes.items():
-                graph.add_node(node_id, self._wrap_node_enhanced(node_id, gnode))
+                if self._is_flow_node(node_id):
+                    graph.add_node(node_id, self._wrap_node_enhanced(node_id, gnode))
 
             # 2) Add control-flow constructs using ControlFlowManager
             self.control_flow_manager.add_control_flow_edges(graph)
@@ -576,9 +692,6 @@ class GraphBuilder:
             import time
             start_time = time.time()
             try:
-                # -------------------------------------------------------------
-                # Partial Execution / Dependency Resolution Logic (n8n Style)
-                # -------------------------------------------------------------
                 if isinstance(state, dict):
                     variables = state.get("variables", {})
                     node_outputs = state.get("node_outputs", {})
@@ -737,7 +850,7 @@ class GraphBuilder:
                     err.context["executed_nodes"] = exec_nodes
                     raise err from e
 
-        wrapper.__name__ = f"node_{node_id}"
+        wrapper.__name__ = node_id
         return wrapper
 
     # ---------------------------------------------------------------------
@@ -763,6 +876,12 @@ class GraphBuilder:
             # Skip if either node is not in our graph (StartNode/EndNode handled separately)
             if source_id not in self.nodes or target_id not in self.nodes:
                 logger.debug(f"Skipping edge {source_id} -> {target_id} (node not in graph)")
+                continue
+
+            # Provider/memory nodes are resolved through the target node's
+            # connection handler. They remain in the registry but never form
+            # independent LangGraph branches.
+            if not self._is_flow_node(source_id) or not self._is_flow_node(target_id):
                 continue
             
             # Check if source is a ConditionNode
@@ -877,7 +996,7 @@ class GraphBuilder:
         if self.explicit_start_nodes:
             logger.info(f"START -> {list(self.explicit_start_nodes)}")
             for start_target in self.explicit_start_nodes:
-                if start_target in self.nodes:
+                if self._is_flow_node(start_target):
                     graph.add_edge(START, start_target)
                     logger.debug(f"START -> {start_target}")
                 else:
@@ -894,7 +1013,7 @@ class GraphBuilder:
         if end_connections:
             logger.info(f"{end_connections} -> END")
             for end_source in end_connections:
-                if end_source in self.nodes:
+                if self._is_flow_node(end_source):
                     graph.add_edge(end_source, END)
                     logger.debug(f"{end_source} -> END")
                 else:
@@ -904,7 +1023,10 @@ class GraphBuilder:
             logger.debug("No explicit END connections, finding last nodes")
             all_targets = {conn.target_node_id for conn in self.connections}
             all_sources = {conn.source_node_id for conn in self.connections}
-            last_nodes = [node_id for node_id in all_sources if node_id not in all_targets and node_id in self.nodes]
+            last_nodes = [
+                node_id for node_id in all_sources
+                if node_id not in all_targets and self._is_flow_node(node_id)
+            ]
             
             if last_nodes:
                 logger.info(f"Auto-connecting last nodes to END: {last_nodes}")
@@ -921,6 +1043,8 @@ class GraphBuilder:
             for edge in self.visual_edges:
                 if edge.get("target") == current:
                     source = edge.get("source")
+                    if not self._is_flow_node(source) or not self._is_flow_node(current):
+                        continue
                     if source and source not in ancestors:
                         ancestors.add(source)
                         queue.append(source)
@@ -942,6 +1066,11 @@ class GraphBuilder:
             return True
             
         # 3. Topology check: if the node has no incoming connections, it's a starting point (trigger-like)
+
+        # A disconnected provider or memory node is still a dependency, not a
+        # workflow trigger. It runs only when a consumer resolves it.
+        if self._is_dependency_node(node_id):
+            return False
         incoming_edges = [edge for edge in self.visual_edges if edge.get("target") == node_id]
         if not incoming_edges:
             return True
@@ -1334,31 +1463,39 @@ class GraphBuilder:
             raise
 
     async def _execute_stream(self, init_state: FlowState, config: RunnableConfig):
-        """Streaming execution - preserved from original."""
+        """Streaming execution with branching graph support."""
+        # Track which nodes have been reported to frontend via events
+        streamed_node_starts: set = set()
+        streamed_node_ends: set = set()
+        current_running_node: str | None = None
+        completed_nodes: set = set()
+        transmitted_edge_ids: set = set()
+
         try:
             logger.info(f"Starting streaming execution for session: {init_state.session_id}")
             yield {"type": "start", "session_id": init_state.session_id, "message": "Starting workflow execution"}
-            
-            # Track previously executed node to help frontend animate correct edge
-            previous_node_id: str | None = None
             
             # Stream workflow execution events
             event_count = 0
             async for ev in self.graph.astream_events(init_state, config=config):
                 event_count += 1
                 
-                # Process and yield events (simplified version of original logic)
+                # Process and yield events
                 ev_type = ev.get("event", "")
                 node_name = ev.get("name", "unknown")
                 
                 if ev_type == "on_chain_start":
                     if node_name not in self.nodes:
                         continue
-                    incoming_edge_ids = self._visual_edge_ids_for_node(node_name, previous_node_id)
+                    current_running_node = node_name
+                    streamed_node_starts.add(node_name)
+                    incoming_edge_ids = self._visual_edge_ids_for_node(
+                        node_name, completed_nodes=completed_nodes
+                    )
+                    transmitted_edge_ids.update(incoming_edge_ids)
                     yield {
                         "type": "node_start", 
                         "node_id": node_name,
-                        "previous_node_id": previous_node_id,
                         "incoming_edge_ids": incoming_edge_ids,
                         "active_edge_ids": incoming_edge_ids,
                         "outgoing_edge_ids": self._visual_outgoing_edge_ids_for_node(node_name),
@@ -1369,7 +1506,9 @@ class GraphBuilder:
                     # Extract output from the event data for node_end
                     ev_data = ev.get("data", {})
                     node_output = ev_data.get("output", {})
-                    incoming_edge_ids = self._visual_edge_ids_for_node(node_name, previous_node_id)
+                    incoming_edge_ids = self._visual_edge_ids_for_node(
+                        node_name, completed_nodes=completed_nodes
+                    )
                     
                     # Try to extract meaningful output from various formats
                     output_data = {}
@@ -1393,20 +1532,107 @@ class GraphBuilder:
                     yield {
                         "type": "node_end",
                         "node_id": node_name,
-                        "previous_node_id": previous_node_id,
                         "incoming_edge_ids": incoming_edge_ids,
                         "active_edge_ids": incoming_edge_ids,
                         "outgoing_edge_ids": self._visual_outgoing_edge_ids_for_node(node_name),
                         "output": output_data
                     }
                     
-                    # Update previous node after successful completion
-                    previous_node_id = node_name
+                    # Add to completed set for branching graph edge resolution
+                    completed_nodes.add(node_name)
+                    streamed_node_ends.add(node_name)
+                elif ev_type == "on_custom_event" and node_name == "kai_node_status":
+                    status_data = ev.get("data", {})
+                    status_node_id = status_data.get("node_id")
+                    status_value = status_data.get("status")
+                    if status_node_id and status_value in {"pending", "success", "failed"}:
+                        execution_role = self._execution_role_for_node(status_node_id)
+                        status_edge_ids = (
+                            self._visual_outgoing_edge_ids_for_node(status_node_id)
+                            if execution_role == "dependency"
+                            else []
+                        )
+                        status_event = {
+                            "type": "node_status",
+                            "node_id": status_node_id,
+                            "status": status_value,
+                            "execution_role": execution_role,
+                            "edge_ids": status_edge_ids,
+                            "active_edge_ids": status_edge_ids,
+                        }
+                        if status_value in {"success", "failed"}:
+                            status_event["output"] = self._runtime_node_output(
+                                status_node_id,
+                                status_value,
+                                status_data.get("error"),
+                            )
+                        yield status_event
                 elif ev_type == "on_llm_new_token":
                     yield {"type": "token", "content": ev.get("data", {}).get("chunk", "")}
                 elif ev_type == "on_chain_error":
-                    error_msg = str(ev.get("data", {}).get("error", "Unknown error"))
-                    yield {"type": "error", "error": error_msg, "node_id": ev.get("name", "unknown")}
+                    raw_error = ev.get("data", {}).get("error", "Unknown error")
+                    deepest_error = (
+                        find_deepest_node_execution_error(raw_error)
+                        if isinstance(raw_error, BaseException)
+                        else None
+                    )
+                    failed_node = (
+                        deepest_error.node_id
+                        if deepest_error
+                        else node_name if node_name in self.nodes else current_running_node
+                    )
+                    execution_node = node_name if node_name in self.nodes else current_running_node
+                    node_statuses = (
+                        dict(deepest_error.context.get("node_statuses", {}))
+                        if deepest_error
+                        else get_runtime_node_statuses(init_state)
+                    )
+                    context_outputs = (
+                        deepest_error.context.get("node_outputs", {})
+                        if deepest_error
+                        else {}
+                    )
+                    context_executed_nodes = (
+                        deepest_error.context.get("executed_nodes", [])
+                        if deepest_error
+                        else []
+                    )
+                    current_node_outputs = context_outputs or dict(init_state.node_outputs)
+                    current_executed_nodes = (
+                        context_executed_nodes or list(init_state.executed_nodes)
+                    )
+                    execution_edge_ids = (
+                        self._visual_edge_ids_for_node(
+                            execution_node,
+                            completed_nodes=completed_nodes,
+                        )
+                        if execution_node
+                        else []
+                    )
+                    transmitted_edge_ids.update(execution_edge_ids)
+                    current_node_outputs = self._merge_runtime_node_outputs(
+                        current_node_outputs,
+                        node_statuses,
+                        failed_node_id=failed_node,
+                        error_message=str(raw_error),
+                    )
+                    yield {
+                        "type": "error",
+                        "error": str(raw_error),
+                        "node_id": failed_node or "unknown",
+                        "execution_node_id": execution_node,
+                        "incoming_edge_ids": execution_edge_ids,
+                        "active_edge_ids": execution_edge_ids,
+                        "edge_statuses": self._edge_statuses_for_execution(
+                            node_statuses,
+                            transmitted_edge_ids,
+                        ),
+                        "node_statuses": node_statuses,
+                        "node_outputs": current_node_outputs,
+                        "executed_nodes": current_executed_nodes,
+                        "session_id": init_state.session_id,
+                    }
+
             
             # Get final state
             final_state = await self.graph.aget_state(config)
@@ -1420,6 +1646,15 @@ class GraphBuilder:
                 executed_nodes = []
                 node_outputs = {}
                 errors = []
+            node_statuses = get_runtime_node_statuses(
+                final_state.values
+                if hasattr(final_state, "values") and final_state.values
+                else init_state
+            )
+            node_outputs = self._merge_runtime_node_outputs(
+                node_outputs,
+                node_statuses,
+            )
             
             # Yield completion event with node_outputs for frontend display
             yield {
@@ -1429,6 +1664,11 @@ class GraphBuilder:
                 "node_outputs": node_outputs,
                 "errors": errors,
                 "session_id": init_state.session_id,
+                "node_statuses": node_statuses,
+                "edge_statuses": self._edge_statuses_for_execution(
+                    node_statuses,
+                    transmitted_edge_ids,
+                ),
             }
             
             # Cleanup session-scoped registry to prevent memory leak
@@ -1440,12 +1680,21 @@ class GraphBuilder:
             node_outputs = {}
             executed_nodes = []
             
-            # Recursively traverse exception chain to find context
+            # Attribute nested provider/tool failures to the original node, not
+            # to the processor that happened to request that dependency.
+            deepest_error = find_deepest_node_execution_error(e)
+            failed_node_id = deepest_error.node_id if deepest_error else current_running_node
+
+            node_statuses = (
+                dict(deepest_error.context.get("node_statuses", {}))
+                if deepest_error
+                else get_runtime_node_statuses(init_state)
+            )
             curr_e = e
             while curr_e:
                 if hasattr(curr_e, "context") and isinstance(curr_e.context, dict):
-                    node_outputs = curr_e.context.get("node_outputs") or {}
-                    executed_nodes = curr_e.context.get("executed_nodes") or []
+                    node_outputs = curr_e.context.get("node_outputs") or node_outputs
+                    executed_nodes = curr_e.context.get("executed_nodes") or executed_nodes
                     if node_outputs:
                         break
                 curr_e = getattr(curr_e, "__cause__", None) or getattr(curr_e, "__context__", None)
@@ -1458,14 +1707,67 @@ class GraphBuilder:
                         executed_nodes = final_state.values.get('executed_nodes', [])
                 except Exception as state_err:
                     logger.warning(f"Failed to get graph state on streaming error: {state_err}")
-                
+
+            node_outputs = self._merge_runtime_node_outputs(
+                node_outputs or dict(init_state.node_outputs),
+                node_statuses,
+                failed_node_id=failed_node_id,
+                error_message=str(e),
+            )
+            if not executed_nodes:
+                executed_nodes = list(init_state.executed_nodes)
+
+            # Emit retroactive node_end events for successfully completed nodes
+            # that the frontend never saw (because the stream was cut short by the exception)
+            for completed_node_id in executed_nodes:
+                if completed_node_id in self.nodes and completed_node_id not in streamed_node_ends:
+                    completed_edge_ids = self._visual_edge_ids_for_node(completed_node_id)
+                    transmitted_edge_ids.update(completed_edge_ids)
+                    # Send node_start if we never sent it
+                    if completed_node_id not in streamed_node_starts:
+                        yield {
+                            "type": "node_start",
+                            "node_id": completed_node_id,
+                            "incoming_edge_ids": completed_edge_ids,
+                            "active_edge_ids": completed_edge_ids,
+                            "outgoing_edge_ids": self._visual_outgoing_edge_ids_for_node(completed_node_id),
+                        }
+                    yield {
+                        "type": "node_end",
+                        "node_id": completed_node_id,
+                        "incoming_edge_ids": completed_edge_ids,
+                        "active_edge_ids": completed_edge_ids,
+                        "outgoing_edge_ids": self._visual_outgoing_edge_ids_for_node(completed_node_id),
+                        "output": node_outputs.get(completed_node_id, {}),
+                    }
+
+            execution_edge_ids = (
+                self._visual_edge_ids_for_node(
+                    current_running_node,
+                    completed_nodes=completed_nodes,
+                )
+                if current_running_node
+                else []
+            )
+            transmitted_edge_ids.update(execution_edge_ids)
+
+            # Yield error event with node_id for failed node identification
             yield {
                 "type": "error", 
                 "error": str(e), 
-                "error_type": type(e).__name__, 
+                "error_type": type(e).__name__,
+                "node_id": failed_node_id or "unknown",
+                "execution_node_id": current_running_node,
+                "incoming_edge_ids": execution_edge_ids,
+                "active_edge_ids": execution_edge_ids,
+                "edge_statuses": self._edge_statuses_for_execution(
+                    node_statuses,
+                    transmitted_edge_ids,
+                ),
                 "session_id": init_state.session_id,
                 "node_outputs": node_outputs,
-                "executed_nodes": executed_nodes
+                "executed_nodes": executed_nodes,
+                "node_statuses": node_statuses,
             }
             
             # Cleanup session-scoped registry even on error

--- a/backend/app/core/graph_builder/exceptions.py
+++ b/backend/app/core/graph_builder/exceptions.py
@@ -15,6 +15,11 @@ from typing import Any, Dict, Optional, List
 import traceback
 import datetime
 
+from app.core.error_normalization import (
+    normalize_execution_error,
+    sanitize_error_text,
+)
+
 
 class WorkflowError(Exception):
     """
@@ -68,19 +73,31 @@ class NodeExecutionError(WorkflowError):
         self.node_config = node_config or {}
         self.input_connections = input_connections or {}
         self.output_connections = output_connections or {}
+        self.error_details = normalize_execution_error(original_error)
         
-        # Build detailed error message
-        message = f"Node {node_id} ({node_type}) execution failed: {str(original_error)}"
+        # The public message is stable and actionable. The original exception
+        # object and its sanitized provider diagnostics remain available below.
+        message = (
+            f"Node {node_id} ({node_type}) execution failed: "
+            f"{self.error_details.display_message}"
+        )
         
         # Build enhanced context
         context = {
             "node_id": node_id,
             "node_type": node_type,
-            "original_error": str(original_error),
+            "original_error": self.error_details.raw_message,
             "original_error_type": type(original_error).__name__,
+            "error_code": self.error_details.code,
+            "error_category": self.error_details.category,
+            "http_status": self.error_details.status_code,
+            "provider_error_code": self.error_details.provider_code,
+            "provider_message": self.error_details.provider_message,
+            "retryable": self.error_details.retryable,
+            "resolution": self.error_details.resolution,
             "node_config": node_config,
             "input_connections": input_connections,
-            "output_connections": output_connections
+            "output_connections": output_connections,
         }
         
         super().__init__(message, context)
@@ -98,10 +115,38 @@ class NodeExecutionError(WorkflowError):
             },
             "original_error_details": {
                 "type": type(self.original_error).__name__,
-                "message": str(self.original_error),
-                "args": getattr(self.original_error, 'args', [])
-            }
+                "message": sanitize_error_text(self.original_error),
+                "args": sanitize_error_text(getattr(self.original_error, 'args', [])),
+            },
+            "normalized_error": self.error_details.to_dict(),
         }
+
+
+def find_deepest_node_execution_error(error: BaseException) -> Optional["NodeExecutionError"]:
+    """Return the original failing node error from a wrapped exception chain."""
+    deepest: Optional[NodeExecutionError] = None
+    pending: List[BaseException] = [error]
+    visited: set[int] = set()
+
+    while pending:
+        current = pending.pop()
+        if id(current) in visited:
+            continue
+        visited.add(id(current))
+
+        if isinstance(current, NodeExecutionError):
+            deepest = current
+
+        for nested in (
+            getattr(current, "__context__", None),
+            getattr(current, "__cause__", None),
+            getattr(current, "original_error", None),
+            getattr(current, "_kai_node_execution_error", None),
+        ):
+            if isinstance(nested, BaseException) and id(nested) not in visited:
+                pending.append(nested)
+
+    return deepest
 
 
 class ConnectionError(WorkflowError):

--- a/backend/app/core/graph_builder/node_executor.py
+++ b/backend/app/core/graph_builder/node_executor.py
@@ -30,8 +30,12 @@ from .types import (
     PooledConnectionRegistry,
     ConnectionPoolStats
 )
-from .exceptions import NodeExecutionError
-from app.core.state import FlowState
+from .exceptions import NodeExecutionError, find_deepest_node_execution_error
+from app.core.state import (
+    FlowState,
+    attach_runtime_execution_context,
+    set_runtime_node_status,
+)
 from app.core.templating import apply_jinja_to_inputs
 from app.core.output_cache import default_connection_extractor
 from app.core.node_handlers import node_handler_registry
@@ -135,6 +139,7 @@ class NodeExecutor:
         Raises:
             NodeExecutionError: If processor execution fails
         """
+        set_runtime_node_status(state, node_id, "pending")
         try:
             logger.info(f"[PROCESSING] Executing processor node: {node_id} ({gnode.type})")
             start_time = datetime.datetime.now()
@@ -274,9 +279,22 @@ class NodeExecutor:
             logger.info(f"[SUCCESS] Processor node {node_id} completed successfully")
             logger.debug(f"Output: '{str(last_output)[:80]}...' ({len(str(last_output))} chars)")
             
+            set_runtime_node_status(state, node_id, "success")
+            result_dict["variables"] = (
+                state.get("variables", {}) if isinstance(state, dict)
+                else getattr(state, "variables", {})
+            )
             return result_dict
             
         except Exception as e:
+            nested_node_error = find_deepest_node_execution_error(e)
+            if nested_node_error is not None and nested_node_error.node_id != node_id:
+                set_runtime_node_status(state, node_id, "success")
+                attach_runtime_execution_context(nested_node_error, state)
+                raise nested_node_error from e
+
+            set_runtime_node_status(state, node_id, "failed")
+
             try:
                 execution_time_ms = round((datetime.datetime.now() - start_time).total_seconds() * 1000, 2)
                 error_details = {
@@ -311,14 +329,16 @@ class NodeExecutor:
             except Exception as formatting_err:
                 logger.warning(f"Failed to record standardized error in execute_processor_node: {formatting_err}")
 
-            raise NodeExecutionError(
+            node_error = NodeExecutionError(
                 node_id=node_id,
                 node_type=gnode.type,
                 original_error=e,
                 node_config=gnode.user_data,
                 input_connections=getattr(gnode.node_instance, '_input_connections', {}),
                 output_connections=getattr(gnode.node_instance, '_output_connections', {})
-            ) from e
+            )
+            attach_runtime_execution_context(node_error, state)
+            raise node_error from e
     
     def execute_standard_node(self, gnode: GraphNodeInstance, state: FlowState, node_id: str) -> Dict[str, Any]:
         """
@@ -335,6 +355,7 @@ class NodeExecutor:
         Raises:
             NodeExecutionError: If standard execution fails
         """
+        set_runtime_node_status(state, node_id, "pending")
         try:
             logger.info(f"[PROCESSING] Executing standard node: {node_id} ({gnode.type})")
             
@@ -370,17 +391,32 @@ class NodeExecutor:
             logger.info(f"[SUCCESS] Standard node {node_id} completed successfully")
             logger.debug(f"Node {node_id} output: {str(result)[:200]}...")
             
+            set_runtime_node_status(state, node_id, "success")
+            if isinstance(result, dict):
+                result["variables"] = (
+                    state.get("variables", {}) if isinstance(state, dict)
+                    else getattr(state, "variables", {})
+                )
             return result
             
         except Exception as e:
-            raise NodeExecutionError(
+            nested_node_error = find_deepest_node_execution_error(e)
+            if nested_node_error is not None and nested_node_error.node_id != node_id:
+                set_runtime_node_status(state, node_id, "success")
+                attach_runtime_execution_context(nested_node_error, state)
+                raise nested_node_error from e
+
+            set_runtime_node_status(state, node_id, "failed")
+            node_error = NodeExecutionError(
                 node_id=node_id,
                 node_type=gnode.type,
                 original_error=e,
                 node_config=gnode.user_data,
                 input_connections=getattr(gnode.node_instance, '_input_connections', {}),
                 output_connections=getattr(gnode.node_instance, '_output_connections', {})
-            ) from e
+            )
+            attach_runtime_execution_context(node_error, state)
+            raise node_error from e
     
     def extract_user_inputs_for_processor(self, gnode: GraphNodeInstance, state: FlowState) -> Dict[str, Any]:
         """
@@ -487,6 +523,13 @@ class NodeExecutor:
             
         except Exception as e:
             logger.error(f"Clean connection extraction failed for {gnode.id}: {e}")
+            nested_node_error = find_deepest_node_execution_error(e)
+            if nested_node_error is not None:
+                # The clean extractor reached a real connected node and that
+                # node failed. Falling back would replace the value with None,
+                # causing the consumer to emit a misleading secondary error.
+                raise nested_node_error from e
+
             if has_pool:
                 logger.info("Falling back to pool-aware legacy implementation")
             else:
@@ -580,7 +623,8 @@ class NodeExecutor:
                 logger.error(f"Failed to execute Runnable for {node_id}: {e}")
                 import traceback
                 logger.error(f"Full traceback: {traceback.format_exc()}")
-                return {"error": str(e)}
+                # Preserve the original exception chain and dependency owner.
+                raise
         
         # Keep the original result for proper data flow between nodes
         return result

--- a/backend/app/core/node_handlers.py
+++ b/backend/app/core/node_handlers.py
@@ -21,10 +21,15 @@ import re
 import json
 import uuid
 
-from app.core.state import FlowState
+from app.core.state import (
+    FlowState,
+    attach_runtime_execution_context,
+    set_runtime_node_status,
+)
 from app.nodes.base import NodeType
 from app.core.credential_provider import credential_provider
 from app.core.templating import apply_jinja_to_inputs
+from app.core.runtime_execution import instrument_runtime_artifact
 
 logger = logging.getLogger(__name__)
 
@@ -97,6 +102,7 @@ class MemoryNodeHandler(NodeExecutionHandler):
         """Extract memory node instance with session context."""
         node_id = connection_info["source_node_id"]
         self._log_execution(node_id, "memory", "extracting")
+        set_runtime_node_status(state, node_id, "pending")
         
         try:
             # Set session_id on memory nodes before execution
@@ -111,13 +117,24 @@ class MemoryNodeHandler(NodeExecutionHandler):
             
             # Execute memory node to get instance
             node_instance = source_node_instance.execute(**memory_inputs)
+            set_runtime_node_status(state, node_id, "success")
             logger.debug(f"[DEBUG] Memory node {node_id} executed successfully: {type(node_instance).__name__}")
             
             return node_instance
             
         except Exception as e:
             logger.error(f"[ERROR] Failed to extract memory node {node_id}: {e}")
-            raise RuntimeError(f"Memory node extraction failed for {node_id}: {str(e)}")
+            set_runtime_node_status(state, node_id, "failed")
+            from app.core.graph_builder.exceptions import NodeExecutionError
+
+            node_error = NodeExecutionError(
+                node_id=node_id,
+                node_type=getattr(gnode_instance, "type", source_node_instance.__class__.__name__),
+                original_error=e,
+                node_config=getattr(source_node_instance, "user_data", {}) or {},
+            )
+            attach_runtime_execution_context(node_error, state)
+            raise node_error from e
     
     def _extract_memory_inputs(self, source_node_instance: Any, state: FlowState) -> Dict[str, Any]:
         """Extract inputs needed for memory node execution."""
@@ -171,40 +188,119 @@ class ProviderNodeHandler(NodeExecutionHandler):
         """Initialize provider node handler."""
         super().__init__()
     
-    def extract_connected_instance(self,
-                                 connection_info: Dict[str, str],
-                                 source_node_instance: Any,
-                                 gnode_instance: Any,
-                                 state: FlowState) -> Any:
-        """Extract provider node instance from user configuration and connections."""
+    def extract_connected_instance(
+        self,
+        connection_info: Dict[str, str],
+        source_node_instance: Any,
+        gnode_instance: Any,
+        state: FlowState,
+    ) -> Any:
+        """Resolve one provider while preserving the real failure owner."""
+        from app.core.graph_builder.exceptions import (
+            NodeExecutionError,
+            find_deepest_node_execution_error,
+        )
+
         node_id = connection_info["source_node_id"]
         self._log_execution(node_id, "provider", "extracting")
-        
-        try:
-            # Extract provider-specific inputs from user configuration
-            provider_inputs = self._extract_provider_inputs(source_node_instance, state)
-            provider_inputs = apply_jinja_to_inputs(provider_inputs, state, node_id, self.nodes_registry)
-            
-            # NEW: Extract connected inputs for provider nodes that need them
-            connected_inputs = self._extract_connected_inputs(source_node_instance, gnode_instance, state)
-            
-            # Merge both input types
-            all_inputs = {**provider_inputs, **connected_inputs}
-            logger.debug(f"[DEBUG] Provider node {node_id} inputs: user={list(provider_inputs.keys())}, connected={list(connected_inputs.keys())}")
+        set_runtime_node_status(state, node_id, "pending")
 
-            # Inject user_id from state into node instance before execution
+        try:
+            provider_inputs = self._extract_provider_inputs(source_node_instance, state)
+            provider_inputs = apply_jinja_to_inputs(
+                provider_inputs, state, node_id, self.nodes_registry
+            )
+
+            # Validate this provider before touching its child dependencies.
             self._inject_user_context(source_node_instance, state, node_id)
-            
-            # Execute provider node to get LangChain object
+            self._validate_required_credentials(source_node_instance, provider_inputs)
+            source_node_instance.validate_configuration(**provider_inputs)
+
+            connected_inputs = self._extract_connected_inputs(
+                source_node_instance, gnode_instance, state
+            )
+            all_inputs = {**provider_inputs, **connected_inputs}
+            logger.debug(
+                "[DEBUG] Provider node %s inputs: user=%s, connected=%s",
+                node_id,
+                list(provider_inputs.keys()),
+                list(connected_inputs.keys()),
+            )
+
             node_instance = source_node_instance.execute(**all_inputs)
-            logger.debug(f"[DEBUG] Provider node {node_id} executed successfully: {type(node_instance).__name__}")
-            
+            node_instance = instrument_runtime_artifact(
+                node_instance,
+                node_id=node_id,
+                node_type=getattr(gnode_instance, "type", type(source_node_instance).__name__),
+                state=state,
+                node_config=getattr(source_node_instance, "user_data", {}) or {},
+                input_connections=getattr(source_node_instance, "_input_connections", {}) or {},
+                output_connections=getattr(source_node_instance, "_output_connections", {}) or {},
+            )
+
+            set_runtime_node_status(state, node_id, "success")
+            logger.debug(
+                f"[DEBUG] Provider node {node_id} executed successfully: "
+                f"{type(node_instance).__name__}"
+            )
             return node_instance
-            
-        except Exception as e:
-            logger.error(f"[ERROR] Failed to extract provider node {node_id}: {e}")
-            raise RuntimeError(f"Provider node extraction failed for {node_id}: {str(e)}")
-    
+
+        except Exception as error:
+            logger.error(f"[ERROR] Failed to extract provider node {node_id}: {error}")
+            deepest_error = find_deepest_node_execution_error(error)
+
+            if deepest_error is not None and deepest_error.node_id != node_id:
+                # The provider's child failed; this provider is not the error source.
+                set_runtime_node_status(state, node_id, "success")
+                attach_runtime_execution_context(deepest_error, state)
+                raise deepest_error from error
+
+            set_runtime_node_status(state, node_id, "failed")
+            if isinstance(error, NodeExecutionError) and error.node_id == node_id:
+                attach_runtime_execution_context(error, state)
+                raise
+
+            node_error = NodeExecutionError(
+                node_id=node_id,
+                node_type=getattr(
+                    gnode_instance, "type", source_node_instance.__class__.__name__
+                ),
+                original_error=error,
+                node_config=getattr(source_node_instance, "user_data", {}) or {},
+                input_connections=getattr(
+                    source_node_instance, "_input_connections", {}
+                )
+                or {},
+                output_connections=getattr(
+                    source_node_instance, "_output_connections", {}
+                )
+                or {},
+            )
+            attach_runtime_execution_context(node_error, state)
+            raise node_error from error
+
+    def _validate_required_credentials(
+        self, source_node_instance: Any, provider_inputs: Dict[str, Any]
+    ) -> None:
+        """Fail local credential configuration before resolving child nodes."""
+        properties = getattr(source_node_instance.metadata, "properties", None) or []
+        user_data = getattr(source_node_instance, "user_data", {}) or {}
+
+        for prop in properties:
+            raw_type = getattr(prop, "type", "")
+            prop_type = getattr(raw_type, "value", raw_type)
+            if str(prop_type).lower() != "credential-select":
+                continue
+
+            value = provider_inputs.get(prop.name) or user_data.get(prop.name)
+            if getattr(prop, "required", False) and not value:
+                label = getattr(prop, "displayName", None) or prop.name
+                raise ValueError(f"{label} credential selection is required.")
+
+            if value and source_node_instance.get_credential(value) is None:
+                raise ValueError(
+                    f"Selected credential with ID '{value}' could not be found."
+                )
     def _extract_provider_inputs(self, source_node_instance: Any, state: FlowState) -> Dict[str, Any]:
         """Extract inputs needed for provider node execution."""
         provider_inputs = {}
@@ -226,72 +322,68 @@ class ProviderNodeHandler(NodeExecutionHandler):
         
         return provider_inputs
     
-    def _extract_connected_inputs(self, source_node_instance: Any, gnode_instance: Any, state: FlowState) -> Dict[str, Any]:
-        """
-        NEW: Extract connected inputs for provider nodes.
-        
-        This handles provider nodes like RetrieverProvider that need connections
-        from other nodes (e.g., embedder from OpenAIEmbeddingsProvider).
-        """
-        connected_inputs = {}
-        
-        # Check if this provider node has any connected inputs
-        if not hasattr(source_node_instance, '_input_connections'):
-            return connected_inputs
-        
-        # Import here to avoid circular imports
+    def _extract_connected_inputs(
+        self, source_node_instance: Any, gnode_instance: Any, state: FlowState
+    ) -> Dict[str, Any]:
+        """Resolve every attached dependency and collect all real failures."""
+        from app.core.graph_builder.exceptions import (
+            NodeExecutionError,
+            find_deepest_node_execution_error,
+        )
         from app.core.output_cache import NodeConnectionExtractor
-        
-        # Create a temporary extractor to handle connections
-        temp_extractor = NodeConnectionExtractor()
-        
-        # Process each connected input
-        for input_name, connection_info in source_node_instance._input_connections.items():
-            try:
-                source_node_id = connection_info["source_node_id"]
-                logger.debug(f"[DEBUG] Provider extracting connected input '{input_name}' from {source_node_id}")
-                
-                # Get source node instance from global registry (injected by GraphBuilder)
-                if hasattr(self, 'nodes_registry') and source_node_id in self.nodes_registry:
-                    source_gnode = self.nodes_registry[source_node_id]
-                    source_instance = source_gnode.node_instance
-                    source_node_type = source_instance.metadata.node_type
-                    
-                    # Handle different source node types
-                    if source_node_type.value == "provider":
-                        # Execute source provider to get its instance
-                        provider_inputs = self._extract_provider_inputs(source_instance, state)
-                        provider_inputs = apply_jinja_to_inputs(provider_inputs, state, source_node_id, self.nodes_registry)
-                        
-                        # Inject user_id if supported
-                        self._inject_user_context(source_instance, state, source_node_id)
-                        
-                        connected_result = source_instance.execute(**provider_inputs)
-                        connected_inputs[input_name] = connected_result
-                        logger.debug(f"[DEBUG] Successfully extracted provider connection: {input_name} -> {type(connected_result).__name__}")
-                        
-                    elif source_node_type.value == "processor":
-                        # Try to get cached output from processor
-                        if hasattr(state, 'node_outputs') and source_node_id in state.node_outputs:
-                            cached_result = state.node_outputs[source_node_id]
-                            connected_inputs[input_name] = cached_result
-                            logger.debug(f"[DEBUG] Successfully extracted processor connection: {input_name} -> {type(cached_result)}")
-                        else:
-                            logger.warning(f"[WARNING] No cached output for processor {source_node_id}")
-                            
-                    else:
-                        logger.warning(f"[WARNING] Unsupported connected node type for provider: {source_node_type}")
-                        
-                else:
-                    logger.warning(f"[ERROR] Source node {source_node_id} not found in registry")
-                    
-            except Exception as e:
-                logger.warning(f"[ERROR] Failed to extract connected input '{input_name}': {e}")
-                # Continue with other connections rather than failing completely
-                continue
-        
-        return connected_inputs
 
+        connected_inputs: Dict[str, Any] = {}
+        input_connections = getattr(
+            source_node_instance, "_input_connections", {}
+        ) or {}
+        if not input_connections:
+            return connected_inputs
+
+        extractor = NodeConnectionExtractor()
+        extractor.nodes_registry = self.nodes_registry
+        connection_errors = []
+
+        for input_name, connection_info in input_connections.items():
+            try:
+                result = extractor._process_connection(
+                    input_name, connection_info, state
+                )
+                if result is not None:
+                    connected_inputs[input_name] = result
+            except Exception as error:
+                logger.error(
+                    f"[ERROR] Failed to extract connected input '{input_name}': "
+                    f"{error}"
+                )
+                node_error = find_deepest_node_execution_error(error)
+                if node_error is None:
+                    source_info = (
+                        connection_info[0]
+                        if isinstance(connection_info, list) and connection_info
+                        else connection_info
+                    )
+                    source_node_id = (
+                        source_info.get("source_node_id", "unknown")
+                        if isinstance(source_info, dict)
+                        else "unknown"
+                    )
+                    failed_node = self.nodes_registry.get(source_node_id)
+                    node_error = NodeExecutionError(
+                        node_id=source_node_id,
+                        node_type=getattr(failed_node, "type", "Provider"),
+                        original_error=error,
+                    )
+                connection_errors.append(node_error)
+
+        if connection_errors:
+            primary_error = connection_errors[0]
+            attach_runtime_execution_context(primary_error, state)
+            primary_error.context["node_errors"] = [
+                error.to_dict() for error in connection_errors
+            ]
+            raise primary_error
+
+        return connected_inputs
 
 class ProcessorNodeHandler(NodeExecutionHandler):
     """

--- a/backend/app/core/output_cache.py
+++ b/backend/app/core/output_cache.py
@@ -268,47 +268,83 @@ class NodeConnectionExtractor:
         self.output_cache = NodeOutputCache()
         self.nodes_registry = {}  # Will be injected by GraphBuilder
     
-    def extract_connected_instances(self, 
-                                  gnode: Any, 
-                                  state: FlowState,
-                                  nodes_registry: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Main extraction method replacing the monolithic function.
-        
-        This is the clean, maintainable replacement for 
-        _extract_connected_node_instances that uses Strategy Pattern.
-        """
+    def extract_connected_instances(
+        self,
+        gnode: Any,
+        state: FlowState,
+        nodes_registry: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Resolve every input so sibling failures never hide one another."""
+        from app.core.graph_builder.exceptions import (
+            NodeExecutionError,
+            find_deepest_node_execution_error,
+        )
+        from app.core.state import get_runtime_node_statuses
+
         self.nodes_registry = nodes_registry
-        connected = {}
-        
-        # Validate input connections exist
-        if not hasattr(gnode.node_instance, "_input_connections"):
+        connected: Dict[str, Any] = {}
+        connection_errors = []
+        input_connections = getattr(gnode.node_instance, "_input_connections", {}) or {}
+
+        if not input_connections:
             logger.debug(f"[DEBUG] No input connections found for {gnode.id}")
             return connected
-        
-        logger.debug(f"[DEBUG] Extracting {len(gnode.node_instance._input_connections)} connections for {gnode.id}")
-        
-        # Process each input connection
-        for input_name, connection_info in gnode.node_instance._input_connections.items():
+
+        logger.debug(
+            f"[DEBUG] Extracting {len(input_connections)} connections for {gnode.id}"
+        )
+
+        for input_name, connection_info in input_connections.items():
             try:
-                result = self._process_connection(input_name, connection_info, state)
-                
+                result = self._process_connection(
+                    input_name, connection_info, state
+                )
                 if result is not None:
                     connected[input_name] = result
-                    connection_count = len(connection_info) if isinstance(connection_info, list) else 1
-                    logger.debug(f"[DEBUG] Successfully connected {input_name} with {connection_count} connection(s)")
-                else:
-                    logger.debug(f"[DEBUG] No result for connection {input_name}")
+                    connection_count = (
+                        len(connection_info)
+                        if isinstance(connection_info, list)
+                        else 1
+                    )
+                    logger.debug(
+                        f"[DEBUG] Successfully connected {input_name} with "
+                        f"{connection_count} connection(s)"
+                    )
+            except Exception as error:
+                logger.error(
+                    f"[ERROR] Failed to extract connection {input_name}: {error}"
+                )
+                node_error = find_deepest_node_execution_error(error)
+                if node_error is None:
+                    source_info = (
+                        connection_info[0]
+                        if isinstance(connection_info, list) and connection_info
+                        else connection_info
+                    )
+                    source_node_id = (
+                        source_info.get("source_node_id", "unknown")
+                        if isinstance(source_info, dict)
+                        else "unknown"
+                    )
+                    node_error = NodeExecutionError(
+                        node_id=source_node_id,
+                        node_type="connected_node",
+                        original_error=error,
+                    )
+                connection_errors.append(node_error)
 
-            except Exception as e:
-                logger.error(f"[ERROR] Failed to extract connection {input_name}: {e}")
-                import traceback
-                logger.error(f"[ERROR] Stack trace: {traceback.format_exc()}")
-                continue
-        
-        logger.debug(f"[DEBUG] Extraction completed: {len(connected)} connections established")
+        if connection_errors:
+            primary_error = connection_errors[0]
+            primary_error.context["node_statuses"] = get_runtime_node_statuses(state)
+            primary_error.context["node_errors"] = [
+                error.to_dict() for error in connection_errors
+            ]
+            raise primary_error
+
+        logger.debug(
+            f"[DEBUG] Extraction completed: {len(connected)} connections established"
+        )
         return connected
-    
     def _process_connection(self,
                            input_name: str,
                            connection_info: Union[Dict[str, str], List[Dict[str, str]]],
@@ -390,6 +426,7 @@ class NodeConnectionExtractor:
         logger.debug(f"[DEBUG] Processing {len(connection_list)} connections for {input_name}")
         # Extract results from each connection
         results = []
+        connection_errors = []
         for i, connection_info in enumerate(connection_list):
             try:
                 if not isinstance(connection_info, dict):
@@ -415,9 +452,31 @@ class NodeConnectionExtractor:
                 else:
                     logger.debug(f"✗ Connection {i + 1} returned None: {source_node_id}")
 
-            except Exception as e:
-                logger.error(f"Failed to process connection {i}: {e}")
-                continue
+            except Exception as error:
+                logger.error(f"Failed to process connection {i}: {error}")
+                from app.core.graph_builder.exceptions import (
+                    NodeExecutionError,
+                    find_deepest_node_execution_error,
+                )
+
+                node_error = find_deepest_node_execution_error(error)
+                if node_error is None:
+                    node_error = NodeExecutionError(
+                        node_id=connection_info.get("source_node_id", "unknown"),
+                        node_type="connected_node",
+                        original_error=error,
+                    )
+                connection_errors.append(node_error)
+        if connection_errors:
+            from app.core.state import get_runtime_node_statuses
+
+            primary_error = connection_errors[0]
+            primary_error.context["node_statuses"] = get_runtime_node_statuses(state)
+            primary_error.context["node_errors"] = [
+                error.to_dict() for error in connection_errors
+            ]
+            raise primary_error
+
         
         if not results:
             logger.debug(f"No successful connections for {input_name}")

--- a/backend/app/core/runtime_execution.py
+++ b/backend/app/core/runtime_execution.py
@@ -1,0 +1,384 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from langchain_core.callbacks import BaseCallbackHandler
+from langchain_core.documents import Document
+from langchain_core.documents.compressor import BaseDocumentCompressor
+from langchain_core.embeddings import Embeddings
+from langchain_core.language_models import BaseLanguageModel
+from langchain_core.retrievers import BaseRetriever
+from langchain_core.runnables import Runnable
+from langchain_core.tools import BaseTool
+from pydantic import ConfigDict
+
+from app.core.state import attach_runtime_execution_context, set_runtime_node_status
+
+if TYPE_CHECKING:
+    from app.core.graph_builder.exceptions import NodeExecutionError
+
+KAI_NODE_ERROR_ATTRIBUTE = "_kai_node_execution_error"
+KAI_ORIGIN_NODE_METADATA_KEY = "kai_origin_node_id"
+
+T = TypeVar("T")
+
+
+class RuntimeNodeTracker:
+    """Own the runtime lifecycle of one lazy dependency node."""
+
+    def __init__(
+        self,
+        *,
+        node_id: str,
+        node_type: str,
+        state: Any,
+        node_config: Mapping[str, Any] | None = None,
+        input_connections: Mapping[str, Any] | None = None,
+        output_connections: Mapping[str, Any] | None = None,
+    ) -> None:
+        self.node_id = node_id
+        self.node_type = node_type
+        self.state = state
+        self.node_config = dict(node_config or {})
+        self.input_connections = dict(input_connections or {})
+        self.output_connections = dict(output_connections or {})
+        self.failed = False
+
+    def pending(self) -> None:
+        if not self.failed:
+            set_runtime_node_status(self.state, self.node_id, "pending")
+
+    def success(self) -> None:
+        if not self.failed:
+            set_runtime_node_status(self.state, self.node_id, "success")
+
+    def failure(self, error: BaseException) -> "NodeExecutionError":
+        # Kept local to avoid importing the graph_builder package while its
+        # node-handler registry is still being initialized.
+        from app.core.graph_builder.exceptions import (
+            NodeExecutionError,
+            find_deepest_node_execution_error,
+        )
+
+        nested_error = find_deepest_node_execution_error(error)
+        if nested_error is not None and nested_error.node_id != self.node_id:
+            # A child dependency owns this failure. This wrapper only propagated it.
+            self.success()
+            self._attach_node_error(error, nested_error)
+            return nested_error
+
+        self.failed = True
+        set_runtime_node_status(self.state, self.node_id, "failed")
+
+        if nested_error is not None:
+            node_error = nested_error
+        else:
+            original_error = (
+                error if isinstance(error, Exception) else RuntimeError(str(error))
+            )
+            node_error = NodeExecutionError(
+                node_id=self.node_id,
+                node_type=self.node_type,
+                original_error=original_error,
+                node_config=self.node_config,
+                input_connections=self.input_connections,
+                output_connections=self.output_connections,
+            )
+
+        attach_runtime_execution_context(node_error, self.state)
+        self._attach_node_error(error, node_error)
+        return node_error
+
+    @staticmethod
+    def _attach_node_error(
+        error: BaseException,
+        node_error: "NodeExecutionError",
+    ) -> None:
+        try:
+            setattr(error, KAI_NODE_ERROR_ATTRIBUTE, node_error)
+        except Exception:
+            # Some third-party exception implementations disallow attributes.
+            pass
+
+    def call(self, function, *args, **kwargs):
+        self.pending()
+        try:
+            result = function(*args, **kwargs)
+        except BaseException as error:
+            node_error = self.failure(error)
+            raise node_error from error
+        self.success()
+        return result
+
+    async def acall(self, function, *args, **kwargs):
+        self.pending()
+        try:
+            result = await function(*args, **kwargs)
+        except BaseException as error:
+            node_error = self.failure(error)
+            raise node_error from error
+        self.success()
+        return result
+
+
+class RuntimeNodeStatusCallback(BaseCallbackHandler):
+    """Translate LangChain runtime callbacks into KAI node lifecycle events."""
+
+    def __init__(self, tracker: RuntimeNodeTracker) -> None:
+        super().__init__()
+        self.tracker = tracker
+
+    def on_chat_model_start(self, *args, **kwargs) -> None:
+        self.tracker.pending()
+
+    def on_llm_start(self, *args, **kwargs) -> None:
+        self.tracker.pending()
+
+    def on_llm_end(self, *args, **kwargs) -> None:
+        self.tracker.success()
+
+    def on_llm_error(self, error: BaseException, **kwargs) -> None:
+        self.tracker.failure(error)
+
+    def on_tool_start(self, *args, **kwargs) -> None:
+        self.tracker.pending()
+
+    def on_tool_end(self, *args, **kwargs) -> None:
+        self.tracker.success()
+
+    def on_tool_error(self, error: BaseException, **kwargs) -> None:
+        self.tracker.failure(error)
+
+    def on_retriever_start(self, *args, **kwargs) -> None:
+        self.tracker.pending()
+
+    def on_retriever_end(self, *args, **kwargs) -> None:
+        self.tracker.success()
+
+    def on_retriever_error(self, error: BaseException, **kwargs) -> None:
+        self.tracker.failure(error)
+
+
+class RuntimeTrackedArtifact:
+    """Marker used to avoid re-wrapping a child dependency for its parent."""
+
+
+class RuntimeTrackedEmbeddings(RuntimeTrackedArtifact, Embeddings):
+    def __init__(self, delegate: Embeddings, tracker: RuntimeNodeTracker) -> None:
+        self.delegate = delegate
+        self.tracker = tracker
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.delegate, name)
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        return self.tracker.call(self.delegate.embed_documents, texts)
+
+    async def aembed_documents(self, texts: list[str]) -> list[list[float]]:
+        return await self.tracker.acall(self.delegate.aembed_documents, texts)
+
+    def embed_query(self, text: str) -> list[float]:
+        return self.tracker.call(self.delegate.embed_query, text)
+
+    async def aembed_query(self, text: str) -> list[float]:
+        return await self.tracker.acall(self.delegate.aembed_query, text)
+
+
+class RuntimeTrackedDocumentCompressor(
+    RuntimeTrackedArtifact,
+    BaseDocumentCompressor,
+):
+    delegate: BaseDocumentCompressor
+    tracker: RuntimeNodeTracker
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    def compress_documents(
+        self,
+        documents: Sequence[Document],
+        query: str,
+        callbacks=None,
+    ) -> Sequence[Document]:
+        return self.tracker.call(
+            self.delegate.compress_documents,
+            documents,
+            query,
+            callbacks=callbacks,
+        )
+
+    async def acompress_documents(
+        self,
+        documents: Sequence[Document],
+        query: str,
+        callbacks=None,
+    ) -> Sequence[Document]:
+        return await self.tracker.acall(
+            self.delegate.acompress_documents,
+            documents,
+            query,
+            callbacks=callbacks,
+        )
+
+
+class RuntimeTrackedRunnable(RuntimeTrackedArtifact, Runnable):
+    def __init__(self, delegate: Runnable, tracker: RuntimeNodeTracker) -> None:
+        self.delegate = delegate
+        self.tracker = tracker
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.delegate, name)
+
+    def invoke(self, input: Any, config=None, **kwargs) -> Any:
+        return self.tracker.call(
+            self.delegate.invoke,
+            input,
+            config=config,
+            **kwargs,
+        )
+
+    async def ainvoke(self, input: Any, config=None, **kwargs) -> Any:
+        return await self.tracker.acall(
+            self.delegate.ainvoke,
+            input,
+            config=config,
+            **kwargs,
+        )
+
+    def stream(self, input: Any, config=None, **kwargs) -> Iterator[Any]:
+        self.tracker.pending()
+        try:
+            yield from self.delegate.stream(input, config=config, **kwargs)
+        except BaseException as error:
+            node_error = self.tracker.failure(error)
+            raise node_error from error
+        self.tracker.success()
+
+    async def astream(
+        self,
+        input: Any,
+        config=None,
+        **kwargs,
+    ) -> AsyncIterator[Any]:
+        self.tracker.pending()
+        try:
+            async for chunk in self.delegate.astream(input, config=config, **kwargs):
+                yield chunk
+        except BaseException as error:
+            node_error = self.tracker.failure(error)
+            raise node_error from error
+        self.tracker.success()
+
+    def bind_tools(self, *args, **kwargs):
+        bound = self.delegate.bind_tools(*args, **kwargs)
+        return RuntimeTrackedRunnable(bound, self.tracker)
+
+    def with_structured_output(self, *args, **kwargs):
+        structured = self.delegate.with_structured_output(*args, **kwargs)
+        return RuntimeTrackedRunnable(structured, self.tracker)
+
+
+def _attach_callback(
+    value: BaseLanguageModel | BaseTool | BaseRetriever,
+    callback: RuntimeNodeStatusCallback,
+) -> Any:
+    tracker = callback.tracker
+    metadata = dict(getattr(value, "metadata", None) or {})
+    existing_origin = metadata.get(KAI_ORIGIN_NODE_METADATA_KEY)
+
+    if existing_origin and existing_origin != tracker.node_id:
+        # Preserve the child dependency's ownership when a parent returns it.
+        return value
+
+    current_callbacks = getattr(value, "callbacks", None)
+    if hasattr(current_callbacks, "handlers") and hasattr(
+        current_callbacks, "add_handler"
+    ):
+        for handler in list(getattr(current_callbacks, "handlers", [])):
+            if isinstance(handler, RuntimeNodeStatusCallback):
+                try:
+                    current_callbacks.remove_handler(handler)
+                except Exception:
+                    pass
+        current_callbacks.add_handler(callback)
+    else:
+        callbacks = list(current_callbacks or [])
+        callbacks = [
+            handler
+            for handler in callbacks
+            if not isinstance(handler, RuntimeNodeStatusCallback)
+        ]
+        value.callbacks = [*callbacks, callback]
+
+    metadata[KAI_ORIGIN_NODE_METADATA_KEY] = tracker.node_id
+    value.metadata = metadata
+
+    tags = list(getattr(value, "tags", None) or [])
+    origin_tag = f"kai-node:{tracker.node_id}"
+    value.tags = [*tags, origin_tag] if origin_tag not in tags else tags
+    return value
+
+
+def instrument_runtime_artifact(
+    value: T,
+    *,
+    node_id: str,
+    node_type: str,
+    state: Any,
+    node_config: Mapping[str, Any] | None = None,
+    input_connections: Mapping[str, Any] | None = None,
+    output_connections: Mapping[str, Any] | None = None,
+) -> T:
+    """Attach runtime ownership to lazy provider artifacts and nested containers."""
+    tracker = RuntimeNodeTracker(
+        node_id=node_id,
+        node_type=node_type,
+        state=state,
+        node_config=node_config,
+        input_connections=input_connections,
+        output_connections=output_connections,
+    )
+    callback = RuntimeNodeStatusCallback(tracker)
+    visited: set[int] = set()
+
+    def instrument(item: Any) -> Any:
+        if item is None or isinstance(item, RuntimeTrackedArtifact):
+            return item
+
+        item_identity = id(item)
+        if item_identity in visited:
+            return item
+        visited.add(item_identity)
+
+        if isinstance(item, Embeddings):
+            return RuntimeTrackedEmbeddings(item, tracker)
+
+        if isinstance(item, BaseDocumentCompressor):
+            return RuntimeTrackedDocumentCompressor(
+                delegate=item,
+                tracker=tracker,
+            )
+
+        if isinstance(item, (BaseLanguageModel, BaseTool, BaseRetriever)):
+            return _attach_callback(item, callback)
+
+        if isinstance(item, dict):
+            return {key: instrument(nested) for key, nested in item.items()}
+
+        if isinstance(item, list):
+            return [instrument(nested) for nested in item]
+
+        if isinstance(item, tuple):
+            return tuple(instrument(nested) for nested in item)
+
+        inner_llm = getattr(item, "llm", None)
+        if isinstance(inner_llm, BaseLanguageModel):
+            _attach_callback(inner_llm, callback)
+            return item
+
+        if isinstance(item, Runnable):
+            return RuntimeTrackedRunnable(item, tracker)
+
+        return item
+
+    return instrument(value)

--- a/backend/app/core/state.py
+++ b/backend/app/core/state.py
@@ -27,6 +27,82 @@ from typing import Any, List, Dict, Optional, Union, Annotated
 from datetime import datetime
 import logging
 
+RUNTIME_NODE_STATUSES_KEY = "__kai_runtime_node_statuses"
+
+
+def _state_variables(state: Any) -> Dict[str, Any]:
+    """Return the mutable execution-variable bag for dict and FlowState inputs."""
+    if isinstance(state, dict):
+        variables = state.setdefault("variables", {})
+    else:
+        variables = getattr(state, "variables", None)
+        if variables is None:
+            variables = {}
+            state.variables = variables
+    return variables
+
+
+def set_runtime_node_status(state: Any, node_id: str, status: str) -> None:
+    """Record the lifecycle of a node actually attempted during this run."""
+    if not node_id:
+        return
+    variables = _state_variables(state)
+
+    # When running inside a LangGraph Runnable, surface dependency lifecycle
+    # changes immediately instead of waiting for the parent node to finish.
+    try:
+        from langchain_core.callbacks import dispatch_custom_event
+
+        dispatch_custom_event(
+            "kai_node_status",
+            {"node_id": node_id, "status": status},
+        )
+    except RuntimeError:
+        # Direct/synchronous calls may not have an active callback context.
+        pass
+    statuses = variables.setdefault(RUNTIME_NODE_STATUSES_KEY, {})
+    statuses[node_id] = status
+
+
+def get_runtime_node_statuses(state: Any) -> Dict[str, str]:
+    """Return a copy safe to place on streaming events and exceptions."""
+    variables = _state_variables(state)
+    statuses = variables.get(RUNTIME_NODE_STATUSES_KEY, {})
+    return dict(statuses) if isinstance(statuses, dict) else {}
+
+
+
+def attach_runtime_execution_context(error: Any, state: Any) -> None:
+    """Attach the latest execution data to an error crossing the graph boundary."""
+    context = getattr(error, "context", None)
+    if not isinstance(context, dict):
+        return
+
+    if isinstance(state, dict):
+        node_outputs = state.get("node_outputs", {})
+        executed_nodes = state.get("executed_nodes", [])
+    else:
+        node_outputs = getattr(state, "node_outputs", {})
+        executed_nodes = getattr(state, "executed_nodes", [])
+
+    existing_outputs = context.get("node_outputs", {})
+    context["node_outputs"] = {
+        **(node_outputs if isinstance(node_outputs, dict) else {}),
+        **(existing_outputs if isinstance(existing_outputs, dict) else {}),
+    }
+    context["executed_nodes"] = list(dict.fromkeys([
+        *(executed_nodes if isinstance(executed_nodes, list) else []),
+        *(context.get("executed_nodes", []) if isinstance(context.get("executed_nodes"), list) else []),
+    ]))
+    context["node_statuses"] = {
+        **get_runtime_node_statuses(state),
+        **(
+            context.get("node_statuses", {})
+            if isinstance(context.get("node_statuses"), dict)
+            else {}
+        ),
+    }
+
 
 def merge_node_outputs(left: Dict[str, Any], right: Dict[str, Any]) -> Dict[str, Any]:
     """

--- a/backend/app/nodes/base.py
+++ b/backend/app/nodes/base.py
@@ -639,6 +639,13 @@ class BaseNode(ABC):
         meta = getattr(self, "_metadata", {})
         return meta.get("condition")
 
+    def validate_configuration(self, **inputs) -> None:
+        """Validate this node's own settings before resolving dependencies.
+
+        Dependency-aware nodes override this hook when ordering matters.
+        """
+        return None
+
     def execute(self, *args, **kwargs) -> Runnable:
         """Main execution method.
 
@@ -791,11 +798,9 @@ class BaseNode(ABC):
                     state.node_outputs = {}
                 state.node_outputs[node_id] = standard_error_output
                 
-                return {
-                    "errors": state.errors,
-                    "last_output": f"ERROR: {error_msg}",
-                    "node_outputs": state.node_outputs
-                }
+                # Recording an error is not a successful node result. Let the
+                # execution layer preserve ownership and publish a failed status.
+                raise
         
         return graph_node_function
     
@@ -818,7 +823,9 @@ class BaseNode(ABC):
                 executed_result = result.invoke(invoke_input)
                 return executed_result
             except Exception as e:
-                return f"Runnable execution error: {str(e)}"
+                raise RuntimeError(
+                    f"Runnable execution error: {str(e)}"
+                ) from e
         
         # For other types, ensure JSON-serializable
         try:

--- a/backend/app/nodes/embeddings/openai_embeddings_provider.py
+++ b/backend/app/nodes/embeddings/openai_embeddings_provider.py
@@ -187,6 +187,11 @@ class OpenAIEmbeddingsProvider(ProviderNode):
             if secret:
                 openai_api_key = secret.get('api_key')
 
+        if credential_id and not openai_api_key:
+            raise ValueError(
+                "The selected OpenAI credential has no API key."
+            )
+
         model = kwargs.get("model") or self.user_data.get("model", "text-embedding-3-small")
         request_timeout = kwargs.get("request_timeout") or self.user_data.get("request_timeout", 60)
         max_retries = kwargs.get("max_retries") or self.user_data.get("max_retries", 3)

--- a/backend/app/nodes/llms/openai_compatible_node.py
+++ b/backend/app/nodes/llms/openai_compatible_node.py
@@ -416,6 +416,11 @@ class OpenAICompatibleNode(BaseNode):
                 cred_verify_ssl = not bool(skip_ssl)
                 logger.info(f"[DEBUG][COMPATIBLE] API key length: {len(api_key_value)}")
 
+        if credential_id and not api_key_value:
+            raise ValueError(
+                "The selected OpenAI-compatible credential has no API key."
+            )
+
         # Resolve base URL with priority: kwargs -> credential -> self.user_data
         base_url = kwargs.get("base_url") or cred_base_url or self.user_data.get("base_url")
         if not base_url:

--- a/backend/app/nodes/llms/openai_node.py
+++ b/backend/app/nodes/llms/openai_node.py
@@ -558,6 +558,11 @@ class OpenAINode(BaseNode):
             cred = self.get_credential(credential_id)
             if cred and cred.get('secret'):
                 api_key = cred.get('secret').get('api_key')
+
+        if credential_id and not api_key:
+            raise ValueError(
+                "The selected OpenAI credential has no API key."
+            )
         
         if not api_key:
             import os

--- a/backend/app/nodes/tools/cohere_reranker.py
+++ b/backend/app/nodes/tools/cohere_reranker.py
@@ -186,6 +186,11 @@ class CohereRerankerNode(ProviderNode):
             cred = self.get_credential(credential_id)
             if cred and cred.get('secret'):
                 cohere_api_key = cred.get('secret').get('api_key')
+
+        if credential_id and not cohere_api_key:
+            raise ValueError(
+                "The selected Cohere credential has no API key."
+            )
         
         # Validate API key
         if not cohere_api_key:

--- a/backend/app/nodes/tools/markitdown_tool.py
+++ b/backend/app/nodes/tools/markitdown_tool.py
@@ -4,17 +4,31 @@ import tempfile
 from pathlib import Path
 from typing import Dict, Any, List
 
+from pydantic import BaseModel, Field
+
 from ..base import ProviderNode, NodeOutput, NodeType, NodePropertyType, NodeProperty, NodePosition
 from app.services.minio_service import minio_service
 
 try:
     from markitdown import MarkItDown
-    from langchain_core.tools import Tool
+    from langchain_core.tools import StructuredTool
     MARKITDOWN_AVAILABLE = True
 except ImportError:
     MARKITDOWN_AVAILABLE = False
 
 logger = logging.getLogger(__name__)
+
+
+class MarkItDownToolInput(BaseModel):
+    """Arguments accepted by the MinIO document reader tool."""
+
+    object_key_override: str = Field(
+        default="",
+        description=(
+            "Optional path to a different document in the configured MinIO bucket. "
+            "Leave empty to read the node's default document."
+        ),
+    )
 
 
 class MarkItDownToolNode(ProviderNode):
@@ -233,11 +247,9 @@ class MarkItDownToolNode(ProviderNode):
 
         credential = self.get_credential(llm_credential_id)
         if not credential:
-            logger.warning(
-                "Selected LLM credential (ID: %s) not found, falling back to basic MarkItDown",
-                llm_credential_id
+            raise ValueError(
+                f"Selected LLM credential '{llm_credential_id}' could not be found."
             )
-            return MarkItDown()
 
         secret = credential.get("secret") or {}
         
@@ -251,8 +263,9 @@ class MarkItDownToolNode(ProviderNode):
         ).strip()
         
         if not api_key:
-            logger.warning("LLM credential missing api_key field, falling back to basic MarkItDown")
-            return MarkItDown()
+            raise ValueError(
+                "The selected MarkItDown LLM credential has no API key."
+            )
 
         # Get base URL: prioritize node property override, fallback to credential secret
         base_url = (self.user_data.get("llm_base_url") or "").strip()
@@ -477,10 +490,8 @@ class MarkItDownToolNode(ProviderNode):
                 # Use override if provided, otherwise use configured key
                 read_key = object_key_override.strip() if object_key_override else object_key
                 if not read_key:
-                    return (
-                        f"ERROR: No document specified. "
-                        f"Please provide a document path (e.g., 'reports/document.pdf') "
-                        f"or configure a default document in the node settings."
+                    raise ValueError(
+                        "No document was specified and the node has no default object key."
                     )
                 
                 logger.info(
@@ -497,16 +508,13 @@ class MarkItDownToolNode(ProviderNode):
                     object_key=read_key,
                     max_file_size_mb=max_file_size_mb,
                 )
-            except ValueError as e:
-                # Return user-friendly error message
-                return f"ERROR: {str(e)}"
-            except Exception as e:
+            except Exception:
                 logger.exception(
                     "Unexpected error during MarkItDown conversion: bucket=%s key=%s",
                     bucket_name,
                     object_key_override or object_key
                 )
-                return f"ERROR: Unexpected error during document conversion: {str(e)}"
+                raise
 
         # Create LangChain Tool with agent-optimized description
         tool_description = (
@@ -521,10 +529,11 @@ class MarkItDownToolNode(ProviderNode):
             f"\n\nThe tool returns the document content converted to Markdown format."
         )
 
-        tool = Tool(
+        tool = StructuredTool.from_function(
             name="read_document_from_minio",
             func=markitdown_minio_reader,
             description=tool_description,
+            args_schema=MarkItDownToolInput,
         )
 
         logger.info(

--- a/backend/app/nodes/tools/retriever.py
+++ b/backend/app/nodes/tools/retriever.py
@@ -281,6 +281,44 @@ class RetrieverProvider(ProviderNode):
             ],
         }
 
+    def validate_configuration(self, **inputs) -> None:
+        """Validate Retriever's own settings before resolving child providers."""
+        credential_id = inputs.get("credential_id") or self.user_data.get(
+            "credential_id"
+        )
+        if not credential_id:
+            raise ValueError(
+                "Credential selection is required for Retriever Provider. "
+                "Please select a valid database credential."
+            )
+
+        credential = self.get_credential(credential_id)
+        if not credential:
+            raise ValueError(
+                f"Selected credential with ID '{credential_id}' could not be found. "
+                "Please configure a valid credential."
+            )
+
+        secret = credential.get("secret")
+        if not secret:
+            raise ValueError(
+                "Selected credential contains no secret configuration. "
+                "Please update the credential details."
+            )
+
+        required_fields = ("host", "database", "username", "password")
+        if any(not secret.get(field) for field in required_fields):
+            raise ValueError(
+                "Missing required database credentials "
+                "(host, database, username, or password) in selected credential."
+            )
+
+        collection_name = inputs.get("collection_name") or self.user_data.get(
+            "collection_name"
+        )
+        if not collection_name:
+            raise ValueError("Collection name is required for Retriever Provider.")
+
     def execute(self, **inputs) -> Dict[str, Any]:
         """
         Create retriever tool from existing vector database.
@@ -301,11 +339,16 @@ class RetrieverProvider(ProviderNode):
             embedder = inputs.get("embedder")
             reranker = inputs.get("reranker")  # Optional
 
-            # Get credential_id and extract credential data (like VectorStoreOrchestrator)
-            credential_id = self.user_data.get("credential_id")
-            credential = self.get_credential(credential_id) if credential_id else None
-            
-            # Extract database connection from credential (with null safety)
+            # Get credential_id and extract credential data
+            credential_id = inputs.get("credential_id") or self.user_data.get("credential_id")
+            if not credential_id:
+                raise ValueError("Credential selection is required for Retriever Provider. Please select a valid database credential.")
+
+            credential = self.get_credential(credential_id)
+            if not credential:
+                raise ValueError(f"Selected credential with ID '{credential_id}' could not be found. Please configure a valid credential.")
+
+            # Extract database connection from credential
             database_connection = None
             if credential and credential.get('secret'):
                 secret = credential['secret']
@@ -317,20 +360,22 @@ class RetrieverProvider(ProviderNode):
                 username = secret.get('username')
                 password = secret.get('password')
                 
-                if database and username and password:
+                if database and username and password and host:
                     # Build connection string
                     database_connection = f"postgresql://{username}:{password}@{host}:{port}/{database}"
                     logger.info(f"Connected to vector database: {host}:{port}/{database}")
                 else:
-                    logger.warning("Missing required database credentials (database, username, or password)")
+                    raise ValueError("Missing required database credentials (host, database, username, or password) in selected credential.")
+            else:
+                raise ValueError("Selected credential contains no secret configuration. Please update the credential details.")
 
             # Validation
             if not database_connection:
-                raise ValueError("Database connection is required. Please provide database credentials.")
+                raise ValueError("Database connection is required. Please select valid database credentials.")
             if not collection_name:
-                raise ValueError("Collection name is required")
+                raise ValueError("Collection name is required for Retriever Provider.")
             if not embedder:
-                raise ValueError("Embedder service is required - connect an embeddings provider")
+                raise ValueError("Embedder service is required - please connect an embeddings provider to the Retriever Node.")
 
             # Parse metadata filter
             try:
@@ -539,19 +584,15 @@ class RetrieverProvider(ProviderNode):
 
                 return "\n".join(result_parts)
 
-            except Exception as e:
-                error_msg = str(e)
-                logger.warning(f"Search failed for collection {collection_name}: {error_msg}")
-                return f"""[SEARCH] SEARCH RESULTS - {collection_name}
-    Query: A technical issue occurred while searching for '{query}'.
-    
-    # WARNING: ERROR DETAILS:
-    {error_msg}
-    
-    SEARCH SUMMARY:
-    - Search could not be completed due to technical issues
-    - Collection: {collection_name}
-    - Please try again with different search terms"""
+            except Exception as error:
+                logger.exception(
+                    "Retriever search failed for collection %s and query %r",
+                    collection_name,
+                    query,
+                )
+                raise RuntimeError(
+                    f"Retriever search failed for collection '{collection_name}': {error}"
+                ) from error
 
         # Create tool with descriptive name
         tool_name = f"search_{collection_name}"

--- a/backend/app/nodes/tools/tavily_search.py
+++ b/backend/app/nodes/tools/tavily_search.py
@@ -127,6 +127,11 @@ class TavilySearchNode(ProviderNode):
                 cred = self.get_credential(credential_id)
                 if cred and cred.get('secret'):
                     api_key = cred.get('secret').get('api_key')
+
+            if credential_id and not api_key:
+                raise ValueError(
+                    "The selected Tavily credential has no API key."
+                )
                         
             if not api_key:
                 api_key = os.getenv("TAVILY_API_KEY")
@@ -207,6 +212,9 @@ class TavilySearchNode(ProviderNode):
                 logger.info(f"   API Test: Success ({len(str(test_result))} chars)")
             except Exception as test_error:
                 logger.error(f"   API Test: Failed ({str(test_error)[:50]}...)")
+                raise ValueError(
+                    "Tavily credential validation failed."
+                ) from test_error
 
             # 7. Create agent-ready tool
             search_tool = self._create_search_tool(tavily_search, search_config)
@@ -338,18 +346,11 @@ SEARCH SUMMARY:
 
                 return "\n".join(result_parts)
 
-            except Exception as e:
-                error_msg = str(e)
-                return f"""WEB SEARCH RESULTS - Tavily
-Query: A technical issue occurred while searching for '{query}'.
-
-ERROR DETAILS:
-{error_msg}
-
-SEARCH SUMMARY:
-- Web search could not be completed due to technical issues
-- Search Engine: Tavily API
-- Please try again with different search terms"""
+            except Exception as error:
+                logger.exception(
+                    "Tavily search failed for query %r", query
+                )
+                raise RuntimeError(f"Tavily search failed: {error}") from error
 
         # Create tool with descriptive name and description
         return Tool(

--- a/backend/app/nodes/triggers/error_trigger.py
+++ b/backend/app/nodes/triggers/error_trigger.py
@@ -25,7 +25,9 @@ class ErrorTriggerNode(BaseNode):
             "name": "ErrorTrigger",
             "display_name": "Error Trigger",
             "description": "Runs when a linked workflow fails; receives injected error_data.",
-            "node_type": NodeType.PROVIDER,
+            # Error Trigger emits serializable workflow data and participates
+            # directly in control flow; it is not a lazily-resolved provider.
+            "node_type": NodeType.TERMINATOR,
             "category": "Triggers",
             "colors": ["green-500", "emerald-600"],
             "icon": {"name": "error_trigger", "path": "icons/error_trigger.svg", "alt": "Error Trigger"},

--- a/backend/app/services/workflow_executor.py
+++ b/backend/app/services/workflow_executor.py
@@ -478,6 +478,32 @@ class WorkflowExecutor:
                     final_outputs: Dict[str, Any] = {}
                     execution_failed = False
                     error_msg = None
+
+                    def _capture_stream_metadata(chunk: Dict[str, Any]) -> None:
+                        reported_outputs = chunk.get("node_outputs")
+                        if isinstance(reported_outputs, dict):
+                            final_outputs["node_outputs"] = {
+                                **final_outputs.get("node_outputs", {}),
+                                **reported_outputs,
+                            }
+
+                        reported_nodes = chunk.get("executed_nodes")
+                        if isinstance(reported_nodes, list):
+                            final_outputs["executed_nodes"] = list(dict.fromkeys([
+                                *final_outputs.get("executed_nodes", []),
+                                *reported_nodes,
+                            ]))
+
+                        reported_statuses = chunk.get("node_statuses")
+                        if isinstance(reported_statuses, dict):
+                            final_outputs["node_statuses"] = {
+                                **final_outputs.get("node_statuses", {}),
+                                **reported_statuses,
+                            }
+
+                        for key in ("session_id", "errors"):
+                            if key in chunk:
+                                final_outputs[key] = chunk.get(key)
                     
                     stream_task = asyncio.current_task()
                     if stream_task and execution_id:
@@ -491,6 +517,8 @@ class WorkflowExecutor:
                                 if chunk.get("type") == "error":
                                     execution_failed = True
                                     error_msg = chunk.get("error")
+                                    final_outputs["result"] = f"ERROR: {error_msg or 'Workflow execution failed'}"
+                                    _capture_stream_metadata(chunk)
                                     logger.warning(f"Error chunk detected in stream for {execution_id}: {error_msg}")
                                 
                                 # Process completion and token data
@@ -508,9 +536,7 @@ class WorkflowExecutor:
                                             llm_output += chunk_result.get("output", "")
                                         final_outputs.update(chunk_result)
 
-                                    for key in ("node_outputs", "executed_nodes", "session_id", "errors"):
-                                        if key in chunk:
-                                            final_outputs[key] = chunk.get(key)
+                                    _capture_stream_metadata(chunk)
                             yield chunk
 
                         # Determine final status

--- a/client/app/components/canvas/FlowCanvas.tsx
+++ b/client/app/components/canvas/FlowCanvas.tsx
@@ -58,6 +58,11 @@ import GenericNode from "../node";
 import { config } from "../../lib/config";
 import { GenericNodeForm } from "../node";
 import { useWorkflowHistory, isEditableKeyboardTarget } from "../../lib/useWorkflowHistory";
+import {
+  ensureLiveNodeFailure,
+  mergeLiveNodeOutputMaps,
+  reduceLiveNodeEvent,
+} from "~/lib/liveExecution";
 
 interface FlowCanvasProps {
   workflowId?: string;
@@ -131,6 +136,170 @@ const findCanvasNode = (nodes: Node[], nodeId?: string): Node | undefined => {
   });
 };
 
+const MIN_RUNTIME_PENDING_VISIBILITY_MS = 600;
+
+type RuntimePendingTransition = {
+  startedAt: number;
+  terminalStatus?: Exclude<NodeStatus, "pending">;
+  timeoutId?: ReturnType<typeof setTimeout>;
+};
+
+const runtimePendingTransitions = new Map<string, RuntimePendingTransition>();
+
+const mergeReportedNodeStatuses = (
+  current: Record<string, NodeStatus>,
+  reported: unknown,
+  nodes: Node[],
+  fallbackFailedNodeId?: string
+): Record<string, NodeStatus> => {
+  const next = { ...current };
+
+  if (reported && typeof reported === "object") {
+    Object.entries(reported as Record<string, unknown>).forEach(([nodeId, status]) => {
+      if (status !== "pending" && status !== "success" && status !== "failed") return;
+      const actualNode = findCanvasNode(nodes, nodeId);
+      if (!actualNode) return;
+
+      const pendingTransition = runtimePendingTransitions.get(actualNode.id);
+      if (status !== "pending" && pendingTransition?.terminalStatus) return;
+      next[actualNode.id] = status;
+    });
+  }
+
+  if (fallbackFailedNodeId) {
+    const actualNode = findCanvasNode(nodes, fallbackFailedNodeId);
+    const pendingTransition = actualNode
+      ? runtimePendingTransitions.get(actualNode.id)
+      : undefined;
+    if (actualNode && !pendingTransition?.terminalStatus) {
+      next[actualNode.id] = "failed";
+    }
+  }
+
+  return next;
+};
+
+const mergeReportedEdgeStatuses = (
+  current: Record<string, NodeStatus>,
+  reported: unknown,
+  fallbackSuccessEdgeIds: string[] = []
+): Record<string, NodeStatus> => {
+  const next = { ...current };
+
+  Object.keys(next).forEach((edgeId) => {
+    if (next[edgeId] === "pending") delete next[edgeId];
+  });
+
+  if (reported && typeof reported === "object") {
+    Object.entries(reported as Record<string, unknown>).forEach(([edgeId, status]) => {
+      if (status === "pending" || status === "success" || status === "failed") {
+        next[edgeId] = status;
+      }
+    });
+  }
+
+  fallbackSuccessEdgeIds.forEach((edgeId) => {
+    if (!(edgeId in next)) next[edgeId] = "success";
+  });
+  return next;
+};
+
+const applyRuntimeNodeStatusEvent = (
+  eventData: any,
+  nodes: Node[],
+  edges: Edge[],
+  setNodeStatus: React.Dispatch<React.SetStateAction<Record<string, NodeStatus>>>,
+  setActiveNodes: React.Dispatch<React.SetStateAction<string[]>>,
+  setActiveEdges: React.Dispatch<React.SetStateAction<string[]>>,
+  setEdgeStatus: React.Dispatch<
+    React.SetStateAction<Record<string, NodeStatus>>
+  >
+): boolean => {
+  const status = eventData?.status as NodeStatus | undefined;
+  const actualNode = findCanvasNode(nodes, String(eventData?.node_id || ""));
+
+  if (
+    !actualNode ||
+    (status !== "pending" && status !== "success" && status !== "failed")
+  ) {
+    return false;
+  }
+
+  // GraphBuilder owns this semantic; handle and node names are never inferred.
+  if (eventData?.execution_role !== "dependency") return false;
+
+  const eventEdgeIds = new Set(getEventEdgeIds(eventData));
+  const dependencyEdgeIds = edges
+    .filter((edge) => eventEdgeIds.has(edge.id))
+    .map((edge) => edge.id);
+
+
+  const commitStatus = (nextStatus: NodeStatus) => {
+    setNodeStatus((current) => ({ ...current, [actualNode.id]: nextStatus }));
+
+    setActiveNodes((current) => {
+      if (nextStatus === "pending") {
+        return Array.from(new Set([...current, actualNode.id]));
+      }
+      return current.filter((nodeId) => nodeId !== actualNode.id);
+    });
+
+    setEdgeStatus((current) => ({
+      ...current,
+      ...Object.fromEntries(
+        dependencyEdgeIds.map((edgeId) => [edgeId, nextStatus])
+      ),
+    }));
+
+    setActiveEdges((current) => {
+      if (nextStatus === "pending") {
+        return Array.from(new Set([...current, ...dependencyEdgeIds]));
+      }
+      const completedEdgeIds = new Set(dependencyEdgeIds);
+      return current.filter((edgeId) => !completedEdgeIds.has(edgeId));
+    });
+  };
+
+  if (status === "pending") {
+    const existingTransition = runtimePendingTransitions.get(actualNode.id);
+    if (existingTransition?.timeoutId) {
+      clearTimeout(existingTransition.timeoutId);
+    }
+
+    runtimePendingTransitions.set(actualNode.id, { startedAt: Date.now() });
+    commitStatus("pending");
+    return true;
+  }
+
+  const pendingTransition = runtimePendingTransitions.get(actualNode.id);
+  if (!pendingTransition) {
+    commitStatus(status);
+    return true;
+  }
+
+  pendingTransition.terminalStatus = status;
+  const remainingMs = Math.max(
+    0,
+    MIN_RUNTIME_PENDING_VISIBILITY_MS - (Date.now() - pendingTransition.startedAt)
+  );
+
+  if (remainingMs > 0) {
+    if (!pendingTransition.timeoutId) {
+      pendingTransition.timeoutId = setTimeout(() => {
+        if (runtimePendingTransitions.get(actualNode.id) !== pendingTransition) return;
+        runtimePendingTransitions.delete(actualNode.id);
+        commitStatus(pendingTransition.terminalStatus || status);
+      }, remainingMs);
+    }
+    return true;
+  }
+
+  runtimePendingTransitions.delete(actualNode.id);
+  commitStatus(status);
+  return true;
+};
+
+
 const normalizeNodeOutputs = (nodeOutputs: Record<string, any>, currentNodes: Node[]): Record<string, any> => {
   const normalized: Record<string, any> = {};
   Object.entries(nodeOutputs).forEach(([nodeId, data]) => {
@@ -182,126 +351,53 @@ const isFinalWorkflowNode = (nodeId: string, currentNodes: Node[], currentEdges:
 };
 
 const getEventEdgeIds = (eventData: any): string[] => {
-  const raw =
-    eventData?.active_edge_ids ??
-    eventData?.incoming_edge_ids ??
-    eventData?.edge_ids ??
-    eventData?.edge_id ??
-    [];
+  const raw = [
+    eventData?.edge_ids,
+    eventData?.active_edge_ids,
+    eventData?.incoming_edge_ids,
+    eventData?.edge_id,
+  ].find((candidate) =>
+    Array.isArray(candidate) ? candidate.length > 0 : Boolean(candidate)
+  );
 
   if (Array.isArray(raw)) return raw.filter(Boolean).map(String);
   return raw ? [String(raw)] : [];
 };
 
-const isProcessorNode = (node?: Node): boolean => {
-  if (!node?.type) return false;
-  const processorTypes = [
-    "ReactAgentNode", "Agent",
-    "VectorStoreOrchestrator",
-    "ChunkSplitterNode", "ChunkSplitter",
-    "CodeNode", "ConditionNode", "JsonParserNode",
-  ];
-  return processorTypes.some((type) => node.type?.includes(type) || node.type === type);
-};
-
-const isProviderNode = (node?: Node): boolean => {
-  if (!node?.type) return false;
-  const providerTypes = [
-    "OpenAINode", "OpenAIChat", "OpenAICompatibleNode",
-    "OpenAIEmbeddingsProvider", "OpenAIEmbeddings", "CohereEmbeddings",
-    "BufferMemoryNode", "BufferMemory",
-    "RetrieverProvider",
-    "TavilySearchNode", "TavilySearch",
-    "CohereRerankerNode", "CohereRerankerProvider",
-    "VectorStoreOrchestrator",
-    "ChunkSplitterNode", "ChunkSplitter",
-    "DocumentLoaderNode",
-    "WebScraperNode", "WebScraper",
-    "StringInputNode",
-    "MarkItDownTool",
-  ];
-  return providerTypes.some((type) =>
-    node.type?.includes(type) ||
-    (node.type ? type.includes(node.type) : false) ||
-    node.type === type
-  );
-};
 
 const resolveExecutionEdges = (
   eventData: any,
   actualNode: Node,
-  nodes: Node[],
+  _nodes: Node[],
   edges: Edge[]
 ): Edge[] => {
   const eventEdgeIds = getEventEdgeIds(eventData);
   if (eventEdgeIds.length > 0) {
     const eventEdgeSet = new Set(eventEdgeIds);
-    const eventEdges = edges.filter((edge) => eventEdgeSet.has(edge.id));
-
-    if (isProcessorNode(actualNode)) {
-      const extraProviderEdges: Edge[] = [];
-      const nodesToCheck = [actualNode.id];
-      const checkedNodes = new Set<string>();
-
-      while (nodesToCheck.length > 0) {
-        const currentNodeId = nodesToCheck.pop()!;
-        if (checkedNodes.has(currentNodeId)) continue;
-        checkedNodes.add(currentNodeId);
-
-        const incomingEdges = edges.filter((e) => e.target === currentNodeId);
-
-        for (const edge of incomingEdges) {
-          const sourceNode = nodes.find((n) => n.id === edge.source);
-          if (isProviderNode(sourceNode)) {
-            if (!eventEdgeSet.has(edge.id) && !extraProviderEdges.some(e => e.id === edge.id)) {
-              extraProviderEdges.push(edge);
-            }
-            nodesToCheck.push(sourceNode!.id);
-          }
-        }
-      }
-
-      return [...eventEdges, ...extraProviderEdges];
-    }
-    return eventEdges;
+    return edges.filter((edge) => eventEdgeSet.has(edge.id));
   }
 
-  const allIncomingEdges = edges.filter((edge) => edge.target === actualNode.id);
+  const incomingEdges = edges.filter((edge) => edge.target === actualNode.id);
   const previousNodeId = eventData?.previous_node_id;
 
-  let executionFlowEdge: Edge | null = null;
   if (previousNodeId) {
-    executionFlowEdge =
-      allIncomingEdges.find((edge) => edge.source === previousNodeId) || null;
+    const exactEdge = incomingEdges.find((edge) => edge.source === previousNodeId);
+    if (exactEdge) return [exactEdge];
 
-    if (!executionFlowEdge) {
-      const cleanPrevId = previousNodeId.includes("__")
-        ? previousNodeId.split("__")[0]
-        : previousNodeId;
-      executionFlowEdge =
-        allIncomingEdges.find((edge) =>
-          edge.source.startsWith(cleanPrevId + "__") || edge.source === cleanPrevId
-        ) || null;
-    }
+    const cleanPreviousNodeId = previousNodeId.includes("__")
+      ? previousNodeId.split("__")[0]
+      : previousNodeId;
+    const compatibleEdge = incomingEdges.find(
+      (edge) =>
+        edge.source === cleanPreviousNodeId ||
+        edge.source.startsWith(`${cleanPreviousNodeId}__`)
+    );
+    if (compatibleEdge) return [compatibleEdge];
   }
 
-  const providerInputEdges = isProcessorNode(actualNode)
-    ? allIncomingEdges.filter((edge) => {
-      if (executionFlowEdge && edge.id === executionFlowEdge.id) return false;
-      const sourceNode = nodes.find((node) => node.id === edge.source);
-      return isProviderNode(sourceNode);
-    })
-    : [];
-
-  const edgesToAnimate: Edge[] = [];
-  if (executionFlowEdge) {
-    edgesToAnimate.push(executionFlowEdge);
-  } else if (!previousNodeId && allIncomingEdges.length === 1) {
-    edgesToAnimate.push(allIncomingEdges[0]);
-  }
-
-  edgesToAnimate.push(...providerInputEdges);
-  return edgesToAnimate;
+  // Ambiguous legacy events must not guess. Current GraphBuilder events always
+  // carry stable edge IDs, including branching and dependency executions.
+  return incomingEdges.length === 1 ? incomingEdges : [];
 };
 
 function FlowCanvas({ workflowId }: FlowCanvasProps) {
@@ -325,14 +421,37 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
   const [isTutorialOpen, setIsTutorialOpen] = useState(false);
   const [isLogPanelOpen, setIsLogPanelOpen] = useState(false);
   const [logPanelHeight, setLogPanelHeight] = useState(280);
-  const [activeEdges, setActiveEdges] = useState<string[]>([]);
   const [activeNodes, setActiveNodes] = useState<string[]>([]);
-  const [nodeStatus, setNodeStatus] = useState<
-    Record<string, "success" | "failed" | "pending">
-  >({});
-  const [edgeStatus, setEdgeStatus] = useState<
-    Record<string, "success" | "failed" | "pending">
-  >({});
+  const [nodeStatus, setNodeStatus] = useState<Record<string, NodeStatus>>({});
+  const [edgeStatus, setEdgeStatus] = useState<Record<string, NodeStatus>>({});
+
+  // Edge animation and edge color now share one source of truth. The setter
+  // adapter preserves existing listener call sites while writing edgeStatus.
+  const setActiveEdges = useCallback<
+    React.Dispatch<React.SetStateAction<string[]>>
+  >((nextActiveEdges) => {
+    setEdgeStatus((currentStatuses) => {
+      const currentActiveEdges = Object.entries(currentStatuses)
+        .filter(([, status]) => status === "pending")
+        .map(([edgeId]) => edgeId);
+      const resolvedActiveEdges =
+        typeof nextActiveEdges === "function"
+          ? nextActiveEdges(currentActiveEdges)
+          : nextActiveEdges;
+      const activeEdgeIds = new Set(resolvedActiveEdges);
+      const nextStatuses = { ...currentStatuses };
+
+      Object.entries(nextStatuses).forEach(([edgeId, status]) => {
+        if (status === "pending" && !activeEdgeIds.has(edgeId)) {
+          delete nextStatuses[edgeId];
+        }
+      });
+      activeEdgeIds.forEach((edgeId) => {
+        nextStatuses[edgeId] = "pending";
+      });
+      return nextStatuses;
+    });
+  }, []);
   const [activeExecutionId, setActiveExecutionId] = useState<string | null>(null);
   const [isManualExecutionRunning, setIsManualExecutionRunning] = useState(false);
 
@@ -732,27 +851,6 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
   const handleErrorDismiss = useCallback(() => {
     setDetailedExecutionError(null);
     setErrorNodeId(null);
-
-    // Reset all failed statuses
-    setNodeStatus((s) => {
-      const newStatus = { ...s };
-      Object.keys(newStatus).forEach((key) => {
-        if (newStatus[key] === "failed") {
-          delete newStatus[key];
-        }
-      });
-      return newStatus;
-    });
-
-    setEdgeStatus((s) => {
-      const newStatus = { ...s };
-      Object.keys(newStatus).forEach((key) => {
-        if (newStatus[key] === "failed") {
-          delete newStatus[key];
-        }
-      });
-      return newStatus;
-    });
   }, []);
 
   useEffect(() => {
@@ -1364,10 +1462,14 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
 
       try {
         // Reset previous statuses
-        setNodeStatus({});
+        setNodeStatus({ [nodeId]: "pending" });
         setEdgeStatus({});
 
         let lastExecutionId: string | null = null;
+        let liveNodeOutputs: Record<string, any> = {};
+        const liveExecutedNodes = new Set<string>();
+        const liveStartedAt = new Date().toISOString();
+        let liveSessionId: string | undefined;
 
         streamCancelledByUserRef.current = false;
         setIsManualExecutionRunning(true);
@@ -1399,9 +1501,32 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
           trigger_source: "start_node_double_click",
         };
 
-        // Remove legacy pre-animation; rely solely on streaming events
+        const publishLiveExecution = (
+          status: "running" | "completed" | "failed",
+          result: any = "",
+          completedAt?: string
+        ) => {
+          const executionId = lastExecutionId || `manual-${currentWorkflow.id}`;
+          setCurrentExecutionForWorkflow(currentWorkflow.id, {
+            id: executionId,
+            workflow_id: currentWorkflow.id,
+            input_text: executionData.input_text,
+            result: {
+              result,
+              executed_nodes: Array.from(liveExecutedNodes),
+              node_outputs: { ...liveNodeOutputs },
+              session_id: liveSessionId,
+              status,
+            },
+            started_at: liveStartedAt,
+            ...(completedAt ? { completed_at: completedAt } : {}),
+            status,
+          } as any);
+        };
+
+        // The Start node is the first real execution step on the canvas.
         setActiveEdges([]);
-        setActiveNodes([]);
+        setActiveNodes([nodeId]);
 
         // Streaming execution to reflect real-time node/edge status
         try {
@@ -1409,6 +1534,28 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
             ...executionData,
             workflow_id: currentWorkflow.id,
           });
+
+          // Opening the execution stream means Start completed successfully.
+          // Its outgoing edge must remain green even if a later node fails.
+          setNodeStatus((s) => ({ ...s, [nodeId]: "success" }));
+          setActiveNodes([]);
+          const startNode = nodes.find((node) => node.id === nodeId);
+          liveNodeOutputs = reduceLiveNodeEvent(liveNodeOutputs, nodeId, {
+            type: "node_end",
+            output: {
+              success: true,
+              statusCode: 200,
+              nodeId,
+              nodeType: startNode?.type,
+              timestamp: new Date().toISOString(),
+              executionTimeMs: 0,
+              inputs: {},
+              output: null,
+              error: null,
+            },
+          });
+          liveExecutedNodes.add(nodeId);
+          publishLiveExecution("running");
 
           const reader = stream.getReader();
           activeReaderRef.current = reader;
@@ -1432,35 +1579,51 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
                   lastExecutionId = evt.execution_id;
                   activeExecutionIdRef.current = evt.execution_id;
                   setActiveExecutionId(evt.execution_id);
-                  const currentExec = getCurrentExecutionForWorkflow(currentWorkflow.id);
-                  if (!currentExec || currentExec.id !== evt.execution_id || currentExec.status !== "running") {
-                    setCurrentExecutionForWorkflow(currentWorkflow.id, {
-                      id: evt.execution_id,
-                      workflow_id: currentWorkflow.id,
-                      status: "running",
-                      started_at: new Date().toISOString(),
-                    } as any);
-                  }
                 }
+                liveSessionId = evt.session_id ?? liveSessionId;
                 const t = evt.type as string | undefined;
-                if (t === "node_start") {
-                  const nid = String(evt.node_id || "");
+                const rawNid = String(evt.node_id || "");
+                const resolvedNode = rawNid ? findCanvasNode(nodes, rawNid) : undefined;
+                const targetNodeId = resolvedNode?.id || rawNid;
 
-                  if (nid) {
-                    setActiveNodes([nid]);
-                    setNodeStatus((s) => ({ ...s, [nid]: "pending" }));
+                if (t === "node_status") {
+                  if (targetNodeId) {
+                    liveNodeOutputs = reduceLiveNodeEvent(
+                      liveNodeOutputs,
+                      targetNodeId,
+                      evt
+                    );
+                    if (evt.status === "success" || evt.status === "failed") {
+                      liveExecutedNodes.add(targetNodeId);
+                    }
+                    publishLiveExecution("running");
+                  }
+                  applyRuntimeNodeStatusEvent(
+                    evt,
+                    nodes,
+                    edges as Edge[],
+                    setNodeStatus,
+                    setActiveNodes,
+                    setActiveEdges,
+                    setEdgeStatus
+                  );
+                } else if (t === "node_start") {
+                  if (targetNodeId) {
+                    liveNodeOutputs = reduceLiveNodeEvent(
+                      liveNodeOutputs,
+                      targetNodeId,
+                      evt
+                    );
+                    publishLiveExecution("running");
+                    setActiveNodes([targetNodeId]);
+                    setNodeStatus((s) => ({ ...s, [targetNodeId]: "pending" }));
 
-                    const currentNode = nodes.find((n) => n.id === nid);
-                    const edgesToAnimate = currentNode
-                      ? resolveExecutionEdges(evt, currentNode, nodes, edges as Edge[])
+                    const actualNode = resolvedNode || nodes.find((n) => n.id === targetNodeId);
+                    const edgesToAnimate = actualNode
+                      ? resolveExecutionEdges(evt, actualNode, nodes, edges as Edge[])
                       : [];
 
                     if (edgesToAnimate.length > 0) {
-                      console.log(
-                        "StartNode: Setting edges as pending:",
-                        edgesToAnimate.map(e => e.id),
-                        `(${edgesToAnimate.length} edges to ${nid})`
-                      );
                       setActiveEdges(edgesToAnimate.map((e) => e.id));
                       setEdgeStatus((s) => ({
                         ...s,
@@ -1471,41 +1634,73 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
                     }
                   }
                 } else if (t === "node_end") {
-                  const nid = String(evt.node_id || "");
-                  if (nid) {
-                    setNodeStatus((s) => ({ ...s, [nid]: "success" }));
-                    // Only mark pending edges as success
-                    setEdgeStatus((s) => {
-                      const updated = { ...s };
-                      Object.keys(updated).forEach((edgeId) => {
-                        const edge = (edges as Edge[]).find((e) => e.id === edgeId);
-                        if (edge && edge.target === nid && updated[edgeId] === "pending") {
-                          updated[edgeId] = "success";
-                        }
-                      });
-                      return updated;
-                    });
+                  if (targetNodeId) {
+                    liveNodeOutputs = reduceLiveNodeEvent(
+                      liveNodeOutputs,
+                      targetNodeId,
+                      evt
+                    );
+                    liveExecutedNodes.add(targetNodeId);
+                    publishLiveExecution("running");
+                    setNodeStatus((s) => ({ ...s, [targetNodeId]: "success" }));
+                    // Only edges reported as transmitted by the backend become successful.
+                    const actualNode = resolvedNode || nodes.find((n) => n.id === targetNodeId);
+                    const completedEdges = actualNode
+                      ? resolveExecutionEdges(evt, actualNode, nodes, edges as Edge[])
+                      : [];
+                    setEdgeStatus((s) => ({
+                      ...s,
+                      ...Object.fromEntries(
+                        completedEdges.map((edge) => [edge.id, "success" as const])
+                      ),
+                    }));
                   }
                 } else if (t === "error") {
-                  // Use evt.node_id directly (not stale closure activeNodes)
-                  const failedNodeId = evt.node_id ? String(evt.node_id) : undefined;
-                  setErrorNodeId(failedNodeId || null);
-
+                  const failedNodeId = resolvedNode?.id || rawNid || undefined;
+                  liveNodeOutputs = mergeLiveNodeOutputMaps(
+                    liveNodeOutputs,
+                    normalizeNodeOutputs(evt.node_outputs || {}, nodes)
+                  );
+                  (evt.executed_nodes || []).forEach((executedNodeId: string) => {
+                    const executedNode = findCanvasNode(nodes, String(executedNodeId));
+                    liveExecutedNodes.add(executedNode?.id || String(executedNodeId));
+                  });
                   if (failedNodeId) {
-                    setNodeStatus((s) => ({ ...s, [failedNodeId]: "failed" }));
+                    liveNodeOutputs = ensureLiveNodeFailure(
+                      liveNodeOutputs,
+                      failedNodeId,
+                      evt
+                    );
+                    liveExecutedNodes.add(failedNodeId);
                   }
-                  // Mark edges to the failed node as failed
-                  if (failedNodeId) {
-                    setEdgeStatus((s) => {
-                      const updated = { ...s };
-                      (edges as Edge[]).forEach((edge) => {
-                        if (edge.target === failedNodeId) {
-                          updated[edge.id] = "failed";
-                        }
-                      });
-                      return updated;
+                  const isFirstStreamError = !streamHadError;
+                  setErrorNodeId(failedNodeId || null);
+                  setIsManualExecutionRunning(false);
+
+                  setNodeStatus((current) =>
+                    mergeReportedNodeStatuses(
+                      current,
+                      evt.node_statuses,
+                      nodes,
+                      failedNodeId
+                    )
+                  );
+                  setEdgeStatus((current) =>
+                    mergeReportedEdgeStatuses(
+                      current,
+                      evt.edge_statuses,
+                      getEventEdgeIds(evt)
+                    )
+                  );
+
+                  if (isFirstStreamError) {
+                    enqueueSnackbar(evt.error || "Workflow execution failed", {
+                      variant: "error",
                     });
                   }
+                  // Clear active animation state on error
+                  setActiveEdges([]);
+                  setActiveNodes([]);
 
                   // Create detailed error for display
                   const errorDetails = {
@@ -1522,45 +1717,31 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
 
                   setDetailedExecutionError(errorDetails);
                   streamHadError = true;
-                  streamErrorMessage = evt.error || "Node execution failed";
 
-                  // Store the failed execution result in the store so that nodes reflect the current failed state outputs
-                  const executionResult = {
-                    id: evt.execution_id || Date.now().toString(),
-                    workflow_id: currentWorkflow.id,
-                    input_text: executionData.input_text,
-                    result: {
-                      result: `ERROR: ${evt.error || "Workflow execution failed"}`,
-                      executed_nodes: evt.executed_nodes || [],
-                      node_outputs: evt.node_outputs || {},
-                      session_id: evt.session_id,
-                      status: "failed" as const,
-                    },
-                    started_at: new Date().toISOString(),
-                    completed_at: new Date().toISOString(),
-                    status: "failed" as const,
-                  };
-
-                  setCurrentExecutionForWorkflow(currentWorkflow.id, executionResult);
-                } else if (t === "complete") {
-                  // Store the execution result in the store
-                  const executionResult = {
-                    id: evt.execution_id || Date.now().toString(),
-                    workflow_id: currentWorkflow.id,
-                    input_text: executionData.input_text,
-                    result: {
-                      result: evt.result,
-                      executed_nodes: evt.executed_nodes,
-                      node_outputs: evt.node_outputs,
-                      session_id: evt.session_id,
-                      status: "completed" as const,
-                    },
-                    started_at: new Date().toISOString(),
-                    completed_at: new Date().toISOString(),
-                    status: "completed" as const,
-                  };
-
-                  setCurrentExecutionForWorkflow(currentWorkflow.id, executionResult);
+                  publishLiveExecution(
+                    "failed",
+                    `ERROR: ${evt.error || "Workflow execution failed"}`,
+                    new Date().toISOString()
+                  );
+                } else if (t === "complete" && !streamHadError) {
+                  setNodeStatus((current) =>
+                    mergeReportedNodeStatuses(current, evt.node_statuses, nodes));
+                  setEdgeStatus((current) =>
+                    mergeReportedEdgeStatuses(current, evt.edge_statuses)
+                  );
+                  liveNodeOutputs = mergeLiveNodeOutputMaps(
+                    liveNodeOutputs,
+                    normalizeNodeOutputs(evt.node_outputs || {}, nodes)
+                  );
+                  (evt.executed_nodes || []).forEach((executedNodeId: string) => {
+                    const executedNode = findCanvasNode(nodes, String(executedNodeId));
+                    liveExecutedNodes.add(executedNode?.id || String(executedNodeId));
+                  });
+                  publishLiveExecution(
+                    "completed",
+                    evt.result,
+                    new Date().toISOString()
+                  );
 
                   setTimeout(() => {
                     setActiveEdges([]);
@@ -1575,7 +1756,6 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
 
           // Track streaming error state
           let streamHadError = false;
-          let streamErrorMessage = "";
 
           // Pump the stream
           // We intentionally do not await the entire stream to keep UI responsive
@@ -1612,7 +1792,20 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
                   try {
                     const finalExecution = await getExecution(execIdToFetch);
                     if (finalExecution) {
-                      setCurrentExecutionForWorkflow(currentWorkflow.id, normalizeExecutionForCanvas(finalExecution, nodes));
+                      const normalizedFinal = normalizeExecutionForCanvas(finalExecution, nodes);
+                      const finalNodeOutputs = normalizedFinal?.result?.node_outputs || {};
+                      normalizedFinal.result = {
+                        ...normalizedFinal.result,
+                        node_outputs: mergeLiveNodeOutputMaps(
+                          liveNodeOutputs,
+                          finalNodeOutputs
+                        ),
+                        executed_nodes: Array.from(new Set([
+                          ...liveExecutedNodes,
+                          ...(normalizedFinal.result?.executed_nodes || []),
+                        ])),
+                      };
+                      setCurrentExecutionForWorkflow(currentWorkflow.id, normalizedFinal);
                       if (finalExecution.status === "cancelled" || finalExecution.status === "failed") {
                         setActiveEdges([]);
                         setActiveNodes([]);
@@ -1653,19 +1846,26 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
 
         setDetailedExecutionError(errorDetails);
 
-        // Mark failed node/edges
-        if (failedNodeId) {
-          setNodeStatus((s) => ({ ...s, [failedNodeId]: "failed" }));
-          setEdgeStatus((s) => {
-            const updated = { ...s };
-            (edges as Edge[]).forEach((edge) => {
-              if (edge.target === failedNodeId) {
-                updated[edge.id] = "failed";
-              }
-            });
-            return updated;
-          });
-        }
+        setNodeStatus((current) =>
+          mergeReportedNodeStatuses(
+            current,
+            error.node_statuses,
+            nodes,
+            failedNodeId
+          )
+        );
+        setEdgeStatus((current) =>
+          mergeReportedEdgeStatuses(
+            current,
+            error.edge_statuses,
+            getEventEdgeIds(error)
+          )
+        );
+        setActiveEdges([]);
+        setActiveNodes([]);
+        enqueueSnackbar(error.message || "Workflow execution failed", {
+          variant: "error",
+        });
       }
     },
     [
@@ -2099,18 +2299,13 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
     setFullscreenModal({ isOpen: false });
   }, []);
 
-  // Edge'leri render ederken CustomEdge'a isActive prop'u ilet
   const edgeTypes = useMemo(
     () => ({
-      custom: (edgeProps: any) => (
-        <CustomEdge
-          {...edgeProps}
-          isActive={activeEdges.includes(edgeProps.id)}
-        />
-      ),
+      custom: (edgeProps: any) => <CustomEdge {...edgeProps} />,
     }),
-    [activeEdges]
+    []
   );
+
 
   return (
     <>
@@ -2217,7 +2412,7 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
             onConnect={onConnect}
             nodeTypes={nodeTypes as any}
             edgeTypes={edgeTypes}
-            activeEdges={activeEdges}
+            activeNodes={activeNodes}
             reactFlowWrapper={reactFlowWrapper}
             onDrop={onDrop}
             onDragOver={onDragOver}
@@ -2297,13 +2492,10 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
                   d="M8 10h.01M12 10h.01M16 10h.01M21 12c0 4.418-4.03 8-9 8a9.77 9.77 0 01-4-.8L3 20l.8-3.2A7.96 7.96 0 013 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
                 />
               </svg>
-              {chatOpen && (
-                <div className="absolute -top-1 -right-1 w-2 h-2 bg-green-400 rounded-full animate-pulse"></div>
-              )}
             </div>
             <span className="font-medium text-sm">Chat</span>
             {chatOpen && (
-              <div className="w-1 h-1 bg-white rounded-full animate-ping"></div>
+              <div className="w-1.5 h-1.5 bg-green-400 rounded-full"></div>
             )}
           </button>
 
@@ -2574,13 +2766,60 @@ function useChatExecutionListener(
       setActiveNodes([]);
     };
 
-    const handleChatExecutionComplete = () => {
+    const handleChatExecutionComplete = (event: CustomEvent) => {
+      setNodeStatus((current) =>
+        mergeReportedNodeStatuses(current, event.detail?.node_statuses, nodes));
+      setEdgeStatus((current) =>
+        mergeReportedEdgeStatuses(current, event.detail?.edge_statuses)
+      );
+      setActiveEdges([]);
+      setActiveNodes([]);
+    };
+
+    const handleChatExecutionError = (event: CustomEvent) => {
+      const detail = event.detail || {};
+      const targetId = detail.node_id || detail.nodeId;
+      const actualNode = targetId ? findCanvasNode(nodes, targetId) : undefined;
+
+      setNodeStatus((current) => {
+        const fallbackFailedNodeId =
+          actualNode?.id || Object.keys(current).find((key) => current[key] === "pending");
+        return mergeReportedNodeStatuses(
+          current,
+          detail.node_statuses,
+          nodes,
+          fallbackFailedNodeId
+        );
+      });
+
+      setEdgeStatus((current) =>
+        mergeReportedEdgeStatuses(
+          current,
+          detail.edge_statuses,
+          getEventEdgeIds(detail)
+        )
+      );
+
+
       setActiveEdges([]);
       setActiveNodes([]);
     };
 
     const handleChatExecutionEvent = (event: CustomEvent) => {
       const { event: eventType, node_id, ...data } = event.detail;
+
+      if (eventType === "node_status") {
+        applyRuntimeNodeStatusEvent(
+          { node_id, ...data },
+          nodes,
+          edges,
+          setNodeStatus,
+          setActiveNodes,
+          setActiveEdges,
+          setEdgeStatus
+        );
+        return;
+      }
 
       if (eventType === "node_start" && node_id) {
         const actualNode = findCanvasNode(nodes, node_id);
@@ -2637,6 +2876,10 @@ function useChatExecutionListener(
           }
         }
       }
+
+      if (eventType === "error" || eventType === "node_error") {
+        handleChatExecutionError(event);
+      }
     };
 
     window.addEventListener(
@@ -2646,6 +2889,10 @@ function useChatExecutionListener(
     window.addEventListener(
       "chat-execution-event",
       handleChatExecutionEvent as EventListener
+    );
+    window.addEventListener(
+      "chat-execution-error",
+      handleChatExecutionError as EventListener
     );
     window.addEventListener(
       "chat-execution-complete",
@@ -2660,6 +2907,10 @@ function useChatExecutionListener(
       window.removeEventListener(
         "chat-execution-event",
         handleChatExecutionEvent as EventListener
+      );
+      window.removeEventListener(
+        "chat-execution-error",
+        handleChatExecutionError as EventListener
       );
       window.removeEventListener(
         "chat-execution-complete",
@@ -3048,6 +3299,18 @@ function useWebhookExecutionListener(
               }
 
               // Handle node_start events
+              if (eventType === "node_status") {
+                applyRuntimeNodeStatusEvent(
+                  executionEvent,
+                  currentNodes,
+                  currentEdges,
+                  setNodeStatus,
+                  setActiveNodes,
+                  setActiveEdges,
+                  setEdgeStatus
+                );
+              }
+
               if (eventType === "node_start" && node_id) {
                 const actualNode = findCanvasNode(currentNodes, node_id);
                 console.log("[WebhookListener] node_start details:", { node_id, actualNodeId: actualNode?.id });
@@ -3096,6 +3359,12 @@ function useWebhookExecutionListener(
                           nodeId: actualNode.id,
                           nodeType: actualNode.type,
                           stackTrace: ev.stack_trace,
+                          node_statuses: ev.node_statuses,
+                          edge_statuses: ev.edge_statuses,
+                          edge_ids: ev.edge_ids,
+                          incoming_edge_ids: ev.incoming_edge_ids,
+                          active_edge_ids: ev.active_edge_ids,
+                          executionNodeId: ev.execution_node_id,
                         },
                       })
                     );
@@ -3175,6 +3444,16 @@ function useWebhookExecutionListener(
               if (eventType === "complete" || eventType === "workflow_complete") {
                 console.log("[WebhookListener] complete / workflow_complete UI reset.");
                 clearFallbackTimeout();
+                setNodeStatus((current) =>
+                  mergeReportedNodeStatuses(
+                    current,
+                    executionEvent.node_statuses,
+                    currentNodes
+                  )
+                );
+                setEdgeStatus((current) =>
+                  mergeReportedEdgeStatuses(current, executionEvent.edge_statuses)
+                );
                 throttledUpdate(() => {
                   setActiveEdges([]);
                   setActiveNodes([]);
@@ -3194,6 +3473,12 @@ function useWebhookExecutionListener(
                       type: ev.error_type || "execution",
                       nodeId: ev.node_id,
                       stackTrace: ev.stack_trace,
+                      node_statuses: ev.node_statuses,
+                      edge_statuses: ev.edge_statuses,
+                      edge_ids: ev.edge_ids,
+                      incoming_edge_ids: ev.incoming_edge_ids,
+                      active_edge_ids: ev.active_edge_ids,
+                      executionNodeId: ev.execution_node_id,
                     },
                   })
                 );
@@ -3445,6 +3730,18 @@ function useKafkaExecutionListener(
 
             const execData = executionData.get(executionId)!;
 
+            if (eventType === "node_status") {
+              applyRuntimeNodeStatusEvent(
+                executionEvent,
+                currentNodes,
+                currentEdges,
+                setNodeStatus,
+                setActiveNodes,
+                setActiveEdges,
+                setEdgeStatus
+              );
+            }
+
             if (eventType === "node_start" && nodeId) {
               const actualNode = findCanvasNode(currentNodes, nodeId);
               const targetId = actualNode ? actualNode.id : nodeId;
@@ -3494,6 +3791,12 @@ function useKafkaExecutionListener(
                         nodeId: actualNode.id,
                         nodeType: actualNode.type,
                         stackTrace: executionEvent.stack_trace,
+                        node_statuses: executionEvent.node_statuses,
+                        edge_statuses: executionEvent.edge_statuses,
+                        edge_ids: executionEvent.edge_ids,
+                        incoming_edge_ids: executionEvent.incoming_edge_ids,
+                        active_edge_ids: executionEvent.active_edge_ids,
+                        executionNodeId: executionEvent.execution_node_id,
                       },
                     })
                   );
@@ -3570,6 +3873,12 @@ function useKafkaExecutionListener(
                     type: ev.error_type || "execution",
                     nodeId: ev.node_id,
                     stackTrace: ev.stack_trace,
+                    node_statuses: ev.node_statuses,
+                    edge_statuses: ev.edge_statuses,
+                    edge_ids: ev.edge_ids,
+                    incoming_edge_ids: ev.incoming_edge_ids,
+                    active_edge_ids: ev.active_edge_ids,
+                    executionNodeId: ev.execution_node_id,
                   },
                 })
               );
@@ -3613,6 +3922,16 @@ function useKafkaExecutionListener(
             if (eventType === "complete" || eventType === "workflow_complete") {
               console.log("[KafkaListener] complete / workflow_complete event received. Saving execution to store.");
               clearFallbackTimeout();
+              setNodeStatus((current) =>
+                mergeReportedNodeStatuses(
+                  current,
+                  executionEvent.node_statuses,
+                  currentNodes
+                )
+              );
+              setEdgeStatus((current) =>
+                mergeReportedEdgeStatuses(current, executionEvent.edge_statuses)
+              );
               execData.completedAt = data.timestamp || new Date().toISOString();
               execData.result = executionEvent.result;
               if (executionEvent.node_outputs) {
@@ -3841,6 +4160,18 @@ function useErrorTriggerExecutionListener(
 
           const execData = executionData.get(executionId)!;
 
+          if (eventType === "node_status") {
+            applyRuntimeNodeStatusEvent(
+              executionEvent,
+              currentNodes,
+              currentEdges,
+              setNodeStatus,
+              setActiveNodes,
+              setActiveEdges,
+              setEdgeStatus
+            );
+          }
+
           if (eventType === "node_start" && nodeId) {
             const actualNode = findCanvasNode(currentNodes, nodeId);
             const targetId = actualNode ? actualNode.id : nodeId;
@@ -3886,6 +4217,12 @@ function useErrorTriggerExecutionListener(
                       nodeId: actualNode.id,
                       nodeType: actualNode.type,
                       stackTrace: executionEvent.stack_trace,
+                      node_statuses: executionEvent.node_statuses,
+                      edge_statuses: executionEvent.edge_statuses,
+                      edge_ids: executionEvent.edge_ids,
+                      incoming_edge_ids: executionEvent.incoming_edge_ids,
+                      active_edge_ids: executionEvent.active_edge_ids,
+                      executionNodeId: executionEvent.execution_node_id,
                     },
                   })
                 );
@@ -3960,6 +4297,12 @@ function useErrorTriggerExecutionListener(
                   type: ev.error_type || "execution",
                   nodeId: ev.node_id,
                   stackTrace: ev.stack_trace,
+                  node_statuses: ev.node_statuses,
+                  edge_statuses: ev.edge_statuses,
+                  edge_ids: ev.edge_ids,
+                  incoming_edge_ids: ev.incoming_edge_ids,
+                  active_edge_ids: ev.active_edge_ids,
+                  executionNodeId: ev.execution_node_id,
                 },
               })
             );
@@ -4002,6 +4345,18 @@ function useErrorTriggerExecutionListener(
 
           if (eventType === "complete" || eventType === "workflow_complete") {
             clearFallbackTimeout();
+            setNodeStatus((current) =>
+              mergeReportedNodeStatuses(
+                current,
+                executionEvent.node_statuses,
+                currentNodes
+              )
+            );
+            setEdgeStatus((current) =>
+              mergeReportedEdgeStatuses(current, executionEvent.edge_statuses)
+            );
+            setActiveEdges([]);
+            setActiveNodes([]);
             execData.completedAt = data.timestamp || new Date().toISOString();
             execData.result = executionEvent.result;
             if (executionEvent.node_outputs) {
@@ -4215,6 +4570,18 @@ function useTimerExecutionListener(
 
               console.log("[TimerListener] Processing event:", { type: eventType, node_id });
 
+              if (eventType === "node_status") {
+                applyRuntimeNodeStatusEvent(
+                  executionEvent,
+                  currentNodesList,
+                  currentEdgesList as Edge[],
+                  setNodeStatus,
+                  setActiveNodes,
+                  setActiveEdges,
+                  setEdgeStatus
+                );
+              }
+
               if (eventType === "node_start") {
                 if (node_id) {
                   const actualNode = findCanvasNode(currentNodesList, node_id);
@@ -4266,23 +4633,37 @@ function useTimerExecutionListener(
                           nodeId: actualNode.id,
                           nodeType: actualNode.type,
                           stackTrace: ev.stack_trace,
+                          node_statuses: ev.node_statuses,
+                          edge_statuses: ev.edge_statuses,
+                          edge_ids: ev.edge_ids,
+                          incoming_edge_ids: ev.incoming_edge_ids,
+                          active_edge_ids: ev.active_edge_ids,
+                          executionNodeId: ev.execution_node_id,
                         },
                       })
                     );
                   }
 
                   if (actualNode) {
-                    setNodeStatus((s) => ({ ...s, [actualNode.id]: isError ? "failed" : "success" }));
-                    setEdgeStatus((s) => {
-                      const updated = { ...s };
-                      Object.keys(updated).forEach((edgeId) => {
-                        const edge = (currentEdgesList as Edge[]).find((e) => e.id === edgeId);
-                        if (edge && edge.target === actualNode.id && updated[edgeId] === "pending") {
-                          updated[edgeId] = isError ? "failed" : "success";
-                        }
-                      });
-                      return updated;
-                    });
+                    const completedEdges = resolveExecutionEdges(
+                      executionEvent,
+                      actualNode,
+                      currentNodesList,
+                      currentEdgesList as Edge[]
+                    );
+                    setNodeStatus((s) => ({
+                      ...s,
+                      [actualNode.id]: isError ? "failed" : "success",
+                    }));
+                    setEdgeStatus((s) => ({
+                      ...s,
+                      ...Object.fromEntries(
+                        completedEdges.map((edge) => [
+                          edge.id,
+                          isError ? ("failed" as const) : ("success" as const),
+                        ])
+                      ),
+                    }));
                   }
 
                   // Incrementally update execution in store
@@ -4362,22 +4743,16 @@ function useTimerExecutionListener(
                       nodeId: actualFailedNode?.id || failedNodeId,
                       nodeType: actualFailedNode?.type,
                       stackTrace: ev.stack_trace,
+                      node_statuses: ev.node_statuses,
+                      edge_statuses: ev.edge_statuses,
+                      edge_ids: ev.edge_ids,
+                      incoming_edge_ids: ev.incoming_edge_ids,
+                      active_edge_ids: ev.active_edge_ids,
+                      executionNodeId: ev.execution_node_id,
                     },
                   })
                 );
 
-                if (failedNodeId) {
-                  setNodeStatus((s) => ({ ...s, [failedNodeId]: "failed" }));
-                  setEdgeStatus((s) => {
-                    const updated = { ...s };
-                    (currentEdgesList as Edge[]).forEach((edge) => {
-                      if (edge.target === failedNodeId) {
-                        updated[edge.id] = "failed";
-                      }
-                    });
-                    return updated;
-                  });
-                }
 
                 if (currentWorkflowId && setCurrentExecutionForWorkflow) {
                   setCurrentExecutionForWorkflow(currentWorkflowId, {
@@ -4397,6 +4772,16 @@ function useTimerExecutionListener(
                 }
               } else if (eventType === "complete" || eventType === "workflow_complete") {
                 clearFallbackTimeout();
+                setNodeStatus((current) =>
+                  mergeReportedNodeStatuses(
+                    current,
+                    executionEvent.node_statuses,
+                    currentNodesList
+                  )
+                );
+                setEdgeStatus((current) =>
+                  mergeReportedEdgeStatuses(current, executionEvent.edge_statuses)
+                );
                 execData.completedAt = data.timestamp || new Date().toISOString();
                 execData.result = executionEvent.result;
                 if (executionEvent.node_outputs) {

--- a/client/app/components/canvas/ReactFlowCanvas.tsx
+++ b/client/app/components/canvas/ReactFlowCanvas.tsx
@@ -13,6 +13,10 @@ import {
   type Connection,
 } from "@xyflow/react";
 import CustomEdge from "../common/CustomEdge";
+import {
+  getEdgeExecutionStatus,
+  getEffectiveNodeStatus,
+} from "~/lib/nodeStatusUtils";
 
 interface ReactFlowCanvasProps {
   nodes: Node[];
@@ -22,7 +26,7 @@ interface ReactFlowCanvasProps {
   onConnect: (connection: Connection) => void;
   nodeTypes: any;
   edgeTypes: any;
-  activeEdges: string[];
+  activeNodes: string[];
   reactFlowWrapper: React.RefObject<HTMLDivElement | null>;
   onDrop: (event: React.DragEvent) => void;
   onDragOver: (event: React.DragEvent) => void;
@@ -41,7 +45,7 @@ export default function ReactFlowCanvas({
   onConnect,
   nodeTypes,
   edgeTypes,
-  activeEdges,
+  activeNodes,
   reactFlowWrapper,
   onDrop,
   onDragOver,
@@ -51,6 +55,8 @@ export default function ReactFlowCanvas({
   onNodeContextMenu,
   onPaneClick,
 }: ReactFlowCanvasProps) {
+  const activeNodeIds = new Set(activeNodes);
+
   return (
     <div
       ref={reactFlowWrapper}
@@ -60,24 +66,28 @@ export default function ReactFlowCanvas({
     >
       <ReactFlow
         nodes={nodes.map((node) => {
-          const status = nodeStatus[node.id];
-          const statusStyle =
-            status === 'success'
-              ? { outline: '2px solid #22c55e', outlineOffset: 2, borderRadius: 12 }
-              : status === 'failed'
-                ? { outline: '2px solid #ef4444', outlineOffset: 2, borderRadius: 12 }
-                : {};
+          const reportedStatus = getEffectiveNodeStatus(node.id, nodeStatus, nodes, edges);
+          const status =
+            reportedStatus === "pending" && !activeNodeIds.has(node.id)
+              ? undefined
+              : reportedStatus;
           return {
             ...node,
-            style: { ...(node.style || {}), ...statusStyle },
-            data: { ...node.data },
+            data: {
+              ...(node.data || {}),
+              executionStatus: status,
+            },
           };
         })}
-        edges={edges.map((edge) => ({
-          ...edge,
-          data: { ...(edge.data || {}), status: edgeStatus[edge.id] },
-          style: { ...(edge.style || {}), __status: edgeStatus[edge.id] },
-        }))}
+        edges={edges.map((edge) => {
+          const status = getEdgeExecutionStatus(edge, edgeStatus);
+
+          return {
+            ...edge,
+            data: { ...(edge.data || {}), status },
+            style: { ...(edge.style || {}), __status: status },
+          };
+        })}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
         onConnect={onConnect}

--- a/client/app/components/common/CustomEdge.tsx
+++ b/client/app/components/common/CustomEdge.tsx
@@ -8,10 +8,6 @@ import {
 } from "@xyflow/react";
 import { X } from "lucide-react";
 
-interface CustomAnimatedEdgeProps extends EdgeProps {
-  isActive?: boolean;
-}
-
 function CustomAnimatedEdge({
   id,
   sourceX,
@@ -22,12 +18,12 @@ function CustomAnimatedEdge({
   targetPosition,
   style = {},
   markerEnd,
-  isActive = false,
-}: CustomAnimatedEdgeProps) {
+}: EdgeProps) {
   const { setEdges } = useReactFlow();
   const [isHovered, setIsHovered] = React.useState(false);
   // read status that ReactFlowCanvas injected into edge.data
   const status: 'success' | 'failed' | 'pending' | undefined = (style as any)?.__status;
+  const isActive = status === "pending";
 
   const [edgePath, labelX, labelY] = getSmoothStepPath({
     sourceX,

--- a/client/app/components/common/Navbar.tsx
+++ b/client/app/components/common/Navbar.tsx
@@ -21,6 +21,10 @@ import WidgetExportModal from "../modals/WidgetExportModal";
 import ErrorWorkflowModal from "../modals/ErrorWorkflowModal";
 import WorkflowService from "~/services/workflows";
 import { useNodeStore } from "~/stores/nodes";
+import {
+  getWorkflowJsonErrorMessage,
+  parseWorkflowJson,
+} from "~/lib/workflowJson";
 
 interface NavbarProps {
   workflowName: string;
@@ -141,81 +145,110 @@ const Navbar: React.FC<NavbarProps> = ({
     enqueueSnackbar("Workflow name updated", { variant: "success" });
   };
 
-  const handleLoad = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
+  const handleLoad = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const input = e.currentTarget;
+    const file = input.files?.[0];
     if (!file) return;
-    const reader = new FileReader();
-    reader.onload = async (event) => {
-      try {
-        const json = JSON.parse(event.target?.result as string);
-        if (setCurrentWorkflow && setNodes && setEdges) {
-          let nodeStore = useNodeStore.getState();
-          if (nodeStore.nodes.length === 0) {
-            await nodeStore.fetchNodes();
-            await nodeStore.fetchCategories();
-          }
-          if (nodeStore.customNodes.length === 0) {
-            await nodeStore.fetchCustomNodes();
-          }
-          nodeStore = useNodeStore.getState();
 
-          const allNodesMetadata = [...(nodeStore.nodes || []), ...(nodeStore.customNodes || [])];
-          const enrichedNodes = (json.flow_data?.nodes || []).map((node: any) => {
-            if (!node.data?.metadata && allNodesMetadata.length > 0) {
-              const metadata = allNodesMetadata.find(
-                m => m.name === node.type || (m as any).id === node.type
-              ) as any;
-
-              if (metadata) {
-                return {
-                  ...node,
-                  data: {
-                    ...node.data,
-                    metadata: metadata,
-                    icon: metadata.icon,
-                    description: metadata.description,
-                    displayName: metadata.display_name,
-                    inputs: metadata.inputs,
-                    outputs: metadata.outputs,
-                  }
-                };
-              }
-            }
-            return node;
-          });
-
-          if (onImportStart) onImportStart();
-
-          if (currentWorkflow && setCurrentWorkflow) {
-            setCurrentWorkflow({
-              ...currentWorkflow,
-              name: json.name || currentWorkflow.name,
-              flow_data: {
-                ...currentWorkflow.flow_data,
-                nodes: enrichedNodes,
-                edges: json.flow_data?.edges || []
-              }
-            });
-          } else if (setCurrentWorkflow) {
-            setCurrentWorkflow(null);
-          }
-
-          setNodes(enrichedNodes);
-          setEdges(json.flow_data?.edges || []);
-          onWorkflowImported?.(enrichedNodes, json.flow_data?.edges || []);
-          if (json.name) {
-            setWorkflowName(json.name);
-          }
-          enqueueSnackbar("Workflow loaded successfully!", { variant: "success" });
-        }
-      } catch (err) {
-        console.error("Load error:", err);
-        enqueueSnackbar("Invalid JSON file!", { variant: "error" });
-      }
-    };
-    reader.readAsText(file);
     setIsDropdownOpen(false);
-    e.target.value = "";
+    input.value = "";
+
+    let importedWorkflow;
+    try {
+      importedWorkflow = parseWorkflowJson(await file.text());
+    } catch (error) {
+      console.error("Workflow JSON parse error:", error);
+      enqueueSnackbar(getWorkflowJsonErrorMessage(error), { variant: "error" });
+      return;
+    }
+
+    if (!setCurrentWorkflow || !setNodes || !setEdges) {
+      enqueueSnackbar("Canvas import is not available in this view.", {
+        variant: "error",
+      });
+      return;
+    }
+
+    try {
+      let nodeStore = useNodeStore.getState();
+      const metadataLoads: Promise<void>[] = [];
+      if (nodeStore.nodes.length === 0) {
+        metadataLoads.push(nodeStore.fetchNodes());
+      }
+      if (nodeStore.customNodes.length === 0) {
+        metadataLoads.push(nodeStore.fetchCustomNodes());
+      }
+
+      if (metadataLoads.length > 0) {
+        const metadataResults = await Promise.allSettled(metadataLoads);
+        metadataResults.forEach((result) => {
+          if (result.status === "rejected") {
+            console.warn(
+              "Node metadata could not be refreshed; importing raw workflow nodes.",
+              result.reason,
+            );
+          }
+        });
+      }
+      nodeStore = useNodeStore.getState();
+
+      const allNodesMetadata = [
+        ...(nodeStore.nodes || []),
+        ...(nodeStore.customNodes || []),
+      ];
+      const importedNodes = importedWorkflow.flow_data.nodes;
+      const importedEdges = importedWorkflow.flow_data.edges;
+      const enrichedNodes = importedNodes.map((node: any) => {
+        if (!node.data?.metadata && allNodesMetadata.length > 0) {
+          const metadata = allNodesMetadata.find(
+            (candidate) =>
+              candidate.name === node.type || (candidate as any).id === node.type,
+          ) as any;
+
+          if (metadata) {
+            return {
+              ...node,
+              data: {
+                ...node.data,
+                metadata,
+                icon: metadata.icon,
+                description: metadata.description,
+                displayName: metadata.display_name,
+                inputs: metadata.inputs,
+                outputs: metadata.outputs,
+              },
+            };
+          }
+        }
+        return node;
+      });
+
+      onImportStart?.();
+
+      if (currentWorkflow) {
+        setCurrentWorkflow({
+          ...currentWorkflow,
+          name: importedWorkflow.name || currentWorkflow.name,
+          flow_data: {
+            ...currentWorkflow.flow_data,
+            ...importedWorkflow.flow_data,
+            nodes: enrichedNodes,
+            edges: importedEdges,
+          },
+        });
+      }
+
+      setNodes(enrichedNodes);
+      setEdges(importedEdges);
+      onWorkflowImported?.(enrichedNodes, importedEdges);
+      if (importedWorkflow.name) {
+        setWorkflowName(importedWorkflow.name);
+      }
+      enqueueSnackbar("Workflow loaded successfully!", { variant: "success" });
+    } catch (error) {
+      console.error("Canvas workflow import error:", error);
+      enqueueSnackbar(getWorkflowJsonErrorMessage(error), { variant: "error" });
+    }
   };
 
   const handleExport = () => {

--- a/client/app/components/common/NeonHandle.tsx
+++ b/client/app/components/common/NeonHandle.tsx
@@ -42,7 +42,7 @@ export const NeonHandle = ({
             ? "shadow-[0_0_8px_2px_var(--neon-color),0_0_16px_4px_var(--neon-color)]"
             : ""
         }
-         z-10
+         z-30
         ${
           glow
             ? "before:content-[''] before:absolute before:inset-0 before:rounded-full before:bg-[radial-gradient(circle,var(--neon-color)_0%,transparent_80%)] before:opacity-40 before:blur-[3px] after:content-[''] after:absolute after:inset-0 after:rounded-full after:bg-[radial-gradient(circle,var(--neon-color)_0%,transparent_80%)] after:opacity-30 after:blur-[5px]"

--- a/client/app/components/node/EndNode.tsx
+++ b/client/app/components/node/EndNode.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState } from "react";
 import { useReactFlow, Handle, Position } from "@xyflow/react";
 import NeonHandle from "../common/NeonHandle";
+import { getExecutionStatusStyle, PendingWormRing } from "~/lib/nodeStatusUtils";
 import {
   Play,
   Square,
@@ -47,15 +48,10 @@ function EndNode({ data, id, onExecute, validationStatus }: EndNodeProps) {
   };
 
   const getGlowColor = () => {
-    switch (validationState) {
-      case "success":
-        return "shadow-emerald-500/30";
-      case "error":
-        return "shadow-red-500/30";
-      default:
-        return "shadow-gray-500/30";
-    }
+    return "";
   };
+
+  const executionStatusStyle = getExecutionStatusStyle(data?.executionStatus);
 
   return (
     <>
@@ -65,34 +61,29 @@ function EndNode({ data, id, onExecute, validationStatus }: EndNodeProps) {
           cursor-pointer transition-all duration-300 transform
           ${isHovered ? "scale-105" : "scale-100"}
           bg-gradient-to-br ${getStatusColor()}
-          ${
-            isHovered
-              ? `shadow-2xl ${getGlowColor()}`
-              : "shadow-lg shadow-black/50"
-          }
           border border-white/20 backdrop-blur-sm
           hover:border-white/40`}
+        style={executionStatusStyle}
         onDoubleClick={() => executeHandler?.(id)}
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
         title="Double click to execute"
       >
+        {/* Pending status clockwise revolving amber worm light */}
+        {data?.executionStatus === "pending" && (
+          <PendingWormRing borderRadius="1rem" rx={16} />
+        )}
+
         {/* Background pattern */}
         <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-white/10 to-transparent opacity-50"></div>
 
         {/* Main icon */}
         <div className="relative z-10 mb-2">
-          <div className="relative">
-            <Flag className="w-10 h-10 text-white drop-shadow-lg" />
-            {/* Activity indicator */}
-            <div className="absolute -top-1 -right-1 w-4 h-4 bg-gradient-to-r from-gray-400 to-slate-500 rounded-full flex items-center justify-center">
-              <CheckCircle className="w-2 h-2 text-white" />
-            </div>
-          </div>
+          <Flag className="w-10 h-10 text-white" />
         </div>
 
         {/* Node title */}
-        <div className="text-white text-xs font-semibold text-center drop-shadow-lg z-10">
+        <div className="text-white text-xs font-semibold text-center z-10">
           {data?.displayName || data?.name || "End"}
         </div>
 
@@ -153,140 +144,6 @@ function EndNode({ data, id, onExecute, validationStatus }: EndNodeProps) {
 
 
 
-        {/* Connection Status Indicator */}
-        {data?.has_input && (
-          <div className="absolute -top-2 left-1/2 transform -translate-x-1/2 z-10">
-            <div className="w-3 h-3 bg-gray-400 rounded-full shadow-lg animate-pulse"></div>
-          </div>
-        )}
-
-        {/* Completion Status Indicator */}
-        {data?.is_completed && (
-          <div className="absolute top-1 left-1 z-10">
-            <div className="w-4 h-4 bg-gradient-to-r from-green-400 to-emerald-500 rounded-full flex items-center justify-center shadow-lg">
-              <CheckCircle className="w-2 h-2 text-white" />
-            </div>
-          </div>
-        )}
-
-        {/* Execution Status Indicator */}
-        {data?.is_executing && (
-          <div className="absolute top-1 right-1 z-10">
-            <div className="w-4 h-4 bg-gradient-to-r from-yellow-400 to-orange-500 rounded-full flex items-center justify-center shadow-lg">
-              <Activity className="w-2 h-2 text-white" />
-            </div>
-          </div>
-        )}
-
-        {/* Execution Time Indicator */}
-        {data?.execution_time && (
-          <div className="absolute bottom-1 left-1 z-10">
-            <div className="w-3 h-3 bg-blue-400 rounded-full shadow-lg animate-pulse"></div>
-          </div>
-        )}
-
-        {/* Performance Indicator */}
-        {data?.performance_metrics && (
-          <div className="absolute bottom-1 right-1 z-10">
-            <div className="w-3 h-3 bg-green-400 rounded-full shadow-lg animate-pulse"></div>
-          </div>
-        )}
-
-        {/* End Type Badge */}
-        {data?.end_type && (
-          <div className="absolute -right-2 top-1/2 transform -translate-y-1/2 z-10">
-            <div className="px-2 py-1 rounded bg-slate-600 text-white text-xs font-bold shadow-lg transform rotate-90">
-              {data.end_type === "success"
-                ? "Success"
-                : data.end_type === "error"
-                ? "Error"
-                : "End"}
-            </div>
-          </div>
-        )}
-
-        {/* Completion Count Indicator */}
-        {data?.completion_count && (
-          <div className="absolute -left-2 top-1/2 transform -translate-y-1/2 z-10">
-            <div className="px-2 py-1 rounded bg-gray-600 text-white text-xs font-bold shadow-lg transform -rotate-90">
-              {data.completion_count > 1000
-                ? `${Math.round(data.completion_count / 1000)}K`
-                : data.completion_count}
-            </div>
-          </div>
-        )}
-
-        {/* End Status Badge */}
-        {data?.end_status && (
-          <div className="absolute -bottom-2 left-1/2 transform -translate-x-1/2 z-10">
-            <div className="px-2 py-1 rounded bg-gradient-to-r from-gray-500 to-slate-600 text-white text-xs font-bold shadow-lg">
-              {data.end_status === "ready"
-                ? "Ready"
-                : data.end_status === "executing"
-                ? "Executing"
-                : data.end_status === "completed"
-                ? "Completed"
-                : data.end_status === "error"
-                ? "Error"
-                : "Active"}
-            </div>
-          </div>
-        )}
-
-        {/* Last Completion Indicator */}
-        {data?.last_completion && (
-          <div className="absolute top-1 right-1 z-10">
-            <div className="w-4 h-4 bg-gradient-to-r from-blue-400 to-indigo-500 rounded-full flex items-center justify-center shadow-lg">
-              <Clock className="w-2 h-2 text-white" />
-            </div>
-          </div>
-        )}
-
-        {/* Completion Speed Indicator */}
-        {data?.completion_speed && (
-          <div className="absolute bottom-1 left-1 z-10">
-            <div className="w-3 h-3 bg-blue-400 rounded-full shadow-lg animate-pulse"></div>
-          </div>
-        )}
-
-        {/* Workflow Status Indicator */}
-        {data?.workflow_status && (
-          <div className="absolute bottom-1 right-1 z-10">
-            <div className="w-3 h-3 bg-orange-400 rounded-full shadow-lg animate-pulse"></div>
-          </div>
-        )}
-
-        {/* Auto Complete Indicator */}
-        {data?.auto_complete && (
-          <div className="absolute top-1 left-1 z-10">
-            <div className="w-4 h-4 bg-gradient-to-r from-blue-400 to-sky-500 rounded-full flex items-center justify-center shadow-lg">
-              <Zap className="w-2 h-2 text-white" />
-            </div>
-          </div>
-        )}
-
-        {/* Timer Indicator */}
-        {data?.has_timer && (
-          <div className="absolute top-1 right-1 z-10">
-            <div className="w-4 h-4 bg-gradient-to-r from-yellow-400 to-orange-500 rounded-full flex items-center justify-center shadow-lg">
-              <Clock className="w-2 h-2 text-white" />
-            </div>
-          </div>
-        )}
-
-        {/* Success Rate Indicator */}
-        {data?.success_rate && (
-          <div className="absolute bottom-1 left-1 z-10">
-            <div className="w-3 h-3 bg-green-400 rounded-full shadow-lg animate-pulse"></div>
-          </div>
-        )}
-
-        {/* Error Rate Indicator */}
-        {data?.error_rate && (
-          <div className="absolute bottom-1 right-1 z-10">
-            <div className="w-3 h-3 bg-red-400 rounded-full shadow-lg animate-pulse"></div>
-          </div>
-        )}
       </div>
     </>
   );

--- a/client/app/components/node/GenericVisual.tsx
+++ b/client/app/components/node/GenericVisual.tsx
@@ -8,6 +8,7 @@ import * as LucideIcons from "lucide-react";
 import { resolveIconPath } from "~/lib/iconUtils";
 import type { CSSProperties } from "react";
 import colors from "tailwindcss/colors";
+import { getExecutionStatusStyle, PendingWormRing } from "~/lib/nodeStatusUtils";
 
 // Helper functions for node colors
 function resolveNodeColorToken(token: string): string | null {
@@ -118,14 +119,7 @@ function GenericVisual({
   const gradientStyle = getNodeGradientStyle(colorStops);
 
   const getGlowColor = () => {
-    switch (data.validationStatus) {
-      case "success":
-        return "shadow-emerald-500/30";
-      case "error":
-        return "shadow-red-500/30";
-      default:
-        return "shadow-blue-500/30";
-    }
+    return "";
   };
 
   const getIconComponent = (icon: NodeMetadata["icon"]) => {
@@ -225,35 +219,38 @@ function GenericVisual({
     });
   };
 
+  const executionStatusStyle = getExecutionStatusStyle(data.executionStatus);
+
   return (
     <div
       className={`relative group w-24 h-24 rounded-2xl flex flex-col items-center justify-center 
           cursor-pointer transition-all duration-300 transform
         ${isHovered ? "scale-105" : "scale-100"}
-        ${isHovered
-          ? `shadow-2xl ${getGlowColor()}`
-          : "shadow-lg shadow-black/50"
-        }
         border border-white/20 backdrop-blur-sm
         hover:border-white/40`}
-      style={gradientStyle}
+      style={{ ...gradientStyle, ...executionStatusStyle }}
       onDoubleClick={onDoubleClick}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       title="Yapılandırmak için çift tıklayın"
     >
+      {/* Pending status clockwise revolving amber worm light */}
+      {data?.executionStatus === "pending" && (
+        <PendingWormRing borderRadius="1rem" rx={16} />
+      )}
+
       {/* Arka plan deseni */}
       <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-white/10 to-transparent opacity-50"></div>
 
       {/* Ana ikon */}
       <div className="relative z-10 mb-2">
         <div className="relative">
-          <Icon className="w-8 h-8 text-white drop-shadow-lg" />
+          <Icon className="w-8 h-8 text-white" />
         </div>
       </div>
 
       {/* Node başlığı */}
-      <div className="text-white text-xs font-semibold text-center drop-shadow-lg z-10 px-2">
+      <div className="text-white text-xs font-semibold text-center z-10 px-2">
         {data?.display_name ||
           data?.displayName ||
           data?.name ||
@@ -267,7 +264,7 @@ function GenericVisual({
           <button
             className="absolute -top-3 -right-3 w-8 h-8 
               bg-gradient-to-r from-red-500 to-red-600 hover:from-red-400 hover:to-red-500
-              text-white rounded-full border border-white/30 shadow-xl 
+              text-white rounded-full border border-white/30
               transition-all duration-200 hover:scale-110 flex items-center justify-center z-20
               backdrop-blur-sm"
             onClick={onDelete}
@@ -286,7 +283,7 @@ function GenericVisual({
               ? "bg-gradient-to-r from-red-500 to-red-600 hover:from-red-400 hover:to-red-500"
               : "bg-gradient-to-r from-green-500 to-green-600 hover:from-green-400 hover:to-green-500"
             }
-                text-white rounded-full border border-white/30 shadow-xl 
+                text-white rounded-full border border-white/30
                 transition-all duration-200 hover:scale-110 flex items-center justify-center z-20
                 backdrop-blur-sm`}
           onClick={(e) => {
@@ -311,7 +308,7 @@ function GenericVisual({
           <button
             className="absolute -bottom-3 -left-3 w-8 h-8 
                 bg-gradient-to-r from-blue-500 to-blue-600 hover:from-blue-400 hover:to-blue-500
-                text-white rounded-full border border-white/30 shadow-xl 
+                text-white rounded-full border border-white/30
                 transition-all duration-200 hover:scale-110 flex items-center justify-center z-20
                 backdrop-blur-sm"
             onClick={(e) => {
@@ -332,7 +329,7 @@ function GenericVisual({
               ? "bg-gradient-to-r from-red-500 to-red-600 hover:from-red-400 hover:to-red-500"
               : "bg-gradient-to-r from-green-500 to-green-600 hover:from-green-400 hover:to-green-500"
             }
-                text-white rounded-full border border-white/30 shadow-xl 
+                text-white rounded-full border border-white/30
                 transition-all duration-200 hover:scale-110 flex items-center justify-center z-20
                 backdrop-blur-sm`}
           onClick={(e) => {
@@ -360,7 +357,7 @@ function GenericVisual({
               <button
                 className="w-8 h-8 bg-gradient-to-r from-green-500 to-green-600 
                     hover:from-green-400 hover:to-green-500 text-white rounded-full 
-                    border border-white/30 shadow-xl transition-all duration-200 
+                    border border-white/30 transition-all duration-200
                     hover:scale-110 flex items-center justify-center z-20 backdrop-blur-sm"
                 onClick={(e) => {
                   e.stopPropagation();
@@ -374,7 +371,7 @@ function GenericVisual({
               <button
                 className="w-8 h-8 bg-gradient-to-r from-red-500 to-red-600 
                     hover:from-red-400 hover:to-red-500 text-white rounded-full 
-                    border border-white/30 shadow-xl transition-all duration-200 
+                    border border-white/30 transition-all duration-200
                     hover:scale-110 flex items-center justify-center z-20 backdrop-blur-sm"
                 onClick={(e) => {
                   e.stopPropagation();
@@ -389,7 +386,7 @@ function GenericVisual({
             <button
               className="w-8 h-8 bg-gradient-to-r from-blue-500 to-blue-600 
                   hover:from-blue-400 hover:to-blue-500 text-white rounded-full 
-                  border border-white/30 shadow-xl transition-all duration-200 
+                  border border-white/30 transition-all duration-200
                   hover:scale-110 flex items-center justify-center z-20 backdrop-blur-sm"
               onClick={(e) => {
                 e.stopPropagation();

--- a/client/app/components/node/StartNode.tsx
+++ b/client/app/components/node/StartNode.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 
 import NeonHandle from "../common/NeonHandle";
+import { getExecutionStatusStyle, PendingWormRing } from "~/lib/nodeStatusUtils";
 
 interface StartNodeProps {
   data: any;
@@ -75,21 +76,10 @@ function StartNode({
   };
 
   const getGlowColor = () => {
-    if (isActive) {
-      return "shadow-green-400/70";
-    }
-    if (localExecuting || isExecuting) {
-      return "shadow-yellow-500/50";
-    }
-    switch (validationStatus || data?.validationStatus) {
-      case "success":
-        return "shadow-emerald-500/30";
-      case "error":
-        return "shadow-red-500/30";
-      default:
-        return "shadow-green-500/30";
-    }
+    return "";
   };
+
+  const executionStatusStyle = getExecutionStatusStyle(data?.executionStatus);
 
   return (
     <>
@@ -99,15 +89,9 @@ function StartNode({
           cursor-pointer transition-all duration-300 transform
           ${isHovered ? "scale-105" : "scale-100"}
           bg-gradient-to-br ${getStatusColor()}
-          ${
-            isHovered
-              ? `shadow-2xl ${getGlowColor()}`
-              : "shadow-lg shadow-black/50"
-          }
           border border-white/20 backdrop-blur-sm
-          hover:border-white/40
-          ${localExecuting || isExecuting ? "animate-pulse" : ""}
-          ${isActive ? "animate-pulse ring-4 ring-green-400/50" : ""}`}
+          hover:border-white/40`}
+        style={executionStatusStyle}
         onDoubleClick={handleDoubleClick}
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
@@ -117,26 +101,25 @@ function StartNode({
             : "Double click to execute"
         }
       >
+        {/* Pending status clockwise revolving amber worm light */}
+        {data?.executionStatus === "pending" && (
+          <PendingWormRing borderRadius="1rem" rx={16} />
+        )}
+
         {/* Background pattern */}
         <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-white/10 to-transparent opacity-50"></div>
 
         {/* Main icon */}
         <div className="relative z-10 mb-2">
-          <div className="relative">
-            {localExecuting || isExecuting ? (
-              <Loader className="w-10 h-10 text-white drop-shadow-lg animate-spin" />
-            ) : (
-              <Rocket className="w-10 h-10 text-white drop-shadow-lg" />
-            )}
-            {/* Activity indicator */}
-            <div className="absolute -top-1 -right-1 w-4 h-4 bg-gradient-to-r from-green-400 to-emerald-500 rounded-full flex items-center justify-center">
-              <Play className="w-2 h-2 text-white" />
-            </div>
-          </div>
+          {localExecuting || isExecuting ? (
+            <Loader className="w-10 h-10 text-white animate-spin" />
+          ) : (
+            <Rocket className="w-10 h-10 text-white" />
+          )}
         </div>
 
         {/* Node title */}
-        <div className="text-white text-xs font-semibold text-center drop-shadow-lg z-10">
+        <div className="text-white text-xs font-semibold text-center z-10">
           {localExecuting || isExecuting
             ? "Executing..."
             : data?.displayName || data?.name || "Start"}
@@ -195,126 +178,6 @@ function StartNode({
           </div>
         )}
 
-        {/* Connection Status Indicator */}
-        {isHandleConnected && (
-          <div className="absolute -top-2 left-1/2 transform -translate-x-1/2 z-10">
-            <div className="w-3 h-3 bg-green-400 rounded-full shadow-lg animate-pulse"></div>
-          </div>
-        )}
-
-        {/* Execution Status Indicator */}
-        {(localExecuting || isExecuting) && (
-          <div className="absolute top-1 left-1 z-10">
-            <div className="w-4 h-4 bg-gradient-to-r from-yellow-400 to-orange-500 rounded-full flex items-center justify-center shadow-lg animate-pulse">
-              <Activity className="w-2 h-2 text-white" />
-            </div>
-          </div>
-        )}
-
-        {/* Ready Status Indicator */}
-        {data?.is_ready && (
-          <div className="absolute top-1 right-1 z-10">
-            <div className="w-4 h-4 bg-gradient-to-r from-green-400 to-emerald-500 rounded-full flex items-center justify-center shadow-lg">
-              <Power className="w-2 h-2 text-white" />
-            </div>
-          </div>
-        )}
-
-        {/* Execution Time Indicator */}
-        {data?.execution_time && (
-          <div className="absolute bottom-1 left-1 z-10">
-            <div className="w-3 h-3 bg-blue-400 rounded-full shadow-lg animate-pulse"></div>
-          </div>
-        )}
-
-        {/* Performance Indicator */}
-        {data?.performance_metrics && (
-          <div className="absolute bottom-1 right-1 z-10">
-            <div className="w-3 h-3 bg-green-400 rounded-full shadow-lg animate-pulse"></div>
-          </div>
-        )}
-
-        {/* Start Type Badge */}
-        {data?.start_type && (
-          <div className="absolute -right-2 top-1/2 transform -translate-y-1/2 z-10">
-            <div className="px-2 py-1 rounded bg-emerald-600 text-white text-xs font-bold shadow-lg transform rotate-90">
-              {data.start_type === "manual"
-                ? "Manual"
-                : data.start_type === "trigger"
-                ? "Trigger"
-                : "Start"}
-            </div>
-          </div>
-        )}
-
-        {/* Execution Count Indicator */}
-        {data?.execution_count && (
-          <div className="absolute -left-2 top-1/2 transform -translate-y-1/2 z-10">
-            <div className="px-2 py-1 rounded bg-green-600 text-white text-xs font-bold shadow-lg transform -rotate-90">
-              {data.execution_count > 1000
-                ? `${Math.round(data.execution_count / 1000)}K`
-                : data.execution_count}
-            </div>
-          </div>
-        )}
-
-        {/* Start Status Badge */}
-        {data?.start_status && (
-          <div className="absolute -bottom-2 left-1/2 transform -translate-x-1/2 z-10">
-            <div className="px-2 py-1 rounded bg-gradient-to-r from-green-500 to-emerald-600 text-white text-xs font-bold shadow-lg">
-              {data.start_status === "ready"
-                ? "Ready"
-                : data.start_status === "executing"
-                ? "Executing"
-                : data.start_status === "completed"
-                ? "Completed"
-                : data.start_status === "error"
-                ? "Error"
-                : "Active"}
-            </div>
-          </div>
-        )}
-
-        {/* Last Execution Indicator */}
-        {data?.last_execution && (
-          <div className="absolute top-1 right-1 z-10">
-            <div className="w-4 h-4 bg-gradient-to-r from-blue-400 to-indigo-500 rounded-full flex items-center justify-center shadow-lg">
-              <Clock className="w-2 h-2 text-white" />
-            </div>
-          </div>
-        )}
-
-        {/* Execution Speed Indicator */}
-        {data?.execution_speed && (
-          <div className="absolute bottom-1 left-1 z-10">
-            <div className="w-3 h-3 bg-blue-400 rounded-full shadow-lg animate-pulse"></div>
-          </div>
-        )}
-
-        {/* Workflow Status Indicator */}
-        {data?.workflow_status && (
-          <div className="absolute bottom-1 right-1 z-10">
-            <div className="w-3 h-3 bg-orange-400 rounded-full shadow-lg animate-pulse"></div>
-          </div>
-        )}
-
-        {/* Auto Start Indicator */}
-        {data?.auto_start && (
-          <div className="absolute top-1 left-1 z-10">
-            <div className="w-4 h-4 bg-gradient-to-r from-blue-400 to-sky-500 rounded-full flex items-center justify-center shadow-lg">
-              <Zap className="w-2 h-2 text-white" />
-            </div>
-          </div>
-        )}
-
-        {/* Timer Indicator */}
-        {data?.has_timer && (
-          <div className="absolute top-1 right-1 z-10">
-            <div className="w-4 h-4 bg-gradient-to-r from-yellow-400 to-orange-500 rounded-full flex items-center justify-center shadow-lg">
-              <Timer className="w-2 h-2 text-white" />
-            </div>
-          </div>
-        )}
       </div>
     </>
   );

--- a/client/app/components/node/StickyNoteNode.tsx
+++ b/client/app/components/node/StickyNoteNode.tsx
@@ -3,6 +3,7 @@ import { NodeResizer, useReactFlow } from "@xyflow/react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { Trash, Palette } from "lucide-react";
+import { getExecutionStatusStyle, PendingWormRing } from "~/lib/nodeStatusUtils";
 
 const COLORS = [
   { bg: "#fff5d6", border: "#f6c036", borderUnselected: "#eede8e" }, // Varsayılan renk
@@ -143,9 +144,13 @@ function StickyNoteNode({ id, data, selected }: StickyNoteNodeProps) {
           style={{
             backgroundColor: currentColor.bg,
             border: selected ? `2px solid ${currentColor.border}` : `1px solid ${currentColor.borderUnselected}`,
+            ...getExecutionStatusStyle(data?.executionStatus),
           }}
           onDoubleClick={handleDoubleClick}
         >
+          {data?.executionStatus === "pending" && (
+            <PendingWormRing borderRadius="0.125rem" rx={4} />
+          )}
           {/* Main content area - overflow-hidden to hide scroll in view mode */}
           <div className="flex-1 w-full h-full overflow-hidden">
             {isEditing ? (

--- a/client/app/components/node/types.ts
+++ b/client/app/components/node/types.ts
@@ -41,8 +41,9 @@ export interface NodeProperty {
   serviceType?: string;
   rows?: number;
   displayOptions?: {
-    show: Record<string, any>;
-  };
+    show?: Record<string, any>;
+    [key: string]: any;
+  } | Record<string, any>;
   [key: string]: any;
 }
 

--- a/client/app/lib/executionStatus.ts
+++ b/client/app/lib/executionStatus.ts
@@ -1,0 +1,35 @@
+export type CanvasExecutionStatus = "success" | "failed" | "pending";
+
+type CanvasNodeLike = {
+  id: string;
+  type?: string;
+};
+
+type CanvasEdgeLike = {
+  id: string;
+};
+
+/**
+ * A node only reflects its own execution. A provider/sub-node must never inherit
+ * the status of a downstream agent: an agent may catch a provider error, and a
+ * provider may succeed even when the agent later fails.
+ */
+export function getEffectiveNodeStatus(
+  nodeId: string,
+  nodeStatus: Record<string, CanvasExecutionStatus>,
+  _nodes: CanvasNodeLike[],
+  _edges: CanvasEdgeLike[]
+): CanvasExecutionStatus | undefined {
+  return nodeStatus[nodeId];
+}
+
+/**
+ * Edge lifecycle is reported explicitly by the execution stream. Handle names
+ * and node types are deliberately not used as execution semantics.
+ */
+export function getEdgeExecutionStatus(
+  edge: CanvasEdgeLike,
+  edgeStatus: Record<string, CanvasExecutionStatus> = {}
+): CanvasExecutionStatus | undefined {
+  return edgeStatus[edge.id];
+}

--- a/client/app/lib/liveExecution.ts
+++ b/client/app/lib/liveExecution.ts
@@ -1,0 +1,158 @@
+export type LiveNodeOutputMap = Record<string, any>;
+
+type LiveNodeEvent = Record<string, any>;
+
+const isRecord = (value: unknown): value is Record<string, any> =>
+  Boolean(value) && typeof value === "object" && !Array.isArray(value);
+
+const recordDetailScore = (record: Record<string, any>): number => {
+  let score = 0;
+  if (record.output !== undefined && record.output !== null) score += 4;
+  if (record.outputs !== undefined && record.outputs !== null) score += 2;
+  if (isRecord(record.inputs) && Object.keys(record.inputs).length > 0) score += 2;
+  if (isRecord(record.inputs_meta) && Object.keys(record.inputs_meta).length > 0) score += 1;
+  if (Number(record.executionTimeMs) > 0) score += 1;
+  return score;
+};
+
+const mergeNodeOutputRecord = (current: unknown, reported: unknown): unknown => {
+  if (!isRecord(current) || !isRecord(reported)) return reported;
+
+  const preferCurrent = recordDetailScore(current) > recordDetailScore(reported);
+  const merged = preferCurrent
+    ? { ...reported, ...current }
+    : { ...current, ...reported };
+
+  const reportedFailed =
+    reported.success === false ||
+    reported.status === "failed" ||
+    reported.status === "error";
+  if (reportedFailed) {
+    merged.success = false;
+    merged.status = "failed";
+    merged.statusCode = reported.statusCode ?? 500;
+    merged.error = reported.error || merged.error;
+  }
+
+  return merged;
+};
+
+export const mergeLiveNodeOutputMaps = (
+  current: LiveNodeOutputMap,
+  reported: unknown
+): LiveNodeOutputMap => {
+  if (!isRecord(reported)) return { ...current };
+
+  const merged = { ...current };
+  Object.entries(reported).forEach(([nodeId, output]) => {
+    merged[nodeId] = mergeNodeOutputRecord(current[nodeId], output);
+  });
+  return merged;
+};
+
+/**
+ * Reduce one streaming lifecycle event into the node-output shape consumed by
+ * the canvas detail panel. The same reducer is shared by Start and Chat runs so
+ * node details no longer depend on which trigger opened the execution stream.
+ */
+export const reduceLiveNodeEvent = (
+  current: LiveNodeOutputMap,
+  nodeId: string,
+  event: LiveNodeEvent
+): LiveNodeOutputMap => {
+  if (!nodeId) return current;
+
+  const eventType = event.event || event.type;
+  const runtimeStatus = event.status;
+  const previous = isRecord(current[nodeId]) ? current[nodeId] : {};
+  const metadata = isRecord(event.metadata) ? event.metadata : {};
+  const inputs = event.inputs ?? metadata.inputs;
+  const inputsMeta = event.inputs_meta ?? metadata.inputs_meta;
+
+  if (
+    eventType === "node_start" ||
+    (eventType === "node_status" && runtimeStatus === "pending")
+  ) {
+    return {
+      ...current,
+      [nodeId]: {
+        ...previous,
+        ...(inputs !== undefined ? { inputs } : {}),
+        ...(inputsMeta !== undefined ? { inputs_meta: inputsMeta } : {}),
+        status: "running",
+      },
+    };
+  }
+
+  const isTerminal =
+    eventType === "node_end" ||
+    (eventType === "node_status" &&
+      (runtimeStatus === "success" || runtimeStatus === "failed"));
+  if (!isTerminal) return current;
+
+  const rawOutput = event.output ?? event.node_output;
+  const failed =
+    runtimeStatus === "failed" ||
+    event.status === "error" ||
+    Boolean(event.error);
+
+  let next: Record<string, any> = { ...previous };
+  if (isRecord(rawOutput)) {
+    const isStandardOutput =
+      "success" in rawOutput ||
+      "nodeId" in rawOutput ||
+      "statusCode" in rawOutput;
+    next = isStandardOutput
+      ? { ...next, ...rawOutput }
+      : { ...next, output: rawOutput, outputs: rawOutput };
+  } else if (rawOutput !== undefined) {
+    next = { ...next, output: rawOutput, outputs: rawOutput };
+  }
+
+  if (inputs !== undefined && next.inputs === undefined) next.inputs = inputs;
+  if (inputsMeta !== undefined && next.inputs_meta === undefined) {
+    next.inputs_meta = inputsMeta;
+  }
+
+  next.status = failed ? "failed" : "completed";
+  next.success = failed ? false : next.success ?? true;
+
+  if (failed && !next.error) {
+    next.error = {
+      error_type: event.error_type || "execution",
+      error_message: String(event.error || "Node execution failed"),
+    };
+  }
+
+  return { ...current, [nodeId]: next };
+};
+
+export const ensureLiveNodeFailure = (
+  current: LiveNodeOutputMap,
+  nodeId: string,
+  event: LiveNodeEvent
+): LiveNodeOutputMap => {
+  if (!nodeId) return current;
+
+  const previous = isRecord(current[nodeId]) ? current[nodeId] : {};
+  const errorMessage = String(event.error || event.message || "Node execution failed");
+  const errorDetails = isRecord(previous.error)
+    ? previous.error
+    : {
+        error_type: event.error_type || "execution",
+        error_message: errorMessage,
+      };
+
+  return {
+    ...current,
+    [nodeId]: {
+      ...previous,
+      success: false,
+      status: "failed",
+      statusCode: previous.statusCode ?? 500,
+      nodeId: previous.nodeId ?? nodeId,
+      output: previous.output ?? null,
+      error: errorDetails,
+    },
+  };
+};

--- a/client/app/lib/nodeStatusUtils.tsx
+++ b/client/app/lib/nodeStatusUtils.tsx
@@ -1,0 +1,173 @@
+import React, { type CSSProperties } from "react";
+
+export type ExecutionStatus = "success" | "failed" | "pending" | string;
+export {
+  getEdgeExecutionStatus,
+  getEffectiveNodeStatus,
+} from "./executionStatus";
+export type { CanvasExecutionStatus } from "./executionStatus";
+
+export function getExecutionStatusStyle(
+  status?: ExecutionStatus
+): CSSProperties | undefined {
+  if (status === "success") {
+    return {
+      boxShadow: "0 0 0 3px #22c55e, 0 0 16px rgba(34, 197, 94, 0.6)",
+    };
+  }
+  if (status === "failed") {
+    return {
+      boxShadow: "0 0 0 3px #ef4444, 0 0 16px rgba(239, 68, 68, 0.6)",
+    };
+  }
+  return undefined;
+}
+
+interface PendingWormRingProps {
+  borderRadius?: string;
+  rx?: number;
+}
+
+/**
+ * Finalized Production Pending Execution Ring Component
+ * Uses the user's exact chosen values:
+ * - Amber gold photon particle (#f59e0b) with soft yellow core (#fef08a)
+ * - 3.0px border track (#f59e0b) matching success (3px) and failed (3px) width
+ * - Outward-only SVG mask to keep node face 100% clean
+ * - 4.5s smooth clockwise rotation
+ */
+export const PendingWormRing: React.FC<PendingWormRingProps> = ({
+  borderRadius = "1rem",
+  rx = 16,
+}) => {
+  const orbLength = 12;
+  const dashLength = orbLength;
+  const dashGap = Math.max(1, 100 - orbLength);
+  const strokeDash = `${dashLength} ${dashGap}`;
+  const speed = 4.5;
+
+  const glowBlur = 3.0;
+  const outwardGlowWidth = 3.0;
+  const outwardGlowOpacity = 1.0;
+
+  const mainColor = "#f59e0b";
+  const coreColor = "#fef08a";
+  const trackColor = "#f59e0b";
+  const trackOpacity = 1.0;
+  const trackWidth = 3.0;
+
+  const uniqueId = React.useId().replace(/:/g, "");
+  const filterId = `outward-amber-glow-${uniqueId}`;
+  const maskId = `outward-only-mask-${uniqueId}`;
+
+  return (
+    <div
+      className="pointer-events-none absolute inset-0 z-0 overflow-visible"
+      style={{ borderRadius }}
+    >
+      <svg className="w-full h-full overflow-visible">
+        <defs>
+          {/* Outward-Only Mask: Blackout 100% of light inside node face so glow ONLY radiates outward */}
+          <mask id={maskId}>
+            <rect x="-200%" y="-200%" width="500%" height="500%" fill="white" />
+            <rect
+              x="2"
+              y="2"
+              width="calc(100% - 4px)"
+              height="calc(100% - 4px)"
+              rx={rx}
+              fill="black"
+            />
+          </mask>
+
+          {/* Deep Volumetric Outward Gaussian Blur Filter */}
+          <filter id={filterId} x="-200%" y="-200%" width="500%" height="500%">
+            <feGaussianBlur stdDeviation={glowBlur} result="wideOutwardGlow" />
+            <feMerge>
+              <feMergeNode in="wideOutwardGlow" />
+              <feMergeNode in="wideOutwardGlow" />
+            </feMerge>
+          </filter>
+        </defs>
+
+        {/* Base ambient track rail (Exact 3px thickness) */}
+        <rect
+          x="0"
+          y="0"
+          width="100%"
+          height="100%"
+          rx={rx}
+          fill="none"
+          stroke={trackColor}
+          strokeWidth={trackWidth}
+          strokeOpacity={trackOpacity}
+        />
+
+        {/* Outward-Only Volumetric Glowing Atmosphere */}
+        <g mask={`url(#${maskId})`}>
+          <rect
+            x="0"
+            y="0"
+            width="100%"
+            height="100%"
+            rx={rx}
+            pathLength={100}
+            fill="none"
+            stroke={mainColor}
+            strokeWidth={outwardGlowWidth}
+            strokeLinecap="round"
+            strokeDasharray={strokeDash}
+            style={{
+              animation: `clean-border-flow ${speed}s linear infinite`,
+              filter: `url(#${filterId})`,
+              opacity: outwardGlowOpacity,
+            }}
+          />
+        </g>
+
+        {/* Crisp photon particle track */}
+        <rect
+          x="0"
+          y="0"
+          width="100%"
+          height="100%"
+          rx={rx}
+          pathLength={100}
+          fill="none"
+          stroke={mainColor}
+          strokeWidth={trackWidth}
+          strokeLinecap="round"
+          strokeDasharray={strokeDash}
+          style={{
+            animation: `clean-border-flow ${speed}s linear infinite`,
+          }}
+        />
+
+        {/* Crisp bright yellow-white core spark center */}
+        <rect
+          x="0"
+          y="0"
+          width="100%"
+          height="100%"
+          rx={rx}
+          pathLength={100}
+          fill="none"
+          stroke={coreColor}
+          strokeWidth={trackWidth - 1}
+          strokeLinecap="round"
+          strokeDasharray={strokeDash}
+          style={{
+            animation: `clean-border-flow ${speed}s linear infinite`,
+          }}
+        />
+      </svg>
+
+      <style>{`
+        @keyframes clean-border-flow {
+          0% { stroke-dashoffset: 0; }
+          100% { stroke-dashoffset: -100; }
+        }
+      `}</style>
+    </div>
+  );
+};

--- a/client/app/lib/workflowJson.ts
+++ b/client/app/lib/workflowJson.ts
@@ -1,0 +1,101 @@
+import type { WorkflowData } from "~/types/api";
+
+type JsonObject = Record<string, unknown>;
+
+export interface ImportedWorkflowJson extends JsonObject {
+  name?: string;
+  description?: string;
+  is_public?: boolean;
+  flow_data: WorkflowData;
+}
+
+export class WorkflowJsonError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "WorkflowJsonError";
+  }
+}
+
+const isJsonObject = (value: unknown): value is JsonObject =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const requireArray = (
+  value: unknown,
+  fieldName: string,
+): unknown[] => {
+  if (!Array.isArray(value)) {
+    throw new WorkflowJsonError(
+      `Invalid workflow JSON: ${fieldName} must be an array.`,
+    );
+  }
+  return value;
+};
+
+/**
+ * Parse the simple, single-workflow JSON used by the canvas Export JSON action.
+ * This intentionally does not handle the separate ZIP/package export format.
+ */
+export const parseWorkflowJson = (text: string): ImportedWorkflowJson => {
+  const source = text.replace(/^\uFEFF/, "").trim();
+  if (!source) {
+    throw new WorkflowJsonError("The selected workflow JSON file is empty.");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(source);
+  } catch (error) {
+    throw new WorkflowJsonError(
+      "The selected file does not contain valid JSON.",
+      { cause: error },
+    );
+  }
+
+  if (!isJsonObject(parsed)) {
+    throw new WorkflowJsonError(
+      "Invalid workflow JSON: the root value must be an object.",
+    );
+  }
+
+  // Current exports wrap the graph in flow_data. Direct nodes/edges support is
+  // retained for older single-workflow canvas exports.
+  const rawFlowData = isJsonObject(parsed.flow_data)
+    ? parsed.flow_data
+    : Array.isArray(parsed.nodes) && Array.isArray(parsed.edges)
+      ? parsed
+      : null;
+
+  if (!rawFlowData) {
+    throw new WorkflowJsonError(
+      "Invalid workflow JSON: flow_data with nodes and edges is required.",
+    );
+  }
+
+  const nodes = requireArray(rawFlowData.nodes, "flow_data.nodes");
+  const edges = requireArray(rawFlowData.edges, "flow_data.edges");
+
+  if (!nodes.every(isJsonObject)) {
+    throw new WorkflowJsonError(
+      "Invalid workflow JSON: every node must be an object.",
+    );
+  }
+  if (!edges.every(isJsonObject)) {
+    throw new WorkflowJsonError(
+      "Invalid workflow JSON: every edge must be an object.",
+    );
+  }
+
+  return {
+    ...parsed,
+    flow_data: {
+      ...rawFlowData,
+      nodes: nodes as unknown as WorkflowData["nodes"],
+      edges: edges as unknown as WorkflowData["edges"],
+    },
+  } as ImportedWorkflowJson;
+};
+
+export const getWorkflowJsonErrorMessage = (error: unknown): string =>
+  error instanceof WorkflowJsonError
+    ? error.message
+    : "The workflow JSON is valid, but it could not be loaded into the canvas.";

--- a/client/app/routes/workflows.tsx
+++ b/client/app/routes/workflows.tsx
@@ -40,6 +40,7 @@ import type {
 // import ExternalWorkflowChat from "~/components/external/ExternalWorkflowChat";
 // import ExternalWorkflowViewer from "~/components/external/ExternalWorkflowViewer";
 import { timeAgo } from "~/lib/dateFormatter";
+import { parseWorkflowJson } from "~/lib/workflowJson";
 import { Formik, Form, Field, ErrorMessage } from "formik";
 import { Link } from "react-router";
 import { useSnackbar } from "notistack";
@@ -279,14 +280,14 @@ function WorkflowsLayout() {
         const file = files[i];
         try {
           const text = await file.text();
-          const workflowData = JSON.parse(text);
+          const workflowData = parseWorkflowJson(text);
 
           // Create workflow using the store
           await createWorkflow({
             name: workflowData.name || `Imported Workflow ${i + 1}`,
             description: workflowData.description || "Imported workflow",
-            is_public: workflowData.is_public || false,
-            flow_data: workflowData.flow_data || { nodes: [], edges: [] },
+            is_public: workflowData.is_public ?? false,
+            flow_data: workflowData.flow_data,
           });
 
           successCount++;

--- a/client/app/stores/chat.ts
+++ b/client/app/stores/chat.ts
@@ -4,6 +4,12 @@ import type { ChatMessage, WorkflowExecution } from '../types/api';
 import * as chatService from '../services/chatService';
 import { executeWorkflow } from '../services/workflowService';
 import { executeWorkflowStream } from '../services/executionService';
+import { useExecutionsStore } from './executions';
+import {
+  ensureLiveNodeFailure,
+  mergeLiveNodeOutputMaps,
+  reduceLiveNodeEvent,
+} from '../lib/liveExecution';
 
 interface ChatStore {
   chats: Record<string, ChatMessage[]>;
@@ -47,10 +53,14 @@ const executeWorkflowWithStreaming = async (
   chatflow_id: string,
   workflow_id: string
 ) => {
-  console.log('🔄 Starting chat execution with streaming...');
+  console.log('Starting chat execution with streaming...');
 
-  // Track all node data during execution
-  const nodeExecutionData: Record<string, any> = {};
+  let nodeExecutionData: Record<string, any> = {};
+  const liveExecutedNodes = new Set<string>();
+  const liveStartedAt = new Date().toISOString();
+  let liveSessionId: string | undefined = session_id;
+  let lastExecutionId: string | null = null;
+  let streamHadError = false;
 
   const executionData = {
     flow_data,
@@ -62,15 +72,50 @@ const executeWorkflowWithStreaming = async (
     trigger_source: 'chat_message'
   };
 
-  try {
-    console.log('📡 Starting streaming execution for chat...');
+  const publishLiveExecution = (
+    status: 'running' | 'completed' | 'failed',
+    result: any = '',
+    completedAt?: string
+  ) => {
+    const execution: WorkflowExecution = {
+      id: lastExecutionId || `chat-${chatflow_id}`,
+      workflow_id,
+      input_text,
+      result: {
+        result,
+        executed_nodes: Array.from(liveExecutedNodes),
+        node_outputs: { ...nodeExecutionData },
+        session_id: liveSessionId,
+        status,
+      },
+      started_at: liveStartedAt,
+      ...(completedAt ? { completed_at: completedAt } : {}),
+      status,
+    };
+    useExecutionsStore
+      .getState()
+      .setCurrentExecutionForWorkflow(workflow_id, execution);
+  };
 
-    // Emit start event to reset node/edge status
+  const mergeReportedStatuses = (reported: unknown) => {
+    if (!reported || typeof reported !== 'object' || Array.isArray(reported)) return;
+    Object.entries(reported as Record<string, unknown>).forEach(([nodeId, status]) => {
+      if (status !== 'success' && status !== 'failed' && status !== 'pending') return;
+      nodeExecutionData = reduceLiveNodeEvent(nodeExecutionData, nodeId, {
+        type: 'node_status',
+        status,
+      });
+      if (status === 'success' || status === 'failed') {
+        liveExecutedNodes.add(nodeId);
+      }
+    });
+  };
+
+  try {
     window.dispatchEvent(new CustomEvent('chat-execution-start', { detail: {} }));
 
     const stream = await executeWorkflowStream(executionData);
     const reader = stream.getReader();
-    let lastExecutionId: string | null = null;
 
     try {
       const decoder = new TextDecoder('utf-8');
@@ -78,10 +123,7 @@ const executeWorkflowWithStreaming = async (
 
       while (true) {
         const { value, done } = await reader.read();
-        if (done) {
-          console.log('🏁 Stream ended');
-          break;
-        }
+        if (done) break;
 
         buffer += decoder.decode(value, { stream: true });
         const eventParts = buffer.split('\n\n');
@@ -89,200 +131,145 @@ const executeWorkflowWithStreaming = async (
         const lines = eventParts.flatMap((part) => part.split('\n'));
 
         for (const line of lines) {
-          if (line.startsWith('data: ')) {
-            const data = line.slice(6).trim();
-            if (data === '[DONE]' || !data) continue;
+          if (!line.startsWith('data: ')) continue;
 
-            try {
-              const parsed = JSON.parse(data);
-              console.log('📦 Stream event:', parsed.event || parsed.type, parsed);
+          const data = line.slice(6).trim();
+          if (data === '[DONE]' || !data) continue;
 
-              if (parsed.execution_id) {
-                lastExecutionId = parsed.execution_id;
-                try {
-                  const executionsModule = await import('./executions');
-                  const executionsStore = executionsModule.useExecutionsStore.getState();
-                  const currentExec = executionsStore.getCurrentExecutionForWorkflow(workflow_id);
-                  if (!currentExec || currentExec.id !== parsed.execution_id || currentExec.status !== 'running') {
-                    executionsStore.setCurrentExecutionForWorkflow(workflow_id, {
-                      id: parsed.execution_id,
-                      workflow_id: workflow_id,
-                      status: 'running',
-                      started_at: new Date().toISOString(),
-                    } as any);
-                  }
-                } catch (error) {
-                  console.error('❌ Error setting running execution state in chat:', error);
-                }
+          try {
+            const parsed = JSON.parse(data);
+            const event = parsed.event || parsed.type;
+
+            if (parsed.execution_id) lastExecutionId = parsed.execution_id;
+            liveSessionId = parsed.session_id ?? liveSessionId;
+
+            if (event === 'node_status' && parsed.node_id) {
+              nodeExecutionData = reduceLiveNodeEvent(
+                nodeExecutionData,
+                String(parsed.node_id),
+                parsed
+              );
+              if (parsed.status === 'success' || parsed.status === 'failed') {
+                liveExecutedNodes.add(String(parsed.node_id));
               }
+              publishLiveExecution('running');
+            }
 
-              // Log specific node events for debugging
-              const eventType = parsed.event || parsed.type;
-              if (eventType === 'node_start' || eventType === 'node_end') {
-                console.log(`🎯 ${eventType.toUpperCase()}: node_id="${parsed.node_id}" - Looking for match...`);
-              }
+            if (event === 'node_start' && parsed.node_id) {
+              const nodeId = String(parsed.node_id);
+              nodeExecutionData = reduceLiveNodeEvent(
+                nodeExecutionData,
+                nodeId,
+                parsed
+              );
 
-              // Track all node execution data
-              if (eventType === 'node_start' && parsed.node_id) {
-                console.log('📝 Node start tracking:', parsed.node_id, 'input_text:', input_text);
-
-                // ENHANCEMENT: Use backend-provided input metadata instead of hardcoding
-                const backendInputs = parsed.metadata?.inputs || {};
-                const backendInputsMeta = parsed.metadata?.inputs_meta || {};
-
-                nodeExecutionData[parsed.node_id] = {
-                  inputs: { ...backendInputs },
-                  inputs_meta: { ...backendInputsMeta },
-                  metadata: parsed.metadata || {},
-                  status: 'running'
-                };
-
-                // For provider nodes, use metadata inputs
-                if (parsed.metadata?.node_type === 'provider' && parsed.metadata.inputs) {
-                  nodeExecutionData[parsed.node_id].inputs = parsed.metadata.inputs;
-                  console.log('🔧 Provider inputs captured:', parsed.node_id, parsed.metadata.inputs);
-                }
-
-                // For processor nodes like Agent, merge with user's chat input
-                if (parsed.metadata?.node_type === 'processor' || parsed.node_id.includes('Agent')) {
-                  // Merge backend inputs with user chat input (if not already present)
-                  if (!nodeExecutionData[parsed.node_id].inputs.input) {
-                    nodeExecutionData[parsed.node_id].inputs.input = input_text;
-                    nodeExecutionData[parsed.node_id].inputs_meta.input = {
-                      sourceNodeId: 'chat_input',
-                      sourceNodeName: 'Chat Input',
-                      sourceNodeAlias: 'Chat Input',
-                      sourceHandle: 'user_message'
-                    };
-                  }
-                  console.log('🤖 Agent inputs captured:', parsed.node_id, nodeExecutionData[parsed.node_id].inputs);
-                  console.log('🤖 Agent inputs_meta:', parsed.node_id, nodeExecutionData[parsed.node_id].inputs_meta);
-                }
-
-                console.log('💾 Node data stored:', parsed.node_id, nodeExecutionData[parsed.node_id]);
-              }
-
-              if (eventType === 'node_end' && parsed.node_id) {
-                // Extract output from the event - backend now sends output in node_end events
-                const nodeOutput = parsed.output || {};
-
-                console.log('📤 Node end output received:', parsed.node_id, nodeOutput);
-
-                if (nodeExecutionData[parsed.node_id]) {
-                  // Merge output with existing data
-                  nodeExecutionData[parsed.node_id].output = nodeOutput;
-                  nodeExecutionData[parsed.node_id].outputs = nodeOutput; // Also store as 'outputs' for compatibility
-                  nodeExecutionData[parsed.node_id].status = 'completed';
-                } else {
-                  // If we missed the start event, create entry for output
-                  nodeExecutionData[parsed.node_id] = {
-                    inputs: {},
-                    output: nodeOutput,
-                    outputs: nodeOutput, // Also store as 'outputs' for compatibility
-                    status: 'completed'
+              if (
+                parsed.metadata?.node_type === 'processor' ||
+                nodeId.includes('Agent')
+              ) {
+                const previous = nodeExecutionData[nodeId] || {};
+                const inputs = { ...(previous.inputs || {}) };
+                const inputsMeta = { ...(previous.inputs_meta || {}) };
+                if (!inputs.input) {
+                  inputs.input = input_text;
+                  inputsMeta.input = {
+                    sourceNodeId: 'chat_input',
+                    sourceNodeName: 'Chat Input',
+                    sourceNodeAlias: 'Chat Input',
+                    sourceHandle: 'user_message'
                   };
                 }
-
-                console.log('💾 Node execution data updated:', parsed.node_id, nodeExecutionData[parsed.node_id]);
-              }
-
-              // Emit custom event for FlowCanvas to listen
-              const event = parsed.event || parsed.type;
-              if (event) {
-                window.dispatchEvent(new CustomEvent('chat-execution-event', {
-                  detail: { ...parsed, event }
-                }));
-              }
-
-              // Handle error event to display error in UI
-              if (event === 'error') {
-                console.error('❌ Chat execution error:', parsed.error || parsed.data);
-
-                // Emit error event for FlowCanvas to display
-                window.dispatchEvent(new CustomEvent('chat-execution-error', {
-                  detail: {
-                    type: 'error',
-                    error: parsed.error || parsed.data || 'Unknown error',
-                    error_type: parsed.error_type || 'execution',
-                    node_id: parsed.node_id
-                  }
-                }));
-
-                // Save failed execution to store so canvas updates correctly
-                const executionResult: WorkflowExecution = {
-                  id: parsed.execution_id || Date.now().toString(),
-                  workflow_id: workflow_id,
-                  input_text: input_text,
-                  result: {
-                    result: `ERROR: ${parsed.error || parsed.data || 'Unknown error'}`,
-                    executed_nodes: parsed.executed_nodes || [],
-                    node_outputs: parsed.node_outputs || {},
-                    session_id: parsed.session_id,
-                    status: 'failed' as const,
-                  },
-                  started_at: new Date().toISOString(),
-                  completed_at: new Date().toISOString(),
-                  status: 'failed' as const,
+                nodeExecutionData = {
+                  ...nodeExecutionData,
+                  [nodeId]: { ...previous, inputs, inputs_meta: inputsMeta },
                 };
-
-                try {
-                  const executionsModule = await import('./executions');
-                  const executionsStore = executionsModule.useExecutionsStore.getState();
-                  executionsStore.setCurrentExecutionForWorkflow(workflow_id, executionResult);
-                } catch (error) {
-                  console.error('❌ Error setting failed execution result:', error);
-                }
               }
-
-              // Handle complete event to capture execution data
-              if (event === 'complete' && parsed.result) {
-                const executionResult: WorkflowExecution = {
-                  id: parsed.execution_id || Date.now().toString(),
-                  workflow_id: workflow_id,
-                  input_text: input_text,
-                  result: {
-                    result: parsed.result,
-                    executed_nodes: parsed.executed_nodes || [],
-                    // Use backend node_outputs directly - same as StartNode execution
-                    node_outputs: parsed.node_outputs || {},
-                    session_id: parsed.session_id,
-                    status: 'completed' as const,
-                  },
-                  started_at: new Date().toISOString(),
-                  completed_at: new Date().toISOString(),
-                  status: 'completed' as const,
-                };
-
-                // Import and use executions store
-                try {
-                  const executionsModule = await import('./executions');
-                  const executionsStore = executionsModule.useExecutionsStore.getState();
-                  executionsStore.setCurrentExecutionForWorkflow(workflow_id, executionResult);
-                } catch (error) {
-                  console.error('❌ Error setting execution result:', error);
-                }
-                console.log('💾 Execution result saved to store');
-                console.log('📊 Final node_outputs:', executionResult.result.node_outputs);
-
-                // Emit completion event to clear active edges after delay
-                setTimeout(() => {
-                  window.dispatchEvent(new CustomEvent('chat-execution-complete', { detail: {} }));
-                }, 1500);
-              }
-            } catch (e) {
-              // Handle JSON parsing errors gracefully, especially with Turkish characters
-              if (e instanceof SyntaxError && e.message.includes('Unterminated string')) {
-                console.warn('⚠️ JSON parsing error (likely due to special characters), skipping chunk:', data.substring(0, 100) + '...');
-              } else {
-                console.error('❌ Error parsing stream data:', e, 'Raw data:', data.substring(0, 200) + '...');
-              }
-              // Continue processing other lines instead of breaking
-              continue;
+              publishLiveExecution('running');
             }
+
+            if (event === 'node_end' && parsed.node_id) {
+              const nodeId = String(parsed.node_id);
+              nodeExecutionData = reduceLiveNodeEvent(
+                nodeExecutionData,
+                nodeId,
+                parsed
+              );
+              liveExecutedNodes.add(nodeId);
+              publishLiveExecution('running');
+            }
+
+            if (event) {
+              window.dispatchEvent(new CustomEvent('chat-execution-event', {
+                detail: { ...parsed, event }
+              }));
+            }
+
+            if (event === 'error') {
+              streamHadError = true;
+              nodeExecutionData = mergeLiveNodeOutputMaps(
+                nodeExecutionData,
+                parsed.node_outputs
+              );
+              (parsed.executed_nodes || []).forEach((nodeId: unknown) => {
+                liveExecutedNodes.add(String(nodeId));
+              });
+              mergeReportedStatuses(parsed.node_statuses);
+
+              if (parsed.node_id) {
+                const failedNodeId = String(parsed.node_id);
+                nodeExecutionData = ensureLiveNodeFailure(
+                  nodeExecutionData,
+                  failedNodeId,
+                  parsed
+                );
+                liveExecutedNodes.add(failedNodeId);
+              }
+
+              window.dispatchEvent(new CustomEvent('chat-execution-error', {
+                detail: {
+                  ...parsed,
+                  type: 'error',
+                  event: 'error',
+                  error: parsed.error || parsed.data || 'Unknown error',
+                  error_type: parsed.error_type || 'execution',
+                }
+              }));
+
+              publishLiveExecution(
+                'failed',
+                `ERROR: ${parsed.error || parsed.data || 'Unknown error'}`,
+                new Date().toISOString()
+              );
+            }
+
+            if (event === 'complete' && !streamHadError) {
+              nodeExecutionData = mergeLiveNodeOutputMaps(
+                nodeExecutionData,
+                parsed.node_outputs
+              );
+              (parsed.executed_nodes || []).forEach((nodeId: unknown) => {
+                liveExecutedNodes.add(String(nodeId));
+              });
+              mergeReportedStatuses(parsed.node_statuses);
+              publishLiveExecution(
+                'completed',
+                parsed.result,
+                new Date().toISOString()
+              );
+
+              setTimeout(() => {
+                window.dispatchEvent(
+                  new CustomEvent('chat-execution-complete', {
+                    detail: parsed,
+                  })
+                );
+              }, 1500);
+            }
+          } catch (error) {
+            console.error('Error parsing chat execution stream event:', error);
           }
         }
       }
-      console.log('✅ Chat streaming execution completed successfully');
     } finally {
       try {
         reader.releaseLock();
@@ -293,20 +280,47 @@ const executeWorkflowWithStreaming = async (
           const executionService = await import('../services/executionService');
           const finalExecution = await executionService.getExecution(lastExecutionId);
           if (finalExecution) {
-            const executionsModule = await import('./executions');
-            const executionsStore = executionsModule.useExecutionsStore.getState();
-            executionsStore.setCurrentExecutionForWorkflow(workflow_id, finalExecution);
-            if (finalExecution.status === 'cancelled' || finalExecution.status === 'failed') {
+            const rawFinal = finalExecution as any;
+            const finalPayload =
+              rawFinal.result && typeof rawFinal.result === 'object'
+                ? rawFinal.result
+                : rawFinal.outputs || {};
+            nodeExecutionData = mergeLiveNodeOutputMaps(
+              nodeExecutionData,
+              finalPayload.node_outputs || finalPayload.nodeOutputs
+            );
+            (finalPayload.executed_nodes || finalPayload.executedNodes || []).forEach(
+              (nodeId: unknown) => liveExecutedNodes.add(String(nodeId))
+            );
+            mergeReportedStatuses(finalPayload.node_statuses);
+
+            const mergedFinal = {
+              ...rawFinal,
+              input_text: rawFinal.input_text ?? input_text,
+              result: {
+                ...finalPayload,
+                result: finalPayload.result ?? finalPayload.output ?? '',
+                executed_nodes: Array.from(liveExecutedNodes),
+                node_outputs: { ...nodeExecutionData },
+                session_id: finalPayload.session_id ?? liveSessionId,
+                status: finalPayload.status ?? rawFinal.status,
+              },
+            };
+            useExecutionsStore
+              .getState()
+              .setCurrentExecutionForWorkflow(workflow_id, mergedFinal);
+
+            if (rawFinal.status === 'cancelled' || rawFinal.status === 'failed') {
               window.dispatchEvent(new CustomEvent('chat-execution-complete', { detail: {} }));
             }
           }
-        } catch (err) {
-          console.error('❌ Failed to sync final chat execution status:', err);
+        } catch (error) {
+          console.error('Failed to sync final chat execution status:', error);
         }
       }
     }
   } catch (error) {
-    console.error('❌ Chat streaming execution failed:', error);
+    console.error('Chat streaming execution failed:', error);
     throw error;
   }
 };

--- a/client/app/types/api.ts
+++ b/client/app/types/api.ts
@@ -420,12 +420,12 @@ export interface ChatMessageInput {
 
 // Webhook execution event types
 export interface ExecutionEvent {
-  type: "node_start" | "node_end" | "complete" | "workflow_complete" | "error" | "token";
+  type: "node_start" | "node_end" | "node_status" | "complete" | "workflow_complete" | "error" | "token";
   node_id?: string;
   output?: any;
   result?: any;
   error?: string;
-  status?: "success" | "failed" | "error";
+  status?: "pending" | "success" | "failed" | "error";
   previous_node_id?: string;
   edge_id?: string;
   edge_ids?: string[];
@@ -437,6 +437,10 @@ export interface ExecutionEvent {
   inputs?: Record<string, any>;
   inputs_meta?: Record<string, any>;
   node_outputs?: Record<string, any>;
+  execution_role?: "workflow" | "dependency";
+  node_statuses?: Record<string, "pending" | "success" | "failed">;
+  edge_statuses?: Record<string, "pending" | "success" | "failed">;
+  execution_node_id?: string;
   executed_nodes?: string[];
   session_id?: string;
 }


### PR DESCRIPTION
- Centralize runtime lifecycle tracking for provider nodes so LLM, tool, retriever, embedding, and reranker states are applied to the correct nodes and connections.
- Preserve the original failing provider across nested Agent and Retriever exception chains instead of attributing failures to parent nodes.
- Standardize pending, successful, and failed node and edge states across manual, chat, trigger, webhook, Kafka, timer, and error-trigger executions.
- Prevent provider and tool failures in MarkItDown, Tavily, Retriever, and base node execution paths from being returned as successful `ERROR` strings.
- Reject selected credentials with missing API keys instead of silently falling back to environment-based credentials.
- Normalize provider failures into actionable errors with stable codes for authentication, quota, rate limits, timeouts, connectivity, invalid requests, context limits, content policies, and service availability.
- Sanitize common API key and token formats from public error messages while preserving provider diagnostics and remediation guidance.
- Replace canvas JSON loading with the shared single-workflow parser used by the Workflows import flow.
- Allow valid canvas workflow JSON to load when node metadata or custom-node metadata refresh operations fail.
- Preserve support for legacy direct `nodes` and `edges` JSON while returning specific validation messages for malformed workflow files.