### PR TITLE
feat: add PostgreSQL operations and dynamic database controls

### DIFF
--- a/backend/app/api/nodes.py
+++ b/backend/app/api/nodes.py
@@ -1,13 +1,20 @@
-
 import logging
 from typing import Dict, Any
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
+from pydantic import BaseModel, Field
+from starlette.concurrency import run_in_threadpool
 
 from app.core.node_registry import node_registry
+from app.auth.dependencies import get_current_user
+from app.core.credential_provider import credential_provider
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
+
+class NodeOptionsRequest(BaseModel):
+    property_name: str
+    values: Dict[str, Any] = Field(default_factory=dict)
 
 @router.get("")
 async def get_all_nodes():
@@ -260,3 +267,64 @@ async def search_nodes(query: str):
     # Sort by relevance
     results.sort(key=lambda x: x["relevance_score"], reverse=True)
     return results[:10]  # Return top 10 results
+
+@router.post("/{node_type}/options")
+async def get_node_property_options(
+    node_type: str,
+    request: NodeOptionsRequest,
+    current_user=Depends(get_current_user),
+):
+    """
+    Fill a dynamic field.
+
+    The node declares `optionsMethod` on the property; this endpoint calls that
+    method with the values currently entered in the panel and returns the list.
+    """
+    node_class = node_registry.get_node(node_type)
+    if not node_class:
+        raise HTTPException(status_code=404, detail=f"Node type '{node_type}' not found")
+
+    try:
+        instance = node_class()
+    except Exception as e:
+        logger.error(f"Could not create node {node_type}: {e}")
+        raise HTTPException(status_code=500, detail="Node could not be created")
+
+    prop = next(
+        (p for p in instance._metadata.get("properties", []) if p.name == request.property_name),
+        None,
+    )
+    if prop is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Property '{request.property_name}' not found on {node_type}",
+        )
+
+    method_name = getattr(prop, "optionsMethod", None)
+    if not method_name:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Property '{request.property_name}' does not load options dynamically",
+        )
+
+    loader = getattr(instance, method_name, None)
+    if not callable(loader):
+        raise HTTPException(
+            status_code=500,
+            detail=f"Node {node_type} has no method named '{method_name}'",
+        )
+
+    try:
+        instance.credentials = await run_in_threadpool(
+            credential_provider.get_credentials_sync, current_user.id
+        )
+    except Exception as e:
+        logger.warning(f"Could not load credentials for options request: {e}")
+        instance.credentials = []
+
+    try:
+        options = await run_in_threadpool(loader, request.values)
+        return {"options": options}
+    except Exception as e:
+        logger.error(f"Loading options for {node_type}.{request.property_name} failed: {e}")
+        raise HTTPException(status_code=400, detail=str(e))

--- a/backend/app/nodes/base.py
+++ b/backend/app/nodes/base.py
@@ -119,6 +119,8 @@ class NodePropertyType(str, Enum):
     DATETIME = "datetime"
     CODE_EDITOR = "code-editor"
     SESSION_ID = "session-id"
+    DYNAMIC_SELECT = "dynamic-select"
+    COLUMN_MAPPER = "column-mapper"
 
 
 class NodeProperty(BaseModel):
