### PR TITLE
fix(canvas): prevent sticky note drag while selecting text

### DIFF
--- a/client/app/components/node/StickyNoteNode.tsx
+++ b/client/app/components/node/StickyNoteNode.tsx
@@ -155,7 +155,9 @@ function StickyNoteNode({ id, data, selected }: StickyNoteNodeProps) {
                 onChange={handleChange}
                 onBlur={handleBlur}
                 /* Textarea has its own scrollbar, avoiding double scrollbars */
-                className="w-full h-full resize-none bg-transparent border-none focus:outline-none focus:ring-0 text-gray-800 leading-relaxed overflow-y-auto custom-scrollbar"
+                className="nodrag nowheel w-full h-full resize-none bg-transparent border-none focus:outline-none focus:ring-0 text-gray-800 leading-relaxed overflow-y-auto custom-scrollbar"
+                onMouseDown={(e) => e.stopPropagation()}
+                onTouchStart={(e) => e.stopPropagation()}
                 style={{ fontSize: FONT_SIZE }}
                 placeholder="Type your markdown here..."
               />


### PR DESCRIPTION
 Summary
- Prevent Sticky Note node from moving while selecting text with left-click drag
- Add XYFlow `nodrag` / `nowheel` and pointer event stopPropagation on the edit textarea

Related to #546