### PR TITLE
fix: prevent node configuration input flicker

### DIFF
--- a/client/app/components/canvas/FlowCanvas.tsx
+++ b/client/app/components/canvas/FlowCanvas.tsx
@@ -2327,6 +2327,7 @@ function FlowCanvas({ workflowId }: FlowCanvasProps) {
         onImportStart={() => { isImportingRef.current = true; loadedWorkflowIdRef.current = null; }}
         onWorkflowImported={(importedNodes, importedEdges) => {
           resetHistory(importedNodes, importedEdges);
+          setHistoryRevision((revision) => revision + 1);
         }}
         onUndo={handleUndo}
         onRedo={handleRedo}

--- a/client/app/components/common/FullscreenNodeModal.tsx
+++ b/client/app/components/common/FullscreenNodeModal.tsx
@@ -652,9 +652,12 @@ export default function FullscreenNodeModal({
     nodeAliasRef.current = alias;
     setNodeAlias(alias);
     setNodeAliasError(validateNodeAlias(alias));
-    // Sync workflow state into the form after undo/redo or when configData changes externally (e.g., import).
+    // Live form edits are written back to the canvas through onConfigChange. Do not
+    // feed those canvas echoes into Formik's initialValues: enableReinitialize would
+    // otherwise replace a newer keystroke with an older debounced value. Explicit
+    // workflow revisions (undo/redo/import) still reinitialize the form below.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [historyRevision, configData]);
+  }, [historyRevision]);
 
   useEffect(() => {
     if (prevHistoryRevisionRef.current === historyRevision) return;


### PR DESCRIPTION
## Summary

- Keep the active node configuration draft from being reinitialized by its own debounced canvas state updates.
- Preserve explicit form synchronization for imported workflows through `historyRevision`.

## Root cause

Node form changes are debounced and written into the canvas node state. That state is then passed back to `FullscreenNodeModal` as `configData`. The modal previously copied every `configData` change into `configValues`; because the metadata-driven form uses Formik with `enableReinitialize`, a delayed canvas value could replace a newer keystroke and make the final character disappear and reappear.

## Impact

Fast typing remains stable across metadata-driven node configuration forms. Undo, redo, and workflow import synchronization continue to reinitialize the form through explicit workflow revisions.

## Validation

- `npm run build` — passed.
- `npm run typecheck` — blocked by pre-existing `ServiceField.helpText` type errors in `client/app/types/credentials.ts` on the current `upstream/dev` base.

No test file is included in this PR.
