### PR TITLE
Feat/multiline chat shift enter 543

### DIFF
--- a/client/app/components/KaiChatWidget.tsx
+++ b/client/app/components/KaiChatWidget.tsx
@@ -67,7 +67,7 @@ export default function KaiChatWidget({
   const [isLoading, setIsLoading] = useState(false);
   const [copiedCode, setCopiedCode] = useState<string | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
   const sessionIdRef = useRef(uuidv4());
 
   const copyToClipboard = async (text: string) => {
@@ -105,6 +105,9 @@ export default function KaiChatWidget({
 
     setMessages((prev) => [...prev, userMessage]);
     setInput("");
+    if (inputRef.current) {
+      inputRef.current.style.height = "auto";
+    }
     setIsLoading(true);
 
     // Bot mesajı için placeholder oluştur
@@ -310,6 +313,11 @@ export default function KaiChatWidget({
                     style={!msg.isBot ? { backgroundColor: color } : {}}
                   >
                     <div className="max-w-none break-words">
+                      {!msg.isBot ? (
+                        <p className="m-0 whitespace-pre-wrap break-words text-sm leading-relaxed text-white">
+                          {msg.content}
+                        </p>
+                      ) : (
                       <ReactMarkdown
                         remarkPlugins={[remarkGfm, remarkMath]}
                         rehypePlugins={[rehypeKatex, rehypeRaw]}
@@ -633,6 +641,7 @@ export default function KaiChatWidget({
                       >
                         {msg.content}
                       </ReactMarkdown>
+                      )}
                     </div>
                   </div>
                 </div>
@@ -654,27 +663,33 @@ export default function KaiChatWidget({
 
             {/* Input Alanı */}
             <div className="p-4 bg-white border-t border-gray-100">
-              <div className="flex gap-2 items-center bg-gray-50 rounded-full px-4 py-2 border border-gray-200 focus-within:border-blue-500 focus-within:ring-1 focus-within:ring-blue-500 transition-all">
-                <input
+              <div className="flex gap-2 items-end bg-gray-50 rounded-2xl px-4 py-2 border border-gray-200 focus-within:border-blue-500 focus-within:ring-1 focus-within:ring-blue-500 transition-all">
+                <textarea
                   ref={inputRef}
-                  type="text"
+                  rows={1}
                   value={input}
-                  onChange={(e) => setInput(e.target.value)}
+                  onChange={(e) => {
+                    setInput(e.target.value);
+                    const el = e.target;
+                    el.style.height = "auto";
+                    el.style.height = `${Math.min(el.scrollHeight, 128)}px`;
+                  }}
                   onKeyDown={(e) => {
-                    if (e.key === "Enter") {
+                    if (e.key === "Enter" && !e.shiftKey) {
+                      e.preventDefault();
                       sendMessage();
                       // Immediate focus attempt after sending
                       setTimeout(() => inputRef.current?.focus(), 0);
                     }
                   }}
                   placeholder="Write your message..."
-                  className="flex-1 bg-transparent border-none focus:ring-0 outline-none text-sm py-1"
+                  className="flex-1 bg-transparent border-none focus:ring-0 outline-none text-sm py-1 resize-none overflow-y-auto max-h-32 min-h-[24px]"
                   disabled={isLoading}
                 />
                 <button
                   onClick={sendMessage}
                   disabled={isLoading || !input.trim()}
-                  className={`p-2 rounded-full transition-all ${input.trim() && !isLoading
+                  className={`p-2 rounded-full transition-all shrink-0 ${input.trim() && !isLoading
                     ? "text-blue-600 hover:bg-blue-50"
                     : "text-gray-400"
                     }`}

--- a/client/app/components/canvas/ChatComponent.tsx
+++ b/client/app/components/canvas/ChatComponent.tsx
@@ -67,7 +67,7 @@ export default function ChatComponent({
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
   const [isExpanded, setIsExpanded] = useState(false);
-  const inputRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
   const {
     chats,
     setActiveChatflowId,
@@ -474,6 +474,9 @@ export default function ChatComponent({
       onSendMessage();
       setTimeout(() => inputRef.current?.focus(), 0);
     }
+    if (inputRef.current) {
+      inputRef.current.style.height = "auto";
+    }
   };
 
   const activeBuilderChats = activeBuilderChatflowId ? builderChats[activeBuilderChatflowId] || [] : [];
@@ -860,11 +863,11 @@ export default function ChatComponent({
           </div>
 
           {/* ─── Input Area ─── */}
-          <div className="p-3 border-t border-gray-700 flex gap-2">
-            <input
+          <div className="p-3 border-t border-gray-700 flex gap-2 items-end">
+            <textarea
               ref={inputRef}
-              type="text"
-              className={`flex-1 border rounded-lg px-3 py-2 text-sm transition-all duration-200 focus:outline-none ${mode === "builder"
+              rows={1}
+              className={`flex-1 border rounded-lg px-3 py-2 text-sm transition-all duration-200 focus:outline-none resize-none overflow-y-auto max-h-40 min-h-[40px] ${mode === "builder"
                   ? "border-purple-500 bg-gray-800 text-gray-100 placeholder-gray-400 focus:border-purple-400 focus:ring-1 focus:ring-purple-500/20"
                   : "border-gray-600 bg-gray-800 text-gray-100 placeholder-gray-400 focus:border-blue-400 focus:ring-1 focus:ring-blue-500/20"
                 }`}
@@ -876,15 +879,23 @@ export default function ChatComponent({
                   : "Write your message..."
               }
               value={currentInput}
-              onChange={(e) => setCurrentInput(e.target.value)}
+              onChange={(e) => {
+                setCurrentInput(e.target.value);
+                const el = e.target;
+                el.style.height = "auto";
+                el.style.height = `${Math.min(el.scrollHeight, 160)}px`;
+              }}
               onKeyDown={(e) => {
-                if (e.key === "Enter") handleUnifiedSend();
+                if (e.key === "Enter" && !e.shiftKey) {
+                  e.preventDefault();
+                  handleUnifiedSend();
+                }
               }}
               disabled={isLoading}
             />
             <button
               onClick={handleUnifiedSend}
-              className={`text-white px-4 py-2 rounded-lg disabled:opacity-50 ${mode === "builder"
+              className={`text-white px-4 py-2 rounded-lg disabled:opacity-50 shrink-0 ${mode === "builder"
                   ? "bg-purple-600 hover:bg-purple-700"
                   : "bg-blue-600 hover:bg-blue-700"
                 }`}

--- a/client/app/components/external/ExternalWorkflowChat.tsx
+++ b/client/app/components/external/ExternalWorkflowChat.tsx
@@ -33,7 +33,7 @@ export default function ExternalWorkflowChat({ workflow, isExported = false }: E
   const [loadingSessions, setLoadingSessions] = useState(false);
   const [loadingHistory, setLoadingHistory] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -194,6 +194,9 @@ export default function ExternalWorkflowChat({ workflow, isExported = false }: E
 
     setMessages(prev => [...prev, userMessage]);
     setInput('');
+    if (inputRef.current) {
+      inputRef.current.style.height = 'auto';
+    }
     setIsLoading(true);
 
     try {
@@ -426,20 +429,31 @@ export default function ExternalWorkflowChat({ workflow, isExported = false }: E
 
       {/* Input Form */}
       <div className="p-4 border-t bg-gray-50">
-        <form onSubmit={handleSendMessage} className="flex gap-2">
-          <input
+        <form onSubmit={handleSendMessage} className="flex gap-2 items-end">
+          <textarea
             ref={inputRef}
-            type="text"
+            rows={1}
             value={input}
-            onChange={(e) => setInput(e.target.value)}
+            onChange={(e) => {
+              setInput(e.target.value);
+              const el = e.target;
+              el.style.height = "auto";
+              el.style.height = `${Math.min(el.scrollHeight, 160)}px`;
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                e.currentTarget.form?.requestSubmit();
+              }
+            }}
             placeholder="Type your message..."
-            className="flex-1 px-4 py-2 border border-gray-300 rounded-full focus:ring-2 focus:ring-green-500 focus:border-transparent"
+            className="flex-1 px-4 py-2 border border-gray-300 rounded-2xl focus:ring-2 focus:ring-green-500 focus:border-transparent resize-none overflow-y-auto max-h-40 min-h-[40px]"
             disabled={isLoading || workflow.connection_status !== 'online'}
           />
           <button
             type="submit"
             disabled={!input.trim() || isLoading || workflow.connection_status !== 'online'}
-            className="px-4 py-2 bg-green-600 text-white rounded-full hover:bg-green-700 transition-colors disabled:bg-gray-400 disabled:cursor-not-allowed flex items-center justify-center"
+            className="px-4 py-2 bg-green-600 text-white rounded-full hover:bg-green-700 transition-colors disabled:bg-gray-400 disabled:cursor-not-allowed flex items-center justify-center shrink-0"
           >
             {isLoading ? (
               <Loader className="w-4 h-4 animate-spin" />


### PR DESCRIPTION
## Summary
- Add Shift+Enter support to insert a new line in chat inputs
- Enter still sends the message
- Updated ChatComponent, KaiChatWidget, and ExternalWorkflowChat

## Test plan
-  Enter sends the message
-  Shift+Enter inserts a new line
-  Textarea grows with multiple lines
-  Multiline messages render correctly after sending