@@ -234,6 +236,22 @@ class NodeProperty(BaseModel):
     minLength: Optional[int] = Field(
         default=None,
         description="Minimum length of the input"
+    )
+    optionsMethod: Optional[str] = Field(
+        default=None,
+        description="Name of the method on the node that returns the option list",
+        alias="optionsMethod"
+    )
+
+    optionsDependsOn: Optional[List[str]] = Field(
+        default=None,
+        description="Fields that trigger a refetch of the option list when they change",
+        alias="optionsDependsOn"
+    )
+
+    multiple: Optional[bool] = Field(
+        default=None,
+        description="Allow more than one value to be selected"
     )
     
     colSpan: Optional[int] = Field(

--- a/backend/app/nodes/processing/postgres_node.py
+++ b/backend/app/nodes/processing/postgres_node.py
@@ -1,0 +1,1609 @@
+"""
+PostgreSQL Node
+===============
+
+Performs database operations against a PostgreSQL server: running raw SQL,
+selecting rows, inserting, updating, upserting and deleting.
+
+Design notes
+------------
+- Values are always passed as query parameters, never interpolated into the SQL
+  string. This is what prevents SQL injection.
+- Identifiers (schema, table, column names) cannot be parameterized by the
+  driver, so they are validated and quoted through ``psycopg2.sql`` instead.
+- Connections are opened per execution and always closed in a ``finally`` block.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+import uuid as uuid_module
+import logging
+from datetime import date, datetime, time as time_type, timedelta
+from decimal import Decimal
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+import psycopg2
+from psycopg2 import sql
+from psycopg2.extras import RealDictCursor
+
+from ..base import (
+    ProcessorNode,
+    NodeInput,
+    NodeOutput,
+    NodeType,
+    NodeProperty,
+    NodePropertyType,
+    NodePosition,
+)
+
+logger = logging.getLogger(__name__)
+
+# Identifiers must be plain names. Anything else is rejected before it reaches
+# the database, so a crafted table name cannot break out of its context.
+IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+# Operations that change data. Used by read-only mode.
+WRITE_OPERATIONS = {"insert", "update", "upsert", "delete"}
+
+# Statements that clearly change data or structure. This provides an early,
+# user-friendly error; PostgreSQL's transaction-level read-only mode is the
+# authoritative enforcement layer.
+WRITE_KEYWORDS = {
+    "insert", "update", "delete", "truncate", "drop", "create", "alter",
+    "grant", "revoke", "comment", "merge", "copy", "vacuum", "reindex",
+    "refresh", "call", "do",
+}
+
+# Comparison operators exposed in the condition builder, mapped to SQL.
+# Equality on text ignores case, so a filter written in lower case still finds
+# rows stored with capitals.
+CASE_FOLDED_OPERATORS = {"equals", "not_equals"}
+
+CONDITION_OPERATORS = {
+    "equals": "=",
+    "not_equals": "!=",
+    "greater_than": ">",
+    "greater_or_equal": ">=",
+    "less_than": "<",
+    "less_or_equal": "<=",
+    "like": "LIKE",
+    "ilike": "ILIKE",
+    "is_null": "IS NULL",
+    "is_not_null": "IS NOT NULL",
+}
+
+
+class PostgresNode(ProcessorNode):
+    """Runs SQL statements and table operations against a PostgreSQL database."""
+
+    def __init__(self):
+        super().__init__()
+        self._metadata = {
+            "name": "PostgresNode",
+            "display_name": "PostgreSQL",
+            "description": (
+                "Run queries and manage rows in a PostgreSQL database. Supports raw SQL, "
+                "select, insert, update, upsert and delete with parameterized values."
+            ),
+            "category": "Databases",
+            "node_type": NodeType.PROCESSOR,
+            "icon": {
+                "name": "postgresql_vectorstore",
+                "path": "icons/postgresql_vectorstore.svg",
+                "alt": "PostgreSQL",
+            },
+            "colors": ["indigo-500", "purple-600"],
+            "inputs": [
+                NodeInput(
+                    name="input",
+                    type="any",
+                    description="Incoming data. Used as row values when the Data field is left empty.",
+                    is_connection=True,
+                    direction=NodePosition.LEFT,
+                    required=False,
+                ),
+            ],
+            "outputs": [
+                NodeOutput(
+                    name="output",
+                    displayName="Output",
+                    type="dict",
+                    description=(
+                        "Result of the operation: the rows it returned, how many were affected "
+                        "and how long it took."
+                    ),
+                    is_connection=True,
+                    direction=NodePosition.RIGHT,
+                ),
+                NodeOutput(
+                    name="success",
+                    type="boolean",
+                    description="Whether the operation completed without an error.",
+                ),
+                NodeOutput(
+                    name="error",
+                    type="string",
+                    description="Error message when the operation failed.",
+                ),
+            ],
+            "properties": [
+                # ----------------------------------------------------------
+                # Basic
+                # ----------------------------------------------------------
+                NodeProperty(
+                    name="credential_id",
+                    displayName="Credential",
+                    type=NodePropertyType.CREDENTIAL_SELECT,
+                    description="PostgreSQL connection to use.",
+                    placeholder="Select Credential",
+                    required=True,
+                    serviceType="postgresql_vectorstore",
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="operation",
+                    displayName="Operation",
+                    type=NodePropertyType.SELECT,
+                    description="The database operation to perform.",
+                    required=True,
+                    default="select",
+                    options=[
+                        {"label": "Execute Query", "value": "execute_query"},
+                        {"label": "Select", "value": "select"},
+                        {"label": "Insert", "value": "insert"},
+                        {"label": "Update", "value": "update"},
+                        {"label": "Insert or Update", "value": "upsert"},
+                        {"label": "Delete", "value": "delete"},
+                    ],
+                    tabName="basic",
+                ),
+
+                # --- Execute Query -----------------------------------------
+                NodeProperty(
+                    name="query",
+                    displayName="Query",
+                    type=NodePropertyType.CODE_EDITOR,
+                    description=(
+                        "SQL statement to run. Use $1, $2 placeholders for values and supply "
+                        "them in Query Parameters so they are escaped safely."
+                    ),
+                    placeholder="SELECT * FROM customers WHERE city = $1;",
+                    required=False,
+                    default="",
+                    rows=8,
+                    maxLength=20000,
+                    displayOptions={"show": {"operation": "execute_query"}},
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="query_parameters",
+                    displayName="Query Parameters",
+                    type=NodePropertyType.JSON_EDITOR,
+                    description=(
+                        "Values for the $1, $2 placeholders, in order. Given as a JSON array, "
+                        "for example: [\"aksesuar\", 2000]"
+                    ),
+                    placeholder='["value1", 100]',
+                    required=False,
+                    default="[]",
+                    displayOptions={"show": {"operation": "execute_query"}},
+                    tabName="basic",
+                ),
+
+                # --- Table targeting ---------------------------------------
+                NodeProperty(
+                    name="schema_name",
+                    displayName="Schema",
+                    type=NodePropertyType.DYNAMIC_SELECT,
+                    description=(
+                        "Schema that contains the table. Pick one from the list or type a name, "
+                        "which also accepts a template."
+                    ),
+                    placeholder="Select or type a schema",
+                    required=False,
+                    default="public",
+                    optionsMethod="load_schemas",
+                    optionsDependsOn=["credential_id"],
+                    displayOptions={"show": {"operation": ["select", "insert", "update", "upsert", "delete"]}},
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="table_name",
+                    displayName="Table",
+                    type=NodePropertyType.DYNAMIC_SELECT,
+                    description=(
+                        "Table to operate on. Pick one from the list or type a name, which also "
+                        "accepts a template."
+                    ),
+                    placeholder="Select or type a table",
+                    required=False,
+                    default="",
+                    optionsMethod="load_tables",
+                    optionsDependsOn=["credential_id", "schema_name"],
+                    displayOptions={"show": {"operation": ["select", "insert", "update", "upsert", "delete"], "schema_name": "*"}},
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="columns",
+                    displayName="Columns",
+                    type=NodePropertyType.DYNAMIC_SELECT,
+                    description="Columns to return. Leave empty for all of them.",
+                    placeholder="All columns",
+                    required=False,
+                    default="",
+                    multiple=True,
+                    optionsMethod="load_columns",
+                    optionsDependsOn=["credential_id", "schema_name", "table_name"],
+                    displayOptions={"show": {"operation": "select", "table_name": "*"}},
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="return_all",
+                    displayName="Return All",
+                    type=NodePropertyType.CHECKBOX,
+                    description="Return every matching row. Turn off to apply a limit.",
+                    required=False,
+                    default=True,
+                    displayOptions={"show": {"operation": "select", "table_name": "*"}},
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="limit",
+                    displayName="Limit",
+                    type=NodePropertyType.NUMBER,
+                    description="Maximum number of rows to return.",
+                    required=False,
+                    default=50,
+                    min=1,
+                    max=10000,
+                    displayOptions={"show": {"operation": "select", "return_all": False}},
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="sort_column",
+                    displayName="Sort Column",
+                    type=NodePropertyType.DYNAMIC_SELECT,
+                    description="Column the results are ordered by. Leave empty for no ordering.",
+                    placeholder="No ordering",
+                    required=False,
+                    default="",
+                    optionsMethod="load_columns",
+                    optionsDependsOn=["credential_id", "schema_name", "table_name"],
+                    displayOptions={"show": {"operation": "select", "table_name": "*"}},
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="sort_direction",
+                    displayName="Sort Direction",
+                    type=NodePropertyType.SELECT,
+                    description="Order direction for the sort column.",
+                    required=False,
+                    default="ASC",
+                    options=[
+                        {"label": "Ascending", "value": "ASC"},
+                        {"label": "Descending", "value": "DESC"},
+                    ],
+                    displayOptions={"show": {"operation": "select", "sort_column": "*"}},
+                    tabName="basic",
+                ),
+
+                # --- Conditions --------------------------------------------
+                # --- Conditions (Select and Delete) --------------------------
+                NodeProperty(
+                    name="delete_command",
+                    displayName="Command",
+                    type=NodePropertyType.SELECT,
+                    description="How the data should be removed.",
+                    required=False,
+                    default="delete",
+                    options=[
+                        {"label": "Delete - remove matching rows", "value": "delete"},
+                        {"label": "Truncate - remove all rows, keep the table", "value": "truncate"},
+                    ],
+                    hint=(
+                        "Truncate is much faster than Delete but empties the whole table; "
+                        "any filter below is ignored."
+                    ),
+                    displayOptions={"show": {"operation": "delete", "table_name": "*"}},
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="restart_sequences",
+                    displayName="Restart Sequences",
+                    type=NodePropertyType.CHECKBOX,
+                    description="Reset auto incrementing columns back to their starting value.",
+                    required=False,
+                    default=False,
+                    displayOptions={"show": {"operation": "delete", "delete_command": "truncate"}},
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="cascade",
+                    displayName="Cascade",
+                    type=NodePropertyType.CHECKBOX,
+                    description="Also truncate tables that reference this one through a foreign key.",
+                    required=False,
+                    default=False,
+                    displayOptions={"show": {"operation": "delete", "delete_command": "truncate"}},
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="filter_column",
+                    displayName="Filter Column",
+                    type=NodePropertyType.DYNAMIC_SELECT,
+                    description=(
+                        "Column the rows are matched on. Select may leave this empty. Update and "
+                        "Delete require either this filter or an Extra Condition."
+                    ),
+                    placeholder="No filter, match every row",
+                    required=False,
+                    default="",
+                    optionsMethod="load_columns",
+                    optionsDependsOn=["credential_id", "schema_name", "table_name"],
+                    displayOptions={"show": {"operation": ["select", "update", "delete"], "table_name": "*"}},
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="filter_operator",
+                    displayName="Filter Operator",
+                    type=NodePropertyType.SELECT,
+                    description=(
+                        "How the column is compared to the value. Text comparisons ignore "
+                        "capitalisation, so 'bursa' also matches 'Bursa' and 'BURSA'."
+                    ),
+                    required=False,
+                    default="equals",
+                    options=[
+                        {"label": "is equal to", "value": "equals"},
+                        {"label": "is not equal to", "value": "not_equals"},
+                        {"label": "is greater than", "value": "greater_than"},
+                        {"label": "is greater than or equal to", "value": "greater_or_equal"},
+                        {"label": "is less than", "value": "less_than"},
+                        {"label": "is less than or equal to", "value": "less_or_equal"},
+                        {"label": "contains", "value": "ilike"},
+                        {"label": "contains (case sensitive)", "value": "like"},
+                        {"label": "is empty", "value": "is_null"},
+                        {"label": "is not empty", "value": "is_not_null"},
+                    ],
+                    displayOptions={"show": {"operation": ["select", "update", "delete"], "filter_column": "*"}},
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="filter_value",
+                    displayName="Filter Value",
+                    type=NodePropertyType.TEXT,
+                    description=(
+                        "Value the column is compared to. Not needed for the empty and not empty "
+                        "operators."
+                    ),
+                    placeholder="e.g. Istanbul",
+                    required=False,
+                    default="",
+                    displayOptions={"show": {"operation": ["select", "update", "delete"], "filter_column": "*", "filter_operator": ["equals", "not_equals", "greater_than", "greater_or_equal", "less_than", "less_or_equal", "like", "ilike"]}},
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="where_conditions",
+                    displayName="Extra Conditions",
+                    type=NodePropertyType.JSON_EDITOR,
+                    description=(
+                        "Further conditions as a JSON array, for cases the single filter above "
+                        "cannot express. Each entry takes column, operator and value."
+                    ),
+                    placeholder='[{"column": "is_active", "operator": "equals", "value": true}]',
+                    required=False,
+                    default="[]",
+                    hint=(
+                        "Operators: equals, not_equals, greater_than, greater_or_equal, "
+                        "less_than, less_or_equal, like, ilike, is_null, is_not_null"
+                    ),
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="combine_conditions",
+                    displayName="Combine Conditions",
+                    type=NodePropertyType.SELECT,
+                    description="How multiple conditions are joined together.",
+                    required=False,
+                    default="AND",
+                    options=[
+                        {"label": "AND - all must match", "value": "AND"},
+                        {"label": "OR - any may match", "value": "OR"},
+                    ],
+                    tabName="basic",
+                ),
+
+                # --- Column mapping (Insert, Update, Upsert) ------------------
+                NodeProperty(
+                    name="mapping_mode",
+                    displayName="Mapping Column Mode",
+                    type=NodePropertyType.SELECT,
+                    description="How column names are matched to the incoming data.",
+                    required=False,
+                    default="manual",
+                    options=[
+                        {
+                            "label": "Map Each Column Manually",
+                            "value": "manual",
+                            "hint": "Write the column values yourself.",
+                        },
+                        {
+                            "label": "Map Automatically",
+                            "value": "auto",
+                            "hint": "Take the values from the incoming data. Field names must match the column names.",
+                        },
+                    ],
+                    displayOptions={"show": {"operation": ["insert", "update", "upsert"], "table_name": "*"}},
+                    tabName="basic",
+                ),
+                NodeProperty(
+                    name="match_columns",
+                    displayName="Columns to Match On",
+                    type=NodePropertyType.DYNAMIC_SELECT,
+                    description=(
+                        "Columns used to find the existing row. Their values are read from the "
+                        "data, so they must be present there."
+                    ),
+                    placeholder="Select a column",
+                    required=False,
+                    default="",
+                    multiple=True,
+                    optionsMethod="load_columns",
+                    optionsDependsOn=["credential_id", "schema_name", "table_name"],
+                    hint=(
+                        "For Insert or Update the column has to carry a unique constraint. "
+                        "Pick more than one to match on a composite key."
+                    ),
+                    displayOptions={"show": {"operation": ["update", "upsert"], "table_name": "*"}},
+                    tabName="basic",
+                ),
+
+                NodeProperty(
+                    name="data",
+                    displayName="Values to Send",
+                    type=NodePropertyType.COLUMN_MAPPER,
+                    description=(
+                        "Value for each column of the selected table. Columns can be left out; "
+                        "the database then applies its own default."
+                    ),
+                    required=False,
+                    default="{}",
+                    optionsMethod="load_column_schema",
+                    optionsDependsOn=["credential_id", "schema_name", "table_name"],
+                    hint=(
+                        "Switch Mapping Column Mode to Map Automatically to take the values from "
+                        "the incoming data instead."
+                    ),
+                    displayOptions={"show": {"operation": ["insert", "update", "upsert"], "mapping_mode": "manual"}},
+                    tabName="basic",
+                ),
+
+                # ----------------------------------------------------------
+                # Advanced
+                # ----------------------------------------------------------
+                NodeProperty(
+                    name="read_only",
+                    displayName="Read Only",
+                    type=NodePropertyType.CHECKBOX,
+                    description=(
+                        "Allow reading only. Insert, update, upsert and delete are refused, and "
+                        "raw statements run inside a PostgreSQL read-only transaction. "
+                        "Useful when the node is reachable by an agent."
+                    ),
+                    required=False,
+                    default=False,
+                    tabName="advanced",
+                ),
+                NodeProperty(
+                    name="return_columns",
+                    displayName="Output Columns",
+                    type=NodePropertyType.DYNAMIC_SELECT,
+                    description=(
+                        "Columns to return after a write. Leave empty to return every column of "
+                        "the affected rows."
+                    ),
+                    placeholder="All columns",
+                    required=False,
+                    default="",
+                    multiple=True,
+                    optionsMethod="load_columns",
+                    optionsDependsOn=["credential_id", "schema_name", "table_name"],
+                    displayOptions={"show": {"operation": ["insert", "update", "upsert", "delete"]}},
+                    tabName="advanced",
+                ),
+                NodeProperty(
+                    name="use_transaction",
+                    displayName="Use Transaction",
+                    type=NodePropertyType.CHECKBOX,
+                    description=(
+                        "Wrap the operation in a transaction so a failure rolls back every change. "
+                        "Turn off to commit each statement on its own."
+                    ),
+                    required=False,
+                    default=True,
+                    tabName="advanced",
+                ),
+                NodeProperty(
+                    name="skip_on_conflict",
+                    displayName="Skip on Conflict",
+                    type=NodePropertyType.CHECKBOX,
+                    description=(
+                        "Ignore rows that violate a unique constraint instead of raising an error."
+                    ),
+                    required=False,
+                    default=False,
+                    displayOptions={"show": {"operation": "insert"}},
+                    tabName="advanced",
+                ),
+                NodeProperty(
+                    name="replace_empty_with_null",
+                    displayName="Replace Empty Strings with NULL",
+                    type=NodePropertyType.CHECKBOX,
+                    description=(
+                        "Store empty text values as NULL. Useful for data exported from spreadsheets."
+                    ),
+                    required=False,
+                    default=False,
+                    displayOptions={"show": {"operation": ["insert", "update", "upsert"]}},
+                    tabName="advanced",
+                ),
+                NodeProperty(
+                    name="numbers_as_text",
+                    displayName="Return Numbers as Text",
+                    type=NodePropertyType.CHECKBOX,
+                    description=(
+                        "Return NUMERIC and DECIMAL columns as text to keep every digit. "
+                        "Turn this on for money amounts and other values where rounding is "
+                        "not acceptable."
+                    ),
+                    required=False,
+                    default=False,
+                    tabName="advanced",
+                ),
+                NodeProperty(
+                    name="connection_timeout",
+                    displayName="Connection Timeout (seconds)",
+                    type=NodePropertyType.NUMBER,
+                    description="How long to wait for the database to accept the connection.",
+                    required=False,
+                    default=30,
+                    min=1,
+                    max=300,
+                    tabName="advanced",
+                ),
+                NodeProperty(
+                    name="statement_timeout",
+                    displayName="Statement Timeout (seconds)",
+                    type=NodePropertyType.NUMBER,
+                    description="Cancel the query if it runs longer than this. Set 0 to disable.",
+                    required=False,
+                    default=60,
+                    min=0,
+                    max=3600,
+                    tabName="advanced",
+                ),
+                NodeProperty(
+                    name="continue_on_error",
+                    displayName="Continue on Error",
+                    type=NodePropertyType.CHECKBOX,
+                    description=(
+                        "Let the workflow carry on when the query fails. The error is reported in "
+                        "the output instead of stopping the run."
+                    ),
+                    required=False,
+                    default=False,
+                    tabName="advanced",
+                ),
+            ],
+        }
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _validate_identifier(value: str, label: str) -> str:
+        """Reject anything that is not a plain SQL identifier."""
+        value = (value or "").strip()
+        if not value:
+            raise ValueError(f"{label} is required.")
+        if not IDENTIFIER_PATTERN.match(value):
+            raise ValueError(
+                f"{label} '{value}' is not a valid identifier. "
+                "Use letters, digits and underscores, starting with a letter or underscore."
+            )
+        return value
+
+    @classmethod
+    def _split_columns(cls, raw: Any) -> List[str]:
+        """Turn a string or list of column names into validated identifiers."""
+        if not raw:
+            return []
+        if isinstance(raw, str):
+            parts = raw.split(",")
+        elif isinstance(raw, (list, tuple)):
+            parts = [str(part) for part in raw]
+        else:
+            parts = [str(raw)]
+        return [
+            cls._validate_identifier(part, "Column")
+            for part in parts
+            if part.strip()
+        ]
+
+    @staticmethod
+    def _coerce_json(value: Any, fallback: Any) -> Any:
+        """Accept either an already parsed structure or a JSON string."""
+        if value is None or value == "":
+            return fallback
+        if isinstance(value, (dict, list)):
+            return value
+        if isinstance(value, str):
+            import json
+            try:
+                return json.loads(value)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"Could not parse JSON value: {exc}") from exc
+        return fallback
+
+    def _build_connection_kwargs(self, credential_id: Optional[str]) -> Dict[str, Any]:
+        """Read the credential and return safe keyword arguments for psycopg2."""
+        if not credential_id:
+            raise ValueError("A PostgreSQL credential is required.")
+
+        credential = self.get_credential(credential_id)
+        if not credential or not credential.get("secret"):
+            raise ValueError(
+                "The selected credential could not be read. It may have been created with a "
+                "different encryption key; try recreating it."
+            )
+
+        secret = credential["secret"]
+        connection_args: Dict[str, Any] = {
+            "host": secret.get("host", "localhost"),
+            "port": int(secret.get("port", 5432)),
+            "dbname": secret.get("database", "postgres"),
+            "user": secret.get("username", "postgres"),
+            "password": secret.get("password", ""),
+        }
+
+        for key in (
+            "sslmode",
+            "sslcert",
+            "sslkey",
+            "sslrootcert",
+            "application_name",
+        ):
+            if secret.get(key) not in (None, ""):
+                connection_args[key] = secret[key]
+
+        return connection_args
+
+    # ------------------------------------------------------------------
+    # Option loaders
+    #
+    # Called by the node options endpoint when a dynamic dropdown needs to be
+    # filled. Each one receives the values currently entered in the panel.
+    # ------------------------------------------------------------------
+
+    def _fetch_one_column(self, credential_id: str, statement: str, params: tuple = ()) -> List[str]:
+        """Open a short-lived connection and read a single column."""
+        connection = None
+        try:
+            connection = psycopg2.connect(
+                **self._build_connection_kwargs(credential_id), connect_timeout=10
+            )
+            with connection.cursor() as cursor:
+                cursor.execute("SET statement_timeout = 5000")
+                cursor.execute(statement, params or None)
+                return [row[0] for row in cursor.fetchall()]
+        finally:
+            if connection is not None:
+                connection.close()
+
+    def load_schemas(self, values: Dict[str, Any]) -> List[Dict[str, str]]:
+        """List the schemas the credential can see."""
+        names = self._fetch_one_column(
+            values.get("credential_id"),
+            """
+            SELECT schema_name
+            FROM information_schema.schemata
+            WHERE schema_name NOT IN ('information_schema', 'pg_catalog', 'pg_toast')
+              AND schema_name NOT LIKE 'pg_temp%'
+              AND schema_name NOT LIKE 'pg_toast_temp%'
+            ORDER BY schema_name
+            """,
+        )
+        return [{"label": name, "value": name} for name in names]
+
+    def load_tables(self, values: Dict[str, Any]) -> List[Dict[str, str]]:
+        """List the tables and views in the selected schema."""
+        schema = (values.get("schema_name") or "public").strip()
+        names = self._fetch_one_column(
+            values.get("credential_id"),
+            """
+            SELECT table_name
+            FROM information_schema.tables
+            WHERE table_schema = %s
+              AND table_type IN ('BASE TABLE', 'VIEW')
+            ORDER BY table_name
+            """,
+            (schema,),
+        )
+        return [{"label": name, "value": name} for name in names]
+
+    def load_columns(self, values: Dict[str, Any]) -> List[Dict[str, str]]:
+        """List the columns of the selected table."""
+        schema = (values.get("schema_name") or "public").strip()
+        table = (values.get("table_name") or "").strip()
+        if not table:
+            return []
+        names = self._fetch_one_column(
+            values.get("credential_id"),
+            """
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_schema = %s AND table_name = %s
+            ORDER BY ordinal_position
+            """,
+            (schema, table),
+        )
+        return [{"label": name, "value": name} for name in names]
+
+    # Postgres data types mapped to the input the panel should show.
+    WIDGET_BY_TYPE = {
+        "boolean": "checkbox",
+        "smallint": "number", "integer": "number",
+        "real": "number", "double precision": "number",
+        "date": "datetime",
+        "timestamp with time zone": "datetime",
+        "timestamp without time zone": "datetime",
+        "json": "json", "jsonb": "json",
+    }
+
+    def load_column_schema(self, values: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """
+        Describe the columns of the selected table.
+
+        Each entry carries the input the panel should render, whether a value is
+        required and whether the database fills one in on its own.
+        """
+        schema = (values.get("schema_name") or "public").strip()
+        table = (values.get("table_name") or "").strip()
+        if not table:
+            return []
+
+        connection = None
+        try:
+            connection = psycopg2.connect(
+                **self._build_connection_kwargs(values.get("credential_id")), connect_timeout=10
+            )
+            with connection.cursor() as cursor:
+                cursor.execute("SET statement_timeout = 5000")
+                cursor.execute(
+                    """
+                    SELECT column_name, data_type, is_nullable, column_default
+                    FROM information_schema.columns
+                    WHERE table_schema = %s AND table_name = %s
+                    ORDER BY ordinal_position
+                    """,
+                    (schema, table),
+                )
+                rows = cursor.fetchall()
+        finally:
+            if connection is not None:
+                connection.close()
+
+        columns: List[Dict[str, Any]] = []
+        for name, data_type, is_nullable, default in rows:
+            columns.append({
+                "label": name,
+                "value": name,
+                "name": name,
+                "type": data_type,
+                "widget": self.WIDGET_BY_TYPE.get(data_type, "text"),
+                "required": is_nullable == "NO" and default is None,
+                "hasDefault": default is not None,
+            })
+        return columns
+
+    def _collect_conditions(self, inputs: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """
+        Gather the row filter.
+
+        The three filter fields cover the common case of a single comparison and
+        are picked from lists rather than typed. Anything more involved goes in
+        Extra Conditions as JSON. Both are merged here, so the rest of the code
+        only ever sees one list.
+        """
+        conditions: List[Dict[str, Any]] = []
+
+        column = (inputs.get("filter_column") or "").strip()
+        if column:
+            operator = (inputs.get("filter_operator") or "equals").strip()
+            condition: Dict[str, Any] = {"column": column, "operator": operator}
+            if operator not in ("is_null", "is_not_null"):
+                condition["value"] = inputs.get("filter_value", "")
+            conditions.append(condition)
+
+        extra = self._coerce_json(inputs.get("where_conditions"), [])
+        if isinstance(extra, list):
+            conditions.extend(entry for entry in extra if isinstance(entry, dict) and entry)
+
+        return conditions
+
+    @staticmethod
+    def _prepare_condition_value(operator: str, value: Any) -> Any:
+        """
+        Shape a value for the operator it will be used with.
+
+        The contains operators run on LIKE, which treats a plain string as an
+        exact match. Wrapping it in wildcards is what someone picking "contains"
+        expects. A value that already carries a wildcard is left alone, so a
+        deliberate pattern still works.
+        """
+        if operator not in ("like", "ilike"):
+            return value
+        if not isinstance(value, str) or not value:
+            return value
+        if "%" in value or "_" in value:
+            return value
+        return f"%{value}%"
+
+    def _build_where_clause(
+        self, conditions: List[Dict[str, Any]], combiner: str
+    ) -> Tuple[Optional[sql.Composed], List[Any]]:
+        """Compose a WHERE clause and collect its parameter values."""
+        if not conditions:
+            return None, []
+
+        joiner = " AND " if str(combiner).upper() != "OR" else " OR "
+        fragments: List[sql.Composed] = []
+        values: List[Any] = []
+
+        for condition in conditions:
+            if not isinstance(condition, dict):
+                raise ValueError("Each condition must be an object with column, operator and value.")
+
+            column = self._validate_identifier(condition.get("column", ""), "Condition column")
+            operator_key = str(condition.get("operator", "equals")).lower()
+
+            if operator_key not in CONDITION_OPERATORS:
+                raise ValueError(
+                    f"Unknown operator '{operator_key}'. "
+                    f"Supported operators: {', '.join(CONDITION_OPERATORS)}"
+                )
+
+            operator_sql = CONDITION_OPERATORS[operator_key]
+
+            # NULL checks take no value on the right hand side.
+            if operator_key in ("is_null", "is_not_null"):
+                fragments.append(
+                    sql.SQL("{} {}").format(sql.Identifier(column), sql.SQL(operator_sql))
+                )
+            else:
+                value = self._prepare_condition_value(operator_key, condition.get("value"))
+
+                # Equality on text is compared without regard to case. Someone
+                # filtering on "bursa" means the rows holding "Bursa" and "BURSA"
+                # as well; a plain = would quietly pass over them. The cast keeps
+                # this safe on columns that are not text.
+                if operator_key in CASE_FOLDED_OPERATORS and isinstance(value, str):
+                    fragments.append(
+                        sql.SQL("LOWER({}::text) {} LOWER(%s)").format(
+                            sql.Identifier(column), sql.SQL(operator_sql)
+                        )
+                    )
+                else:
+                    fragments.append(
+                        sql.SQL("{} {} %s").format(
+                            sql.Identifier(column), sql.SQL(operator_sql)
+                        )
+                    )
+
+                values.append(value)
+
+        return sql.SQL(joiner).join(fragments), values
+
+    # Trigger nodes wrap the payload, sometimes more than once. A webhook, for
+    # instance, nests the request body under webhook_data.payload.
+    ENVELOPE_KEYS = ("webhook_data", "payload", "body", "json", "data", "result", "rows")
+
+    @classmethod
+    def _unwrap_payload(cls, value: Any, depth: int = 4) -> Any:
+        """
+        Reach the row inside a trigger's envelope.
+
+        A trigger hands over its whole context, with the row sitting alongside
+        timestamps, identifiers and configuration. Recognised wrapper keys are
+        peeled off one at a time until the row itself is reached.
+        """
+        if depth <= 0 or not isinstance(value, dict):
+            return value
+
+        for key in cls.ENVELOPE_KEYS:
+            inner = value.get(key)
+            if isinstance(inner, dict) and inner:
+                return cls._unwrap_payload(inner, depth - 1)
+            if isinstance(inner, list) and inner and isinstance(inner[0], dict):
+                return inner
+
+        return value
+
+    def _table_columns(self, inputs: Dict[str, Any]) -> List[str]:
+        """Read the column names of the target table, or an empty list on failure."""
+        try:
+            schema = self._validate_identifier(inputs.get("schema_name", "public"), "Schema")
+            table = self._validate_identifier(inputs.get("table_name", ""), "Table")
+        except ValueError:
+            return []
+
+        try:
+            return self._fetch_one_column(
+                inputs.get("credential_id"),
+                """
+                SELECT column_name
+                FROM information_schema.columns
+                WHERE table_schema = %s AND table_name = %s
+                ORDER BY ordinal_position
+                """,
+                (schema, table),
+            )
+        except Exception as exc:
+            logger.warning(f"Could not read the columns of {table}: {exc}")
+            return []
+
+    def _resolve_rows(
+        self,
+        raw_data: Any,
+        connected_nodes: Dict[str, Any],
+        replace_empty: bool,
+        inputs: Optional[Dict[str, Any]] = None,
+    ) -> List[Dict[str, Any]]:
+        """
+        Collect the rows to write.
+
+        Accepts a single object or an array, taken either from the Data field or
+        from the input connection. Always returns a list so one row and many rows
+        can be handled the same way.
+
+        Data arriving on the connection is filtered down to the table's own
+        columns. A trigger usually sends more than the row itself, and passing
+        those extras through would only produce an error the author cannot act
+        on.
+        """
+        mapping_mode = str((inputs or {}).get("mapping_mode") or "").lower()
+        from_connection = mapping_mode == "auto"
+
+        if mapping_mode == "auto":
+            data = self._unwrap_payload(connected_nodes.get("input"))
+        else:
+            data = self._coerce_json(raw_data, None)
+
+            # Preserve workflows created before mapping_mode existed.
+            if not mapping_mode and not data:
+                data = self._unwrap_payload(connected_nodes.get("input"))
+                from_connection = True
+
+        if isinstance(data, dict):
+            rows = [data]
+        elif isinstance(data, list):
+            rows = [row for row in data if isinstance(row, dict) and row]
+        else:
+            rows = []
+
+        if not rows:
+            if mapping_mode == "auto":
+                raise ValueError(
+                    "Automatic mapping requires an input connection that produces an object "
+                    "or a list of objects."
+                )
+            raise ValueError("No column values were supplied in the Data field.")
+
+        # Only the table's own columns survive when the data comes off a wire.
+        known: Optional[Set[str]] = None
+        if from_connection and inputs is not None:
+            columns = self._table_columns(inputs)
+            if columns:
+                known = {name.lower() for name in columns}
+
+        cleaned: List[Dict[str, Any]] = []
+        for row in rows:
+            if known is not None:
+                row = {key: value for key, value in row.items() if str(key).lower() in known}
+                if not row:
+                    raise ValueError(
+                        "None of the incoming fields match a column of the table. "
+                        "Check the field names, or switch to Map Each Column Manually."
+                    )
+
+            if replace_empty:
+                row = {key: (None if value == "" else value) for key, value in row.items()}
+
+            # Column names come from user data, so they are validated too.
+            cleaned.append(
+                {self._validate_identifier(key, "Column"): value for key, value in row.items()}
+            )
+
+        # Every row has to describe the same columns for a single statement to work.
+        first_columns = set(cleaned[0].keys())
+        for index, row in enumerate(cleaned[1:], start=2):
+            if set(row.keys()) != first_columns:
+                raise ValueError(
+                    f"Row {index} does not have the same columns as the first row. "
+                    "Every row must carry the same set of columns."
+                )
+
+        return cleaned
+
+    @classmethod
+    def _split_match_columns(cls, raw: Any) -> List[str]:
+        """Read the match column selection, which may be a string or a list."""
+        if not raw:
+            return []
+        if isinstance(raw, str):
+            parts = [part.strip() for part in raw.split(",")]
+        elif isinstance(raw, (list, tuple)):
+            parts = [str(part).strip() for part in raw]
+        else:
+            parts = [str(raw).strip()]
+        return [cls._validate_identifier(part, "Match column") for part in parts if part]
+
+    @staticmethod
+    def _guard_read_only(operation: str, query: str = "") -> None:
+        """Provide an early error for obvious writes in read-only mode.
+
+        Execute also enables PostgreSQL's transaction-level read-only setting,
+        which is the authoritative protection for complex SQL forms.
+        """
+        if operation in WRITE_OPERATIONS:
+            raise ValueError(
+                f"Read Only is enabled, so the '{operation}' operation is not allowed. "
+                "Turn Read Only off in the Advanced tab to write to the database."
+            )
+
+        if operation != "execute_query" or not query:
+            return
+
+        # A raw statement can hide a write behind a semicolon, so each statement
+        # is checked on its own.
+        for statement in query.split(";"):
+            statement = statement.strip()
+            if not statement:
+                continue
+            first_word = re.split(r"\s+", statement, maxsplit=1)[0].lower()
+            if first_word in WRITE_KEYWORDS:
+                raise ValueError(
+                    f"Read Only is enabled, so a statement starting with '{first_word.upper()}' "
+                    "is not allowed. Only read statements can run in this mode."
+                )
+
+    @classmethod
+    def _serialize_value(cls, value: Any, numbers_as_text: bool = False) -> Any:
+        """
+        Convert driver types into values that survive JSON serialization.
+
+        Execution results are stored as JSON, so ``Decimal``, ``datetime`` and
+        friends have to be converted before they leave the node.
+        """
+        if value is None or isinstance(value, (str, int, float, bool)):
+            return value
+        if isinstance(value, Decimal):
+            return str(value) if numbers_as_text else float(value)
+        if isinstance(value, (datetime, date, time_type)):
+            return value.isoformat()
+        if isinstance(value, timedelta):
+            return value.total_seconds()
+        if isinstance(value, uuid_module.UUID):
+            return str(value)
+        if isinstance(value, (bytes, bytearray, memoryview)):
+            return bytes(value).hex()
+        if isinstance(value, dict):
+            return {key: cls._serialize_value(item, numbers_as_text) for key, item in value.items()}
+        if isinstance(value, (list, tuple, set)):
+            return [cls._serialize_value(item, numbers_as_text) for item in value]
+        return str(value)
+
+    @classmethod
+    def _serialize_rows(
+        cls, rows: List[Dict[str, Any]], numbers_as_text: bool = False
+    ) -> List[Dict[str, Any]]:
+        """Apply value serialization across every returned row."""
+        return [
+            {key: cls._serialize_value(value, numbers_as_text) for key, value in row.items()}
+            for row in rows
+        ]
+
+    @staticmethod
+    def _returning_clause(columns: List[str]) -> sql.Composed:
+        """Build the RETURNING part of a write statement."""
+        if columns:
+            return sql.SQL(" RETURNING {}").format(
+                sql.SQL(", ").join(sql.Identifier(column) for column in columns)
+            )
+        return sql.SQL(" RETURNING *")
+
+    # ------------------------------------------------------------------
+    # Statement builders
+    # ------------------------------------------------------------------
+
+    def _build_select(self, inputs: Dict[str, Any]) -> Tuple[sql.Composed, List[Any]]:
+        schema = self._validate_identifier(inputs.get("schema_name", "public"), "Schema")
+        table = self._validate_identifier(inputs.get("table_name", ""), "Table")
+        columns = self._split_columns(inputs.get("columns", ""))
+
+        column_part = (
+            sql.SQL(", ").join(sql.Identifier(column) for column in columns)
+            if columns
+            else sql.SQL("*")
+        )
+
+        statement = sql.SQL("SELECT {} FROM {}.{}").format(
+            column_part, sql.Identifier(schema), sql.Identifier(table)
+        )
+        values: List[Any] = []
+
+        conditions = self._collect_conditions(inputs)
+        where_clause, where_values = self._build_where_clause(
+            conditions, inputs.get("combine_conditions", "AND")
+        )
+        if where_clause is not None:
+            statement = statement + sql.SQL(" WHERE ") + where_clause
+            values.extend(where_values)
+
+        sort_column = (inputs.get("sort_column") or "").strip()
+        if sort_column:
+            sort_column = self._validate_identifier(sort_column, "Sort column")
+            direction = "DESC" if str(inputs.get("sort_direction", "ASC")).upper() == "DESC" else "ASC"
+            statement = statement + sql.SQL(" ORDER BY {} {}").format(
+                sql.Identifier(sort_column), sql.SQL(direction)
+            )
+
+        if not inputs.get("return_all", True):
+            limit = int(inputs.get("limit", 50) or 50)
+            statement = statement + sql.SQL(" LIMIT %s")
+            values.append(limit)
+
+        return statement, values
+
+    def _build_insert(
+        self, inputs: Dict[str, Any], rows: List[Dict[str, Any]]
+    ) -> Tuple[sql.Composed, List[Any]]:
+        """Build a single INSERT that writes every supplied row."""
+        schema = self._validate_identifier(inputs.get("schema_name", "public"), "Schema")
+        table = self._validate_identifier(inputs.get("table_name", ""), "Table")
+
+        columns = list(rows[0].keys())
+        placeholder_group = sql.SQL("({})").format(
+            sql.SQL(", ").join(sql.Placeholder() * len(columns))
+        )
+
+        statement = sql.SQL("INSERT INTO {}.{} ({}) VALUES {}").format(
+            sql.Identifier(schema),
+            sql.Identifier(table),
+            sql.SQL(", ").join(sql.Identifier(column) for column in columns),
+            sql.SQL(", ").join([placeholder_group] * len(rows)),
+        )
+
+        if inputs.get("skip_on_conflict", False):
+            statement = statement + sql.SQL(" ON CONFLICT DO NOTHING")
+
+        statement = statement + self._returning_clause(
+            self._split_columns(inputs.get("return_columns", ""))
+        )
+
+        values: List[Any] = []
+        for row in rows:
+            values.extend(row[column] for column in columns)
+
+        return statement, values
+
+    def _build_update(
+        self, inputs: Dict[str, Any], rows: List[Dict[str, Any]]
+    ) -> Tuple[sql.Composed, List[Any]]:
+        """
+        Build an UPDATE statement.
+
+        Rows can be matched two ways. Naming match columns takes their values
+        from the data itself, which is how a row is usually identified. Writing
+        conditions instead gives a free-form filter.
+        """
+        if len(rows) > 1:
+            raise ValueError(
+                "Update writes one set of values to every matching row, so it accepts a single "
+                "object rather than a list. Use Insert or Update if each row needs its own values."
+            )
+        row = dict(rows[0])
+
+        schema = self._validate_identifier(inputs.get("schema_name", "public"), "Schema")
+        table = self._validate_identifier(inputs.get("table_name", ""), "Table")
+        match_columns = self._split_match_columns(inputs.get("match_columns"))
+
+        # Match columns identify the row, so they are removed from the SET list.
+        assignments_source = {
+            column: value for column, value in row.items() if column not in match_columns
+        }
+        if not assignments_source:
+            raise ValueError(
+                "Every column given is also a match column, so there is nothing left to update."
+            )
+
+        assignments = sql.SQL(", ").join(
+            sql.SQL("{} = %s").format(sql.Identifier(column)) for column in assignments_source
+        )
+        statement = sql.SQL("UPDATE {}.{} SET {}").format(
+            sql.Identifier(schema), sql.Identifier(table), assignments
+        )
+        values: List[Any] = list(assignments_source.values())
+
+        where_parts: List[sql.Composed] = []
+
+        for column in match_columns:
+            if column not in row:
+                raise ValueError(
+                    f"Match column '{column}' is missing from the data. "
+                    "Its value is read from there, so it has to be present."
+                )
+            where_parts.append(sql.SQL("{} = %s").format(sql.Identifier(column)))
+            values.append(row[column])
+
+        conditions = self._collect_conditions(inputs)
+        where_clause, where_values = self._build_where_clause(
+            conditions, inputs.get("combine_conditions", "AND")
+        )
+        if where_clause is not None:
+            where_parts.append(where_clause)
+            values.extend(where_values)
+
+        if not where_parts:
+            raise ValueError(
+                "Update requires at least one match column or filter condition. "
+                "A filterless update could overwrite every row in the table."
+            )
+
+        statement = statement + sql.SQL(" WHERE ") + sql.SQL(" AND ").join(where_parts)
+
+        statement = statement + self._returning_clause(
+            self._split_columns(inputs.get("return_columns", ""))
+        )
+        return statement, values
+
+    def _build_upsert(
+        self, inputs: Dict[str, Any], rows: List[Dict[str, Any]]
+    ) -> Tuple[sql.Composed, List[Any]]:
+        """Build a single INSERT ... ON CONFLICT that writes every supplied row."""
+        schema = self._validate_identifier(inputs.get("schema_name", "public"), "Schema")
+        table = self._validate_identifier(inputs.get("table_name", ""), "Table")
+        match_columns = self._split_match_columns(inputs.get("match_columns"))
+
+        if not match_columns:
+            raise ValueError(
+                "Insert or Update needs at least one match column so an existing row can be found."
+            )
+
+        columns = list(rows[0].keys())
+        missing = [column for column in match_columns if column not in columns]
+        if missing:
+            raise ValueError(
+                f"Match column(s) {', '.join(missing)} are missing from the data. "
+                "They must be present so an existing row can be found."
+            )
+
+        updatable = [column for column in columns if column not in match_columns]
+        placeholder_group = sql.SQL("({})").format(
+            sql.SQL(", ").join(sql.Placeholder() * len(columns))
+        )
+
+        statement = sql.SQL("INSERT INTO {}.{} ({}) VALUES {} ON CONFLICT ({}) DO ").format(
+            sql.Identifier(schema),
+            sql.Identifier(table),
+            sql.SQL(", ").join(sql.Identifier(column) for column in columns),
+            sql.SQL(", ").join([placeholder_group] * len(rows)),
+            sql.SQL(", ").join(sql.Identifier(column) for column in match_columns),
+        )
+
+        if updatable:
+            statement = statement + sql.SQL("UPDATE SET ") + sql.SQL(", ").join(
+                sql.SQL("{} = EXCLUDED.{}").format(sql.Identifier(column), sql.Identifier(column))
+                for column in updatable
+            )
+        else:
+            statement = statement + sql.SQL("NOTHING")
+
+        statement = statement + self._returning_clause(
+            self._split_columns(inputs.get("return_columns", ""))
+        )
+
+        values: List[Any] = []
+        for row in rows:
+            values.extend(row[column] for column in columns)
+
+        return statement, values
+
+    def _build_delete(self, inputs: Dict[str, Any]) -> Tuple[sql.Composed, List[Any]]:
+        schema = self._validate_identifier(inputs.get("schema_name", "public"), "Schema")
+        table = self._validate_identifier(inputs.get("table_name", ""), "Table")
+        command = str(inputs.get("delete_command", "delete")).lower()
+
+        if command == "truncate":
+            statement = sql.SQL("TRUNCATE TABLE {}.{}").format(
+                sql.Identifier(schema), sql.Identifier(table)
+            )
+            if inputs.get("restart_sequences", False):
+                statement = statement + sql.SQL(" RESTART IDENTITY")
+            if inputs.get("cascade", False):
+                statement = statement + sql.SQL(" CASCADE")
+            return statement, []
+
+        statement = sql.SQL("DELETE FROM {}.{}").format(
+            sql.Identifier(schema), sql.Identifier(table)
+        )
+        values: List[Any] = []
+
+        conditions = self._collect_conditions(inputs)
+        where_clause, where_values = self._build_where_clause(
+            conditions, inputs.get("combine_conditions", "AND")
+        )
+        if where_clause is None:
+            raise ValueError(
+                "Delete requires at least one filter condition. Use Truncate when the explicit "
+                "intention is to empty the whole table."
+            )
+
+        statement = statement + sql.SQL(" WHERE ") + where_clause
+        values.extend(where_values)
+
+        statement = statement + self._returning_clause(
+            self._split_columns(inputs.get("return_columns", ""))
+        )
+        return statement, values
+
+    @staticmethod
+    def _convert_dollar_placeholders(query: str, parameters: List[Any]) -> Tuple[str, List[Any]]:
+        """Convert $n placeholders outside SQL strings/comments to psycopg2 placeholders."""
+        output: List[str] = []
+        ordered: List[Any] = []
+        referenced: Set[int] = set()
+        index = 0
+        length = len(query)
+
+        while index < length:
+            char = query[index]
+
+            if query.startswith("--", index):
+                end = query.find("\n", index + 2)
+                end = length if end == -1 else end
+                output.append(query[index:end])
+                index = end
+                continue
+
+            if query.startswith("/*", index):
+                depth = 1
+                end = index + 2
+                while end < length and depth:
+                    if query.startswith("/*", end):
+                        depth += 1
+                        end += 2
+                    elif query.startswith("*/", end):
+                        depth -= 1
+                        end += 2
+                    else:
+                        end += 1
+                output.append(query[index:end])
+                index = end
+                continue
+
+            if char in ("'", '"'):
+                quote = char
+                end = index + 1
+                while end < length:
+                    if query[end] == quote:
+                        if end + 1 < length and query[end + 1] == quote:
+                            end += 2
+                            continue
+                        end += 1
+                        break
+                    end += 1
+                output.append(query[index:end])
+                index = end
+                continue
+
+            if char == "$":
+                dollar_quote = re.match(r"\$[A-Za-z_][A-Za-z0-9_]*\$|\$\$", query[index:])
+                if dollar_quote:
+                    delimiter = dollar_quote.group(0)
+                    end = query.find(delimiter, index + len(delimiter))
+                    end = length if end == -1 else end + len(delimiter)
+                    output.append(query[index:end])
+                    index = end
+                    continue
+
+                placeholder = re.match(r"\$(\d+)", query[index:])
+                if placeholder:
+                    parameter_index = int(placeholder.group(1))
+                    if parameter_index < 1 or parameter_index > len(parameters):
+                        raise ValueError(
+                            f"The query references ${parameter_index} but only "
+                            f"{len(parameters)} parameter(s) were supplied."
+                        )
+                    output.append("%s")
+                    ordered.append(parameters[parameter_index - 1])
+                    referenced.add(parameter_index)
+                    index += len(placeholder.group(0))
+                    continue
+
+            output.append(char)
+            index += 1
+
+        unused = [position for position in range(1, len(parameters) + 1) if position not in referenced]
+        if unused:
+            labels = ", ".join(f"${position}" for position in unused)
+            raise ValueError(f"Query Parameters contains unused value(s): {labels}.")
+
+        return "".join(output), ordered
+
+    @staticmethod
+    def _build_execute_query(inputs: Dict[str, Any]) -> Tuple[str, List[Any]]:
+        """Prepare a raw statement, converting $n placeholders safely."""
+        query = (inputs.get("query") or "").strip()
+        if not query:
+            raise ValueError("The Query field is empty.")
+
+        parameters = PostgresNode._coerce_json(inputs.get("query_parameters"), [])
+        if isinstance(parameters, dict):
+            parameters = list(parameters.values())
+        if not isinstance(parameters, list):
+            raise ValueError("Query Parameters must be a JSON array, for example: [\"value\", 10]")
+
+        return PostgresNode._convert_dollar_placeholders(query, parameters)
+
+    # ------------------------------------------------------------------
+    # Execution
+    # ------------------------------------------------------------------
+
+    def execute(self, inputs: Dict[str, Any], connected_nodes: Dict[str, Any]) -> Dict[str, Any]:
+        started_at = time.time()
+        operation = str(inputs.get("operation", "select")).lower()
+        continue_on_error = bool(inputs.get("continue_on_error", False))
+        read_only = bool(inputs.get("read_only", False))
+        attempted_rows = 0
+        written_rows = 0
+
+        logger.info("Executing PostgresNode operation=%s", operation)
+
+        connection = None
+        try:
+            if read_only and operation in WRITE_OPERATIONS:
+                self._guard_read_only(operation)
+
+            connect_timeout = int(inputs.get("connection_timeout", 30) or 30)
+
+            connection = psycopg2.connect(
+                **self._build_connection_kwargs(inputs.get("credential_id")),
+                connect_timeout=connect_timeout,
+            )
+            if read_only:
+                connection.set_session(readonly=True, autocommit=False)
+            else:
+                connection.autocommit = not bool(inputs.get("use_transaction", True))
+
+            statement_timeout = int(inputs.get("statement_timeout", 60) or 0)
+
+            with connection.cursor(cursor_factory=RealDictCursor) as cursor:
+                if statement_timeout > 0:
+                    cursor.execute("SET statement_timeout = %s", (statement_timeout * 1000,))
+
+                if operation == "execute_query":
+                    statement, values = self._build_execute_query(inputs)
+                    if read_only:
+                        self._guard_read_only(operation, statement)
+                elif operation == "select":
+                    statement, values = self._build_select(inputs)
+                elif operation in ("insert", "update", "upsert"):
+                    rows_in = self._resolve_rows(
+                        inputs.get("data"), connected_nodes,
+                        bool(inputs.get("replace_empty_with_null", False)),
+                        inputs,
+                    )
+                    attempted_rows = len(rows_in)
+                    if operation == "insert":
+                        statement, values = self._build_insert(inputs, rows_in)
+                    elif operation == "update":
+                        statement, values = self._build_update(inputs, rows_in)
+                    else:
+                        statement, values = self._build_upsert(inputs, rows_in)
+                elif operation == "delete":
+                    statement, values = self._build_delete(inputs)
+                else:
+                    raise ValueError(f"Unknown operation '{operation}'.")
+
+                cursor.execute(statement, values or None)
+
+                if operation in WRITE_OPERATIONS:
+                    written_rows = max(cursor.rowcount, 0)
+
+                rows: List[Dict[str, Any]] = []
+                if cursor.description is not None:
+                    raw_rows = [dict(record) for record in cursor.fetchall()]
+                    rows = self._serialize_rows(
+                        raw_rows, bool(inputs.get("numbers_as_text", False))
+                    )
+
+                row_count = len(rows) if rows else max(cursor.rowcount, 0)
+
+            if not connection.autocommit:
+                connection.commit()
+
+            duration_ms = round((time.time() - started_at) * 1000, 2)
+            logger.info(
+                "PostgresNode finished operation=%s rows=%s duration=%sms",
+                operation, row_count, duration_ms,
+            )
+
+            return {
+                "output": {
+                    "rows": rows,
+                    "row_count": row_count,
+                    "rows_written": written_rows,
+                    "rows_attempted": attempted_rows,
+                    "operation": operation,
+                    "duration_ms": duration_ms,
+                },
+                "success": True,
+                "error": None,
+            }
+
+        except psycopg2.Error as exc:
+            if connection is not None and not connection.autocommit:
+                connection.rollback()
+
+            # psycopg2 messages carry a trailing newline and often a DETAIL block.
+            message = str(exc).strip()
+            logger.error("PostgresNode database error operation=%s: %s", operation, message)
+
+            if not continue_on_error:
+                raise ValueError(f"PostgreSQL error: {message}") from exc
+
+            return {
+                "output": {
+                    "rows": [],
+                    "row_count": 0,
+                    "rows_written": 0,
+                    "rows_attempted": attempted_rows,
+                    "operation": operation,
+                    "duration_ms": round((time.time() - started_at) * 1000, 2),
+                    "error": message,
+                },
+                "success": False,
+                "error": message,
+            }
+
+        except Exception as exc:
+            if connection is not None and not connection.autocommit:
+                connection.rollback()
+
+            message = str(exc)
+            logger.error("PostgresNode failed operation=%s: %s", operation, message)
+
+            if not continue_on_error:
+                raise
+
+            return {
+                "output": {
+                    "rows": [],
+                    "row_count": 0,
+                    "rows_written": 0,
+                    "rows_attempted": attempted_rows,
+                    "operation": operation,
+                    "duration_ms": round((time.time() - started_at) * 1000, 2),
+                    "error": message,
+                },
+                "success": False,
+                "error": message,
+            }
+
+        finally:
+            if connection is not None:
+                connection.close()

--- a/client/app/components/node/GenericNodeForm.tsx
+++ b/client/app/components/node/GenericNodeForm.tsx
@@ -20,6 +20,8 @@ import { FieldLabel, getFieldHelpText } from "./fields/FieldLabel";
 import TabNavigation from "../common/TabNavigation";
 import { useState, useRef, useEffect } from "react";
 import { Settings, Plus, X, ChevronDown } from "lucide-react";
+import { NodeDynamicSelect } from "./fields/NodeDynamicSelect";
+import { NodeColumnMapper } from "./fields/NodeColumnMapper";
 
 interface GenericNodeFormProps {
   initialValues?: GenericData;
@@ -87,6 +89,9 @@ export default function GenericNodeForm({
   onChange,
 }: GenericNodeFormProps) {
   const properties = configData?.metadata?.properties || [];
+  const nodeType =
+    configData?.metadata?.name || configData?.name || configData?.type;
+  const columnMapperSessionsRef = useRef<Record<string, any>>({});
 
   const tabs = properties.reduce((acc: any[], property: NodeProperty) => {
     const tabId = property.tabName || "basic";
@@ -236,7 +241,26 @@ export default function GenericNodeForm({
               // Check display options
               if (property.displayOptions?.show) {
                 const shouldShow = Object.entries(property.displayOptions.show).every(
-                  ([key, value]) => values[key] === value
+                  ([key, value]) => {
+                    const matches = (name: string, expected: any) => {
+                      const current = values[name];
+                      // "*" means the field only has to be filled in.
+                      if (expected === "*") {
+                        return current !== undefined && current !== null && current !== "";
+                      }
+                      return Array.isArray(expected)
+                        ? expected.includes(current)
+                        : current === expected;
+                    };
+
+                    // "_any" holds alternatives; matching one of them is enough.
+                    if (key === "_any" && value && typeof value === "object") {
+                      return Object.entries(value).some(([name, expected]) =>
+                        matches(name, expected)
+                      );
+                    }
+                    return matches(key, value);
+                  }
                 );
                 if (!shouldShow) return null;
               }
@@ -256,6 +280,24 @@ export default function GenericNodeForm({
                     );
                   case "select":
                     return <NodeSelect property={fullWidthProperty} values={values} />;
+
+                  case "dynamic-select":
+                    return (
+                      <NodeDynamicSelect
+                        property={fullWidthProperty}
+                        values={values}
+                        nodeType={nodeType}
+                      />
+                    );
+                  case "column-mapper":
+                    return (
+                      <NodeColumnMapper
+                        property={fullWidthProperty}
+                        values={values}
+                        nodeType={nodeType}
+                        sessionStore={columnMapperSessionsRef.current}
+                      />
+                    );
                   case "credential-select":
                     return (
                       <NodeCredentialSelect
@@ -392,7 +434,14 @@ export default function GenericNodeForm({
               }
 
               return (
-                <div key={property.name} className="col-span-2 bg-slate-800/50 border border-slate-600 rounded-lg px-4 py-3">
+                  <div
+                  key={property.name}
+                  className={
+                    property.type === "title"
+                      ? "col-span-2 pt-3 pb-1"
+                      : "col-span-2 bg-slate-800/50 border border-slate-600 rounded-lg px-4 py-3"
+                  }
+                >
                   {fieldComponent}
                 </div>
               );

--- a/client/app/components/node/fields/NodeCheckbox.tsx
+++ b/client/app/components/node/fields/NodeCheckbox.tsx
@@ -14,9 +14,21 @@ export const NodeCheckbox = ({ property, values }: NodeCheckboxProps) => {
   const show = displayOptions.show || {};
 
   if (Object.keys(show).length > 0) {
+    const compare = (name: string, expected: any) => {
+      const current = values[name];
+      if (expected === "*") {
+        return current !== undefined && current !== null && current !== "";
+      }
+      return Array.isArray(expected) ? expected.includes(current) : current === expected;
+    };
+
     for (const [dependencyName, validValue] of Object.entries(show)) {
-      const dependencyValue = values[dependencyName];
-      if (dependencyValue !== validValue) {
+      // "_any" holds alternatives; matching one of them is enough.
+      const matches =
+        dependencyName === "_any" && validValue && typeof validValue === "object"
+          ? Object.entries(validValue).some(([name, expected]) => compare(name, expected))
+          : compare(dependencyName, validValue);
+      if (!matches) {
         return null;
       }
     }

--- a/client/app/components/node/fields/NodeColumnMapper.tsx
+++ b/client/app/components/node/fields/NodeColumnMapper.tsx
@@ -1,0 +1,405 @@
+import { useField } from "formik";
+import { useState, useEffect, useCallback, useRef } from "react";
+import { RefreshCw, Trash2, Plus, AlertCircle, RotateCcw } from "lucide-react";
+import type { NodeProperty } from "../types";
+import { apiClient } from "~/lib/api-client";
+import { FieldLabel, getFieldHelpText } from "./FieldLabel";
+import { ThemedDateTimeInput } from "./ThemedDateTimeInput";
+
+interface NodeColumnMapperProps {
+  property: NodeProperty;
+  values: any;
+  nodeType?: string;
+  sessionStore?: Record<
+    string,
+    {
+      currentKey: string;
+      valuesByContext: Record<string, any>;
+    }
+  >;
+}
+
+interface ColumnInfo {
+  name: string;
+  type: string;
+  widget: "text" | "number" | "checkbox" | "datetime" | "json";
+  required: boolean;
+  hasDefault: boolean;
+}
+
+/**
+ * Renders one input per column of the selected table.
+ *
+ * The column list and each column's data type come from the backend, so the
+ * panel shows a checkbox for a boolean column, a date picker for a timestamp
+ * and so on. The value is stored as a single object keyed by column name.
+ *
+ * Columns named as match columns are marked and cannot be removed, since their
+ * value is what identifies the row.
+ */
+export const NodeColumnMapper = ({
+  property,
+  values,
+  nodeType,
+  sessionStore,
+}: NodeColumnMapperProps) => {
+  const [field, , helpers] = useField(property.name);
+  const [columns, setColumns] = useState<ColumnInfo[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const requestIdRef = useRef(0);
+  const latestValuesRef = useRef(values);
+  latestValuesRef.current = values;
+
+  const dependsOn: string[] = property.optionsDependsOn || [];
+  const dependencyValues = dependsOn.map((name) => values[name]);
+  const dependencyKey = JSON.stringify(dependencyValues);
+  const missingDependency = dependsOn.find((name) => !values[name]);
+  const operation = String(values.operation || "").toLowerCase();
+  const contextKey = JSON.stringify({ operation, dependencyValues });
+  const isInsertLike = operation === "insert" || operation === "upsert";
+
+  // Match columns are read from the sibling field so they can be marked.
+  const matchColumns: string[] = (() => {
+    const raw = values.match_columns;
+    if (!raw) return [];
+    if (Array.isArray(raw)) return raw.map(String);
+    return String(raw)
+      .split(",")
+      .map((part) => part.trim())
+      .filter(Boolean);
+  })();
+
+  const currentData: Record<string, any> = (() => {
+    const raw = field.value;
+    if (!raw) return {};
+    if (typeof raw === "object" && !Array.isArray(raw)) return raw;
+    if (typeof raw === "string") {
+      try {
+        const parsed = JSON.parse(raw);
+        return typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+      } catch {
+        return {};
+      }
+    }
+    return {};
+  })();
+
+  // Keep mapper values isolated by operation and database target for the
+  // lifetime of the open form. Switching Insert -> Update starts with a clean
+  // update payload; switching back restores the Insert draft.
+  useEffect(() => {
+    if (!sessionStore) return;
+
+    const existing = sessionStore[property.name];
+    if (!existing) {
+      sessionStore[property.name] = {
+        currentKey: contextKey,
+        valuesByContext: { [contextKey]: field.value ?? {} },
+      };
+      return;
+    }
+
+    if (existing.currentKey !== contextKey) {
+      existing.valuesByContext[existing.currentKey] = field.value ?? {};
+      const nextValue = existing.valuesByContext[contextKey] ?? {};
+      existing.currentKey = contextKey;
+      existing.valuesByContext[contextKey] = nextValue;
+      helpers.setValue(nextValue);
+      return;
+    }
+
+    existing.valuesByContext[contextKey] = field.value ?? {};
+  }, [contextKey, field.value, helpers, property.name, sessionStore]);
+
+  const fetchColumns = useCallback(async () => {
+    const requestId = ++requestIdRef.current;
+    if (!nodeType || !property.optionsMethod || missingDependency) {
+      setColumns([]);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      // The shared client carries the base URL, the auth header and refresh
+      // handling, so the request behaves like every other call in the app.
+      const response = await apiClient.post(`/nodes/${nodeType}/options`, {
+        property_name: property.name,
+        values: latestValuesRef.current,
+      });
+
+      if (requestId === requestIdRef.current) {
+        setColumns(response?.options ?? []);
+      }
+    } catch (err: any) {
+      if (requestId === requestIdRef.current) {
+        setError(err?.message ?? "Could not load the columns");
+        setColumns([]);
+      }
+    } finally {
+      if (requestId === requestIdRef.current) {
+        setLoading(false);
+      }
+    }
+  }, [dependencyKey, missingDependency, nodeType, property.name, property.optionsMethod]);
+
+  useEffect(() => {
+    fetchColumns();
+  }, [fetchColumns]);
+
+  const setColumnValue = (name: string, value: any) => {
+    helpers.setValue({ ...currentData, [name]: value });
+  };
+
+  const removeColumn = (name: string) => {
+    const next = { ...currentData };
+    delete next[name];
+    helpers.setValue(next);
+  };
+
+  const includeColumn = (name: string) => {
+    helpers.setValue({ ...currentData, [name]: "" });
+  };
+
+  const clearMappedValues = () => {
+    const matchValues = Object.fromEntries(
+      matchColumns
+        .filter((name) => Object.prototype.hasOwnProperty.call(currentData, name))
+        .map((name) => [name, currentData[name]])
+    );
+    helpers.setValue(matchValues);
+  };
+
+  const inputClass =
+    "w-full bg-[#10182c] border border-slate-600 rounded-lg px-3 py-2 text-sm text-white " +
+    "placeholder:text-slate-500 focus:border-blue-500 focus:outline-none transition-colors";
+
+  const hasMappedValue = (name: string) =>
+    Object.prototype.hasOwnProperty.call(currentData, name);
+
+  const isColumnIncluded = (column: ColumnInfo) =>
+    hasMappedValue(column.name) ||
+    matchColumns.includes(column.name) ||
+    (isInsertLike && column.required);
+
+  const placeholderFor = (column: ColumnInfo) => {
+    if (operation === "update") return "Empty value overwrites the current value";
+    if (column.hasDefault) return "Enter a value or remove the column to use its default";
+    return column.required ? "Required value" : "Enter a value";
+  };
+
+  const renderInput = (column: ColumnInfo) => {
+    const value = currentData[column.name];
+
+    switch (column.widget) {
+      case "checkbox":
+        return (
+          <select
+            className={inputClass}
+            value={value === true ? "true" : value === false ? "false" : ""}
+            onChange={(event) => {
+              if (event.target.value === "") {
+                removeColumn(column.name);
+              } else {
+                setColumnValue(column.name, event.target.value === "true");
+              }
+            }}
+          >
+            <option value="">Select true or false</option>
+            <option value="true">True</option>
+            <option value="false">False</option>
+          </select>
+        );
+
+      case "number":
+        return (
+          <input
+            type="number"
+            className={inputClass}
+            value={value ?? ""}
+            placeholder={placeholderFor(column)}
+            onChange={(e) =>
+              setColumnValue(column.name, e.target.value === "" ? null : Number(e.target.value))
+            }
+          />
+        );
+
+      case "datetime":
+        return (
+          <ThemedDateTimeInput
+            value={value}
+            placeholder={placeholderFor(column)}
+            onChange={(nextValue) => setColumnValue(column.name, nextValue || null)}
+          />
+        );
+
+      case "json":
+        return (
+          <textarea
+            rows={3}
+            className={`${inputClass} font-mono text-xs`}
+            value={typeof value === "string" ? value : value ? JSON.stringify(value, null, 2) : ""}
+            placeholder={column.required ? "Required JSON value" : "{}"}
+            onChange={(e) => setColumnValue(column.name, e.target.value)}
+          />
+        );
+
+      default:
+        return (
+          <input
+            type="text"
+            className={inputClass}
+            value={value ?? ""}
+            placeholder={placeholderFor(column)}
+            onChange={(e) => setColumnValue(column.name, e.target.value)}
+          />
+        );
+    }
+  };
+
+  const includedColumns = columns.filter(isColumnIncluded);
+  const availableColumns = columns.filter((column) => !isColumnIncluded(column));
+
+  return (
+    <div className={`${property?.colSpan ? `col-span-${property?.colSpan}` : "col-span-2"}`}>
+      <div className="flex items-center justify-between">
+        <FieldLabel label={property.displayName} helpText={getFieldHelpText(property)} />
+        <div className="flex items-center gap-1">
+          {Object.keys(currentData).length > 0 && (
+            <button
+              type="button"
+              title="Clear mapped values except match columns"
+              onClick={clearMappedValues}
+              className="text-slate-400 hover:text-amber-300 p-1"
+            >
+              <RotateCcw size={14} />
+            </button>
+          )}
+          <button
+            type="button"
+            title="Reload the columns"
+            onClick={fetchColumns}
+            disabled={loading || !!missingDependency}
+            className="text-slate-400 hover:text-blue-300 disabled:text-slate-600 disabled:cursor-not-allowed p-1"
+          >
+            <RefreshCw size={14} className={loading ? "animate-spin" : ""} />
+          </button>
+        </div>
+      </div>
+
+      {!missingDependency && columns.length > 0 && (
+        <div className="mb-3 rounded-md border border-blue-500/20 bg-blue-500/5 px-3 py-2 text-xs text-slate-400">
+          {operation === "update"
+            ? "Only included columns are updated. An included empty value overwrites the existing value; remove the column to leave it unchanged."
+            : "Only included columns are sent. Remove optional/defaulted columns when PostgreSQL should supply their value."}
+        </div>
+      )}
+
+      {missingDependency && (
+        <div className="text-sm text-slate-400 py-3">
+          Select {missingDependency.replace(/_/g, " ")} first.
+        </div>
+      )}
+
+      {loading && <div className="text-sm text-slate-400 py-3">Loading the columns...</div>}
+
+      {error && (
+        <div className="flex items-start gap-1.5 py-2 text-xs text-amber-400">
+          <AlertCircle size={13} className="mt-0.5 shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {!loading && !missingDependency && !error && columns.length === 0 && (
+        <div className="text-sm text-slate-400 py-3">This table has no columns to show.</div>
+      )}
+
+      <div className="space-y-3 mt-1">
+        {includedColumns.map((column) => {
+          const isMatch = matchColumns.includes(column.name);
+          const isLockedRequired = isInsertLike && column.required;
+          const isExplicitlyMapped = hasMappedValue(column.name);
+          const sendsBlankValue =
+            isExplicitlyMapped &&
+            (currentData[column.name] === "" || currentData[column.name] === null);
+          return (
+            <div key={column.name} className="pl-3 border-l-2 border-blue-500/50">
+              <div className="flex items-center gap-2 mb-1.5">
+                {!isMatch && !isLockedRequired && (
+                  <button
+                    type="button"
+                    title="Do not send this column"
+                    onClick={() => removeColumn(column.name)}
+                    className="text-slate-500 hover:text-red-400 transition-colors"
+                  >
+                    <Trash2 size={13} />
+                  </button>
+                )}
+                <span className="text-sm text-slate-200">{column.name}</span>
+                {isMatch && (
+                  <span className="text-xs text-blue-300">(using to match)</span>
+                )}
+                {column.required && isInsertLike && !isMatch && (
+                  <span className="text-xs text-amber-400">required</span>
+                )}
+                {isExplicitlyMapped ? (
+                  <span className="text-[10px] uppercase tracking-wide text-emerald-400">
+                    included
+                  </span>
+                ) : (
+                  <span className="text-[10px] uppercase tracking-wide text-amber-400">
+                    value required
+                  </span>
+                )}
+                <span className="text-xs text-slate-500 ml-auto">{column.type}</span>
+              </div>
+              {renderInput(column)}
+              {sendsBlankValue && (
+                <div className="mt-1 text-xs text-amber-400">
+                  This empty value will be sent. Remove the column to leave it unchanged.
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {availableColumns.length > 0 && (
+        <div className="mt-3 pt-3 border-t border-slate-700">
+          <div className="text-xs text-slate-500 mb-2">
+            Available columns — not sent until included
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {availableColumns.map((column) => (
+              <button
+                key={column.name}
+                type="button"
+                onClick={() => includeColumn(column.name)}
+                className="flex items-center gap-1 px-2 py-1 text-xs text-slate-400 border border-slate-700 rounded hover:text-blue-300 hover:border-blue-500 transition-colors"
+              >
+                <Plus size={11} />
+                {column.name}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <details className="mt-3 border-t border-slate-700 pt-3">
+        <summary className="cursor-pointer text-xs text-slate-400 hover:text-slate-200">
+          Payload preview ({Object.keys(currentData).length} mapped column
+          {Object.keys(currentData).length === 1 ? "" : "s"})
+        </summary>
+        <pre className="mt-2 max-h-48 overflow-auto rounded-md bg-[#0b1220] p-3 text-xs text-slate-300">
+          {JSON.stringify(currentData, null, 2)}
+        </pre>
+      </details>
+    </div>
+  );
+};
+
+export default NodeColumnMapper;

--- a/client/app/components/node/fields/NodeDateTime.tsx
+++ b/client/app/components/node/fields/NodeDateTime.tsx
@@ -1,7 +1,8 @@
-import { Field } from "formik";
+import { useField } from "formik";
 import type { NodeProperty } from "../types";
 import { CalendarDays } from "lucide-react";
 import { FieldLabel, getFieldHelpText } from "./FieldLabel";
+import { ThemedDateTimeInput } from "./ThemedDateTimeInput";
 
 interface NodeDateTimeProps {
   property: NodeProperty;
@@ -9,6 +10,7 @@ interface NodeDateTimeProps {
 }
 
 export const NodeDateTime = ({ property, values }: NodeDateTimeProps) => {
+  const [field, , helpers] = useField(property.name);
   const displayOptions = property?.displayOptions || {};
   const show = displayOptions.show || {};
 
@@ -31,10 +33,10 @@ export const NodeDateTime = ({ property, values }: NodeDateTimeProps) => {
           className="text-white text-sm font-medium"
         />
       </div>
-      <Field
-        className="w-full bg-slate-900/80 border border-slate-600/50 rounded-lg text-white placeholder-slate-400 px-3 py-2 text-sm focus:border-green-500 focus:ring-2 focus:ring-green-500/20 transition-all"
-        type="datetime-local"
-        name={property.name}
+      <ThemedDateTimeInput
+        value={field.value}
+        onChange={helpers.setValue}
+        placeholder={property.placeholder ?? "Select date and time"}
       />
     </div>
   );

--- a/client/app/components/node/fields/NodeDynamicSelect.tsx
+++ b/client/app/components/node/fields/NodeDynamicSelect.tsx
@@ -1,0 +1,268 @@
+import { useField } from "formik";
+import { useState, useRef, useEffect, useCallback } from "react";
+import { ChevronDown, RefreshCw, AlertCircle, Check, X } from "lucide-react";
+import type { NodeProperty } from "../types";
+import { apiClient } from "~/lib/api-client";
+import { FieldLabel, getFieldHelpText } from "./FieldLabel";
+
+interface NodeDynamicSelectProps {
+  property: NodeProperty;
+  values: any;
+  nodeType?: string;
+}
+
+interface Option {
+  label: string;
+  value: string;
+}
+
+/**
+ * A field that offers values fetched from the backend while still letting the
+ * value be typed by hand.
+ *
+ * The node declares `optionsMethod` on the property; the backend calls that
+ * method and returns the list. `optionsDependsOn` names the fields that should
+ * trigger a refetch when they change, for example a credential or a schema
+ * selection.
+ *
+ * Typing filters the list without preventing a value outside it, which covers
+ * templates and tables the credential cannot list.
+ */
+export const NodeDynamicSelect = ({ property, values, nodeType }: NodeDynamicSelectProps) => {
+  const [field, , helpers] = useField(property.name);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [options, setOptions] = useState<Option[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const requestIdRef = useRef(0);
+  const latestValuesRef = useRef(values);
+  latestValuesRef.current = values;
+
+  const dependsOn: string[] = property.optionsDependsOn || [];
+  const dependencyValues = dependsOn.map((name) => values[name]);
+  const dependencyKey = JSON.stringify(dependencyValues);
+  const missingDependency = dependsOn.find((name) => !values[name]);
+
+  const isMultiple = Boolean(property.multiple);
+
+  const currentValue = field.value ?? property?.default ?? "";
+
+  // Multiple selection is stored as a comma separated string, which is what the
+  // backend already splits on.
+  const selectedValues: string[] = isMultiple
+    ? String(currentValue)
+        .split(",")
+        .map((part) => part.trim())
+        .filter(Boolean)
+    : [];
+
+  const toggleValue = (value: string) => {
+    const next = selectedValues.includes(value)
+      ? selectedValues.filter((entry) => entry !== value)
+      : [...selectedValues, value];
+    helpers.setValue(next.join(", "));
+  };
+
+  const fetchOptions = useCallback(async () => {
+    const requestId = ++requestIdRef.current;
+    if (!nodeType || !property.optionsMethod || missingDependency) {
+      setOptions([]);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      // The shared client carries the base URL, the auth header and refresh
+      // handling, so the request behaves like every other call in the app.
+      const response = await apiClient.post(`/nodes/${nodeType}/options`, {
+        property_name: property.name,
+        values: latestValuesRef.current,
+      });
+
+      if (requestId === requestIdRef.current) {
+        setOptions(response?.options ?? []);
+      }
+    } catch (err: any) {
+      if (requestId === requestIdRef.current) {
+        setError(err?.message ?? "Could not load the list");
+        setOptions([]);
+      }
+    } finally {
+      if (requestId === requestIdRef.current) {
+        setLoading(false);
+      }
+    }
+  }, [dependencyKey, missingDependency, nodeType, property.name, property.optionsMethod]);
+
+  useEffect(() => {
+    fetchOptions();
+  }, [fetchOptions]);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setDropdownOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  // Typing narrows the list without preventing a value outside it. In multiple
+  // mode the box holds the selection, so the list is never filtered by it.
+  const filtered =
+    !isMultiple && currentValue
+      ? options.filter((option) =>
+          option.label.toLowerCase().includes(String(currentValue).toLowerCase())
+        )
+      : options;
+
+  const helperText = (() => {
+    if (loading) return "Loading the list...";
+    if (missingDependency) {
+      const label = missingDependency.replace(/_/g, " ").replace(/ id$/, "");
+      return `Select ${label} to see the list. A name can still be typed.`;
+    }
+    if (error) return error;
+    if (isMultiple && selectedValues.length > 0) {
+      return `${selectedValues.length} of ${options.length} selected`;
+    }
+    if (options.length > 0) return `${options.length} available`;
+    return null;
+  })();
+
+  return (
+    <div
+      className={`${property?.colSpan ? `col-span-${property?.colSpan}` : "col-span-2"}`}
+      key={property.name}
+    >
+      <FieldLabel label={property.displayName} helpText={getFieldHelpText(property)} />
+
+      <div className="relative" ref={containerRef}>
+        <div className="flex gap-2">
+          <div className="relative flex-1">
+            {isMultiple ? (
+              <button
+                type="button"
+                onClick={() => setDropdownOpen(!dropdownOpen)}
+                onMouseDown={(e: any) => e.stopPropagation()}
+                className="w-full min-h-[46px] flex flex-wrap items-center gap-1.5 bg-[#10182c] border border-slate-600 rounded-lg pl-3 pr-10 py-2 text-left focus:border-blue-500 focus:outline-none transition-colors"
+              >
+                {selectedValues.length === 0 && (
+                  <span className="text-sm text-slate-500">
+                    {property.placeholder ?? "Select"}
+                  </span>
+                )}
+                {selectedValues.map((value) => (
+                  <span
+                    key={value}
+                    className="inline-flex items-center gap-1 px-2 py-0.5 rounded bg-blue-500/20 text-blue-300 text-xs"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      toggleValue(value);
+                    }}
+                  >
+                    {value}
+                    <X size={11} />
+                  </span>
+                ))}
+              </button>
+            ) : (
+              <input
+                type="text"
+                value={currentValue}
+                placeholder={property.placeholder ?? "Select or type"}
+                onChange={(e) => {
+                  helpers.setValue(e.target.value);
+                  setDropdownOpen(true);
+                }}
+                onFocus={() => setDropdownOpen(true)}
+                onMouseDown={(e: any) => e.stopPropagation()}
+                className="w-full bg-[#10182c] border border-slate-600 rounded-lg pl-4 pr-10 py-3 text-sm text-white placeholder:text-slate-500 focus:border-blue-500 focus:outline-none transition-colors"
+              />
+            )}
+            <button
+              type="button"
+              tabIndex={-1}
+              onClick={() => setDropdownOpen(!dropdownOpen)}
+              onMouseDown={(e: any) => e.stopPropagation()}
+              className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-slate-400 hover:text-slate-200"
+            >
+              <ChevronDown
+                size={16}
+                className={`transition-transform duration-200 ${dropdownOpen ? "rotate-180" : ""}`}
+              />
+            </button>
+
+            {dropdownOpen && filtered.length > 0 && (
+              <div className="absolute z-50 mt-1 left-0 right-0 max-h-64 overflow-y-auto bg-slate-900 border border-slate-700 rounded-lg shadow-lg shadow-black/40">
+                {filtered.map((option) => {
+                  const selected = isMultiple
+                    ? selectedValues.includes(option.value)
+                    : currentValue === option.value;
+                  return (
+                    <button
+                      key={option.value}
+                      type="button"
+                      onClick={() => {
+                        if (isMultiple) {
+                          toggleValue(option.value);
+                        } else {
+                          helpers.setValue(option.value);
+                          setDropdownOpen(false);
+                        }
+                      }}
+                      onMouseDown={(e: any) => e.stopPropagation()}
+                      className={`w-full flex items-center justify-between gap-3 px-4 py-2.5 text-sm text-left transition-colors duration-150 ${
+                        selected
+                          ? "bg-blue-500/20 text-blue-300"
+                          : "text-slate-300 hover:bg-blue-500/20 hover:text-blue-300"
+                      }`}
+                    >
+                      <span>{option.label}</span>
+                      {selected && <Check size={14} />}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+
+          <button
+            type="button"
+            title="Reload the list"
+            disabled={loading || !!missingDependency}
+            onClick={fetchOptions}
+            onMouseDown={(e: any) => e.stopPropagation()}
+            className={`px-3 rounded-lg border transition-colors ${
+              loading || missingDependency
+                ? "border-slate-700 text-slate-600 cursor-not-allowed"
+                : "border-slate-600 text-slate-400 hover:text-blue-300 hover:border-blue-500"
+            }`}
+          >
+            <RefreshCw size={14} className={loading ? "animate-spin" : ""} />
+          </button>
+        </div>
+
+      </div>
+
+      {helperText && (
+        <div
+          className={`flex items-start gap-1.5 mt-1.5 text-xs ${
+            error ? "text-amber-400" : "text-slate-500"
+          }`}
+        >
+          {error && <AlertCircle size={13} className="mt-0.5 shrink-0" />}
+          <span>{helperText}</span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default NodeDynamicSelect;

--- a/client/app/components/node/fields/NodeSelect.tsx
+++ b/client/app/components/node/fields/NodeSelect.tsx
@@ -31,7 +31,15 @@ export const NodeSelect = ({ property, values }: NodeSelectProps) => {
   if (Object.keys(show).length > 0) {
     for (const [dependencyName, validValue] of Object.entries(show)) {
       const dependencyValue = values[dependencyName];
-      if (dependencyValue !== validValue) {
+      const matches =
+        validValue === "*"
+          ? dependencyValue !== undefined &&
+            dependencyValue !== null &&
+            dependencyValue !== ""
+          : Array.isArray(validValue)
+            ? validValue.includes(dependencyValue)
+            : dependencyValue === validValue;
+      if (!matches) {
         return null;
       }
     }

--- a/client/app/components/node/fields/NodeText.tsx
+++ b/client/app/components/node/fields/NodeText.tsx
@@ -14,7 +14,15 @@ export const NodeText = ({ property, values }: NodeTextProps) => {
   if (Object.keys(show).length > 0) {
     for (const [dependencyName, validValue] of Object.entries(show)) {
       const dependencyValue = values[dependencyName];
-      if (dependencyValue !== validValue) {
+      const matches =
+        validValue === "*"
+          ? dependencyValue !== undefined &&
+            dependencyValue !== null &&
+            dependencyValue !== ""
+          : Array.isArray(validValue)
+            ? validValue.includes(dependencyValue)
+            : dependencyValue === validValue;
+      if (!matches) {
         return null;
       }
     }

--- a/client/app/components/node/fields/ThemedDateTimeInput.tsx
+++ b/client/app/components/node/fields/ThemedDateTimeInput.tsx
@@ -1,0 +1,429 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  CalendarDays,
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  ChevronUp,
+  Clock,
+  X,
+} from "lucide-react";
+
+interface ThemedDateTimeInputProps {
+  value?: string | null;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}
+
+const WEEKDAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+const MONTHS = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+
+const pad = (value: number) => String(value).padStart(2, "0");
+
+const parseValue = (value?: string | null) => {
+  if (!value) return null;
+  const match = String(value).match(/^(\d{4})-(\d{2})-(\d{2})(?:T|\s)(\d{2}):(\d{2})/);
+  if (!match) return null;
+
+  const date = new Date(
+    Number(match[1]),
+    Number(match[2]) - 1,
+    Number(match[3]),
+    Number(match[4]),
+    Number(match[5])
+  );
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+const serialize = (date: Date) =>
+  `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+  `T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+
+const sameDay = (left: Date | null, right: Date) =>
+  !!left &&
+  left.getFullYear() === right.getFullYear() &&
+  left.getMonth() === right.getMonth() &&
+  left.getDate() === right.getDate();
+
+interface TimeControlProps {
+  label: string;
+  value: number | null;
+  max: number;
+  disabled: boolean;
+  onType: (value: string) => void;
+  onStep: (delta: number) => void;
+}
+
+const TimeControl = ({
+  label,
+  value,
+  max,
+  disabled,
+  onType,
+  onStep,
+}: TimeControlProps) => (
+  <div
+    className={`flex h-9 w-[4.5rem] overflow-hidden rounded-md border bg-slate-900 transition-colors focus-within:border-blue-500 ${
+      disabled ? "border-slate-700 opacity-40" : "border-slate-600"
+    }`}
+  >
+    <input
+      aria-label={label}
+      type="text"
+      inputMode="numeric"
+      pattern="[0-9]*"
+      disabled={disabled}
+      value={value === null ? "" : pad(value)}
+      onFocus={(event) => event.currentTarget.select()}
+      onChange={(event) => {
+        const next = event.target.value.trim();
+        if (/^\d{1,2}$/.test(next) && Number(next) <= max) onType(next);
+      }}
+      className="min-w-0 flex-1 bg-transparent px-2 text-center text-sm text-white outline-none"
+    />
+    <div className="flex w-6 shrink-0 flex-col border-l border-slate-700">
+      <button
+        type="button"
+        tabIndex={-1}
+        aria-label={`Increase ${label.toLowerCase()}`}
+        disabled={disabled}
+        onClick={() => onStep(1)}
+        className="flex flex-1 items-center justify-center text-slate-500 hover:bg-blue-500/15 hover:text-blue-300 disabled:pointer-events-none"
+      >
+        <ChevronUp size={11} />
+      </button>
+      <button
+        type="button"
+        tabIndex={-1}
+        aria-label={`Decrease ${label.toLowerCase()}`}
+        disabled={disabled}
+        onClick={() => onStep(-1)}
+        className="flex flex-1 items-center justify-center border-t border-slate-700 text-slate-500 hover:bg-blue-500/15 hover:text-blue-300 disabled:pointer-events-none"
+      >
+        <ChevronDown size={11} />
+      </button>
+    </div>
+  </div>
+);
+
+export const ThemedDateTimeInput = ({
+  value,
+  onChange,
+  placeholder = "Select date and time",
+}: ThemedDateTimeInputProps) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const selected = useMemo(() => parseValue(value), [value]);
+  const [open, setOpen] = useState(false);
+  const [headerPicker, setHeaderPicker] = useState<"month" | "year" | null>(null);
+  const [yearPageStart, setYearPageStart] = useState(() => {
+    const initial = selected ?? new Date();
+    return Math.floor(initial.getFullYear() / 10) * 10;
+  });
+  const [viewMonth, setViewMonth] = useState(() => {
+    const initial = selected ?? new Date();
+    return new Date(initial.getFullYear(), initial.getMonth(), 1);
+  });
+
+  useEffect(() => {
+    const closeOnOutsideClick = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setOpen(false);
+        setHeaderPicker(null);
+      }
+    };
+    document.addEventListener("mousedown", closeOnOutsideClick);
+    return () => document.removeEventListener("mousedown", closeOnOutsideClick);
+  }, []);
+
+  useEffect(() => {
+    if (open && selected) {
+      setViewMonth(new Date(selected.getFullYear(), selected.getMonth(), 1));
+    }
+  }, [open, selected?.getTime()]);
+
+  const calendarDays = useMemo(() => {
+    const year = viewMonth.getFullYear();
+    const month = viewMonth.getMonth();
+    const leadingEmptyDays = (new Date(year, month, 1).getDay() + 6) % 7;
+    const daysInMonth = new Date(year, month + 1, 0).getDate();
+    return [
+      ...Array.from({ length: leadingEmptyDays }, () => null),
+      ...Array.from({ length: daysInMonth }, (_, index) => new Date(year, month, index + 1)),
+    ];
+  }, [viewMonth]);
+
+  const selectDay = (day: Date) => {
+    const next = new Date(day);
+    next.setHours(selected?.getHours() ?? 0, selected?.getMinutes() ?? 0, 0, 0);
+    onChange(serialize(next));
+  };
+
+  const updateTime = (part: "hours" | "minutes", rawValue: string) => {
+    if (!selected) return;
+    const next = new Date(selected);
+    const numericValue = Number(rawValue);
+    if (part === "hours") next.setHours(Math.min(23, Math.max(0, numericValue || 0)));
+    else next.setMinutes(Math.min(59, Math.max(0, numericValue || 0)));
+    onChange(serialize(next));
+  };
+
+  const stepTime = (part: "hours" | "minutes", delta: number) => {
+    if (!selected) return;
+    const next = new Date(selected);
+    if (part === "hours") next.setHours(next.getHours() + delta);
+    else next.setMinutes(next.getMinutes() + delta);
+    onChange(serialize(next));
+  };
+
+  const openHeaderPicker = (picker: "month" | "year") => {
+    setHeaderPicker((current) => (current === picker ? null : picker));
+    if (picker === "year") {
+      setYearPageStart(Math.floor(viewMonth.getFullYear() / 10) * 10);
+    }
+  };
+
+  const chooseToday = () => {
+    const now = new Date();
+    now.setSeconds(0, 0);
+    onChange(serialize(now));
+    setViewMonth(new Date(now.getFullYear(), now.getMonth(), 1));
+  };
+
+  const displayValue = selected
+    ? `${pad(selected.getDate())}.${pad(selected.getMonth() + 1)}.${selected.getFullYear()} ` +
+      `${pad(selected.getHours())}:${pad(selected.getMinutes())}`
+    : "";
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        onClick={() => {
+          setOpen((current) => !current);
+          setHeaderPicker(null);
+        }}
+        onMouseDown={(event) => event.stopPropagation()}
+        className={`w-full flex items-center gap-3 bg-[#10182c] border rounded-lg px-3 py-2.5 text-left text-sm transition-colors focus:outline-none ${
+          open ? "border-blue-500 ring-2 ring-blue-500/20" : "border-slate-600 hover:border-slate-500"
+        }`}
+      >
+        <CalendarDays size={16} className="shrink-0 text-blue-400" />
+        <span className={displayValue ? "text-white" : "text-slate-500"}>
+          {displayValue || placeholder}
+        </span>
+      </button>
+
+      {open && (
+        <div
+          role="dialog"
+          aria-label="Choose date and time"
+          className="absolute z-[70] mt-2 w-full min-w-[20rem] max-w-sm rounded-xl border border-slate-700 bg-[#10182c] p-3 shadow-2xl shadow-black/60"
+        >
+          <div className="relative mb-3 flex items-center justify-between">
+            <button
+              type="button"
+              aria-label="Previous month"
+              onClick={() =>
+                setViewMonth(new Date(viewMonth.getFullYear(), viewMonth.getMonth() - 1, 1))
+              }
+              className="rounded-md p-1.5 text-slate-400 hover:bg-slate-700 hover:text-white"
+            >
+              <ChevronLeft size={17} />
+            </button>
+            <div className="flex items-center gap-1">
+              <button
+                type="button"
+                aria-expanded={headerPicker === "month"}
+                onClick={() => openHeaderPicker("month")}
+                className={`rounded-md px-2 py-1 text-sm font-medium transition-colors ${
+                  headerPicker === "month"
+                    ? "bg-blue-500/20 text-blue-300"
+                    : "text-slate-100 hover:bg-slate-700"
+                }`}
+              >
+                {MONTHS[viewMonth.getMonth()]}
+              </button>
+              <button
+                type="button"
+                aria-expanded={headerPicker === "year"}
+                onClick={() => openHeaderPicker("year")}
+                className={`rounded-md px-2 py-1 text-sm font-medium transition-colors ${
+                  headerPicker === "year"
+                    ? "bg-blue-500/20 text-blue-300"
+                    : "text-slate-100 hover:bg-slate-700"
+                }`}
+              >
+                {viewMonth.getFullYear()}
+              </button>
+            </div>
+            <button
+              type="button"
+              aria-label="Next month"
+              onClick={() =>
+                setViewMonth(new Date(viewMonth.getFullYear(), viewMonth.getMonth() + 1, 1))
+              }
+              className="rounded-md p-1.5 text-slate-400 hover:bg-slate-700 hover:text-white"
+            >
+              <ChevronRight size={17} />
+            </button>
+
+            {headerPicker === "month" && (
+              <div className="absolute left-8 right-8 top-10 z-10 grid grid-cols-3 gap-1 rounded-lg border border-slate-700 bg-slate-900 p-2 shadow-xl shadow-black/50">
+                {MONTHS.map((month, index) => (
+                  <button
+                    key={month}
+                    type="button"
+                    onClick={() => {
+                      setViewMonth(new Date(viewMonth.getFullYear(), index, 1));
+                      setHeaderPicker(null);
+                    }}
+                    className={`rounded-md px-2 py-2 text-xs transition-colors ${
+                      viewMonth.getMonth() === index
+                        ? "bg-blue-500 text-white"
+                        : "text-slate-300 hover:bg-slate-700 hover:text-white"
+                    }`}
+                  >
+                    {month.slice(0, 3)}
+                  </button>
+                ))}
+              </div>
+            )}
+
+            {headerPicker === "year" && (
+              <div className="absolute left-8 right-8 top-10 z-10 rounded-lg border border-slate-700 bg-slate-900 p-2 shadow-xl shadow-black/50">
+                <div className="mb-2 flex items-center justify-between">
+                  <button
+                    type="button"
+                    aria-label="Previous decade"
+                    onClick={() => setYearPageStart((year) => year - 10)}
+                    className="rounded p-1 text-slate-400 hover:bg-slate-700 hover:text-white"
+                  >
+                    <ChevronLeft size={14} />
+                  </button>
+                  <span className="text-xs font-medium text-slate-400">
+                    {yearPageStart}–{yearPageStart + 9}
+                  </span>
+                  <button
+                    type="button"
+                    aria-label="Next decade"
+                    onClick={() => setYearPageStart((year) => year + 10)}
+                    className="rounded p-1 text-slate-400 hover:bg-slate-700 hover:text-white"
+                  >
+                    <ChevronRight size={14} />
+                  </button>
+                </div>
+                <div className="grid grid-cols-4 gap-1">
+                  {Array.from({ length: 12 }, (_, index) => yearPageStart - 1 + index).map(
+                    (year) => (
+                      <button
+                        key={year}
+                        type="button"
+                        onClick={() => {
+                          setViewMonth(new Date(year, viewMonth.getMonth(), 1));
+                          setHeaderPicker(null);
+                        }}
+                        className={`rounded-md px-2 py-2 text-xs transition-colors ${
+                          viewMonth.getFullYear() === year
+                            ? "bg-blue-500 text-white"
+                            : year < yearPageStart || year > yearPageStart + 9
+                              ? "text-slate-600 hover:bg-slate-700 hover:text-slate-300"
+                              : "text-slate-300 hover:bg-slate-700 hover:text-white"
+                        }`}
+                      >
+                        {year}
+                      </button>
+                    )
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+
+          <div className="grid grid-cols-7 gap-1">
+            {WEEKDAYS.map((weekday) => (
+              <div key={weekday} className="py-1 text-center text-[10px] font-medium text-slate-500">
+                {weekday}
+              </div>
+            ))}
+            {calendarDays.map((day, index) =>
+              day ? (
+                <button
+                  key={day.toISOString()}
+                  type="button"
+                  onClick={() => selectDay(day)}
+                  className={`h-8 rounded-md text-xs transition-colors ${
+                    sameDay(selected, day)
+                      ? "bg-blue-500 font-semibold text-white"
+                      : sameDay(new Date(), day)
+                        ? "bg-blue-500/10 text-blue-300 hover:bg-blue-500/20"
+                        : "text-slate-300 hover:bg-slate-700"
+                  }`}
+                >
+                  {day.getDate()}
+                </button>
+              ) : (
+                <div key={`empty-${index}`} />
+              )
+            )}
+          </div>
+
+          <div className="mt-3 flex items-center gap-2 border-t border-slate-700 pt-3">
+            <Clock size={15} className="text-slate-500" />
+            <TimeControl
+              label="Hour"
+              disabled={!selected}
+              value={selected?.getHours() ?? null}
+              max={23}
+              onType={(nextValue) => updateTime("hours", nextValue)}
+              onStep={(delta) => stepTime("hours", delta)}
+            />
+            <span className="text-slate-500">:</span>
+            <TimeControl
+              label="Minute"
+              disabled={!selected}
+              value={selected?.getMinutes() ?? null}
+              max={59}
+              onType={(nextValue) => updateTime("minutes", nextValue)}
+              onStep={(delta) => stepTime("minutes", delta)}
+            />
+          </div>
+
+          <div className="mt-3 flex items-center justify-between">
+            <div className="flex gap-1">
+              <button
+                type="button"
+                onClick={chooseToday}
+                className="rounded-md px-2.5 py-1.5 text-xs text-blue-300 hover:bg-blue-500/10"
+              >
+                Today
+              </button>
+              {selected && (
+                <button
+                  type="button"
+                  onClick={() => onChange("")}
+                  className="flex items-center gap-1 rounded-md px-2.5 py-1.5 text-xs text-slate-400 hover:bg-slate-700 hover:text-red-300"
+                >
+                  <X size={12} /> Clear
+                </button>
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              className="rounded-md bg-blue-500 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-400"
+            >
+              Done
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ThemedDateTimeInput;

--- a/client/app/lib/iconUtils.ts
+++ b/client/app/lib/iconUtils.ts
@@ -83,6 +83,7 @@ export function getNodeTypeIconPath(nodeType: string): string {
         PGVectorStore: "icons/postgresql_vectorstore.svg",
         VectorStoreOrchestrator: "icons/postgresql_vectorstore.svg",
         IntelligentVectorStore: "icons/postgresql_vectorstore.svg",
+        PostgresNode: "icons/postgresql_vectorstore.svg",
         MarkItDownTool: "icons/markitdown.svg",
 
         // Web & APIs


### PR DESCRIPTION
- Add a PostgreSQL processor node supporting Execute Query, Select, Insert, Update, Insert or Update, Delete, and Truncate operations.
- Dynamically load schemas, tables, columns, column metadata, match columns, and returning columns from the selected authenticated credential.
- Extend generic node properties and forms with dependency-aware dynamic selects, multi-selection, column mapping, wildcard and array conditions, and alternative display rules.
- Parameterize SQL values, validate and quote identifiers, safely translate numbered query placeholders, and establish connections without interpolating credentials into URLs.
- Support filters, additional JSON conditions, case-insensitive text comparisons, sorting, result limits, configurable return columns, and safe LIKE patterns.
- Prevent filterless Update and Delete operations, enforce match-column requirements, and protect write operations with PostgreSQL read-only transaction checks.
- Support manual and automatic column mapping, incoming payload unwrapping, table-column filtering, multi-row inserts, conflict handling, and PostgreSQL default values.
- Distinguish omitted columns from explicitly empty values so partial updates preserve existing data while intentional empty values remain supported.
- Preserve independent mapper drafts across operations and database targets, expose the effective payload preview, and render controls based on PostgreSQL column types and constraints.
- Add transaction controls, statement timeouts, conflict skipping, empty-string-to-NULL conversion, sequence resets, cascading truncation, and numeric precision preservation.
- Serialize PostgreSQL dates, times, decimals, UUIDs, binary values, arrays, and objects into stable workflow outputs with row count, duration, success, and error metadata.
- Add a project-themed date and time picker with direct month and decade selection, custom hour and minute controls, today selection, and clear actions.
- Keep dynamic dropdown menus aligned with their input width and prevent refresh controls from expanding the options panel.
- Register the PostgreSQL node icon and reuse the existing PostgreSQL visual identity across the canvas.