### PR TITLE
feat: add auto-resizing multiline input support across chat interfaces

### DIFF
--- a/client/app/components/KaiChatWidget.tsx
+++ b/client/app/components/KaiChatWidget.tsx
@@ -25,6 +25,7 @@ import {
 import { motion, AnimatePresence } from "motion/react";
 import { v4 as uuidv4 } from "uuid";
 import { config } from "../lib/config";
+import { useAutosizeTextArea } from "../hooks/useAutosizeTextArea";
 
 interface Message {
   id: string;
@@ -67,7 +68,7 @@ export default function KaiChatWidget({
   const [isLoading, setIsLoading] = useState(false);
   const [copiedCode, setCopiedCode] = useState<string | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
   const sessionIdRef = useRef(uuidv4());
 
   const copyToClipboard = async (text: string) => {
@@ -92,6 +93,8 @@ export default function KaiChatWidget({
       inputRef.current?.focus();
     }
   }, [isOpen, isLoading]);
+
+  useAutosizeTextArea(inputRef.current, input, 128);
 
   const sendMessage = async () => {
     if (!input.trim() || isLoading) return;
@@ -310,6 +313,11 @@ export default function KaiChatWidget({
                     style={!msg.isBot ? { backgroundColor: color } : {}}
                   >
                     <div className="max-w-none break-words">
+                      {!msg.isBot ? (
+                        <p className="m-0 whitespace-pre-wrap break-words text-sm leading-relaxed text-white">
+                          {msg.content}
+                        </p>
+                      ) : (
                       <ReactMarkdown
                         remarkPlugins={[remarkGfm, remarkMath]}
                         rehypePlugins={[rehypeKatex, rehypeRaw]}
@@ -633,6 +641,7 @@ export default function KaiChatWidget({
                       >
                         {msg.content}
                       </ReactMarkdown>
+                      )}
                     </div>
                   </div>
                 </div>
@@ -654,27 +663,28 @@ export default function KaiChatWidget({
 
             {/* Input Alanı */}
             <div className="p-4 bg-white border-t border-gray-100">
-              <div className="flex gap-2 items-center bg-gray-50 rounded-full px-4 py-2 border border-gray-200 focus-within:border-blue-500 focus-within:ring-1 focus-within:ring-blue-500 transition-all">
-                <input
+              <div className="flex gap-2 items-end bg-gray-50 rounded-2xl px-4 py-2 border border-gray-200 focus-within:border-blue-500 focus-within:ring-1 focus-within:ring-blue-500 transition-all">
+                <textarea
                   ref={inputRef}
-                  type="text"
+                  rows={1}
                   value={input}
                   onChange={(e) => setInput(e.target.value)}
                   onKeyDown={(e) => {
-                    if (e.key === "Enter") {
+                    if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
+                      e.preventDefault();
                       sendMessage();
                       // Immediate focus attempt after sending
                       setTimeout(() => inputRef.current?.focus(), 0);
                     }
                   }}
                   placeholder="Write your message..."
-                  className="flex-1 bg-transparent border-none focus:ring-0 outline-none text-sm py-1"
+                  className="flex-1 bg-transparent border-none focus:ring-0 outline-none text-sm py-1 resize-none overflow-y-auto max-h-32 min-h-[24px]"
                   disabled={isLoading}
                 />
                 <button
                   onClick={sendMessage}
                   disabled={isLoading || !input.trim()}
-                  className={`p-2 rounded-full transition-all ${input.trim() && !isLoading
+                  className={`p-2 rounded-full transition-all shrink-0 ${input.trim() && !isLoading
                     ? "text-blue-600 hover:bg-blue-50"
                     : "text-gray-400"
                     }`}

--- a/client/app/components/canvas/ChatComponent.tsx
+++ b/client/app/components/canvas/ChatComponent.tsx
@@ -23,6 +23,7 @@ import { getWorkflowChats } from "~/services/chatService";
 import { v4 as uuidv4 } from "uuid";
 import type { ChatMessage } from "~/types/api";
 import CredentialSelector from "../credentials/CredentialSelector";
+import { useAutosizeTextArea } from "~/hooks/useAutosizeTextArea";
 
 interface ChatComponentProps {
   chatOpen: boolean;
@@ -67,7 +68,7 @@ export default function ChatComponent({
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
   const [isExpanded, setIsExpanded] = useState(false);
-  const inputRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
   const {
     chats,
     setActiveChatflowId,
@@ -481,6 +482,8 @@ export default function ChatComponent({
   const setCurrentInput = mode === "builder" ? setBuilderInput : setChatInput;
   const isLoading = mode === "builder" ? builderLoading : chatLoading;
 
+  useAutosizeTextArea(inputRef.current, currentInput, 160);
+
   if (!chatOpen) return null;
 
   return (
@@ -860,11 +863,11 @@ export default function ChatComponent({
           </div>
 
           {/* ─── Input Area ─── */}
-          <div className="p-3 border-t border-gray-700 flex gap-2">
-            <input
+          <div className="p-3 border-t border-gray-700 flex gap-2 items-end">
+            <textarea
               ref={inputRef}
-              type="text"
-              className={`flex-1 border rounded-lg px-3 py-2 text-sm transition-all duration-200 focus:outline-none ${mode === "builder"
+              rows={1}
+              className={`flex-1 border rounded-lg px-3 py-2 text-sm transition-all duration-200 focus:outline-none resize-none overflow-y-auto max-h-40 min-h-[40px] ${mode === "builder"
                   ? "border-purple-500 bg-gray-800 text-gray-100 placeholder-gray-400 focus:border-purple-400 focus:ring-1 focus:ring-purple-500/20"
                   : "border-gray-600 bg-gray-800 text-gray-100 placeholder-gray-400 focus:border-blue-400 focus:ring-1 focus:ring-blue-500/20"
                 }`}
@@ -878,13 +881,16 @@ export default function ChatComponent({
               value={currentInput}
               onChange={(e) => setCurrentInput(e.target.value)}
               onKeyDown={(e) => {
-                if (e.key === "Enter") handleUnifiedSend();
+                if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
+                  e.preventDefault();
+                  handleUnifiedSend();
+                }
               }}
               disabled={isLoading}
             />
             <button
               onClick={handleUnifiedSend}
-              className={`text-white px-4 py-2 rounded-lg disabled:opacity-50 ${mode === "builder"
+              className={`text-white px-4 py-2 rounded-lg disabled:opacity-50 shrink-0 ${mode === "builder"
                   ? "bg-purple-600 hover:bg-purple-700"
                   : "bg-blue-600 hover:bg-blue-700"
                 }`}

--- a/client/app/components/external/ExternalWorkflowChat.tsx
+++ b/client/app/components/external/ExternalWorkflowChat.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import { Send, MessageCircle, Bot, User, Clock, Loader, Plus, History, RefreshCw, Trash2, ChevronDown } from 'lucide-react';
 import { externalWorkflowService, exportedWorkflowService } from '~/services/externalWorkflowService';
 import type { ExternalWorkflowInfo } from '~/types/external-workflows';
+import { useAutosizeTextArea } from '~/hooks/useAutosizeTextArea';
 
 interface ChatMessage {
   id: string;
@@ -33,8 +34,10 @@ export default function ExternalWorkflowChat({ workflow, isExported = false }: E
   const [loadingSessions, setLoadingSessions] = useState(false);
   const [loadingHistory, setLoadingHistory] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useAutosizeTextArea(inputRef.current, input, 160);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -426,20 +429,26 @@ export default function ExternalWorkflowChat({ workflow, isExported = false }: E
 
       {/* Input Form */}
       <div className="p-4 border-t bg-gray-50">
-        <form onSubmit={handleSendMessage} className="flex gap-2">
-          <input
+        <form onSubmit={handleSendMessage} className="flex gap-2 items-end">
+          <textarea
             ref={inputRef}
-            type="text"
+            rows={1}
             value={input}
             onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
+                e.preventDefault();
+                e.currentTarget.form?.requestSubmit();
+              }
+            }}
             placeholder="Type your message..."
-            className="flex-1 px-4 py-2 border border-gray-300 rounded-full focus:ring-2 focus:ring-green-500 focus:border-transparent"
+            className="flex-1 px-4 py-2 border border-gray-300 rounded-2xl focus:ring-2 focus:ring-green-500 focus:border-transparent resize-none overflow-y-auto max-h-40 min-h-[40px]"
             disabled={isLoading || workflow.connection_status !== 'online'}
           />
           <button
             type="submit"
             disabled={!input.trim() || isLoading || workflow.connection_status !== 'online'}
-            className="px-4 py-2 bg-green-600 text-white rounded-full hover:bg-green-700 transition-colors disabled:bg-gray-400 disabled:cursor-not-allowed flex items-center justify-center"
+            className="px-4 py-2 bg-green-600 text-white rounded-full hover:bg-green-700 transition-colors disabled:bg-gray-400 disabled:cursor-not-allowed flex items-center justify-center shrink-0"
           >
             {isLoading ? (
               <Loader className="w-4 h-4 animate-spin" />

--- a/client/app/hooks/useAutosizeTextArea.ts
+++ b/client/app/hooks/useAutosizeTextArea.ts
@@ -1,0 +1,19 @@
+import { useEffect } from "react";
+
+/**
+ * Custom hook to automatically adjust the height of a textarea element
+ * based on its content scrollHeight up to a specified maximum height.
+ */
+export const useAutosizeTextArea = (
+  textAreaRef: HTMLTextAreaElement | null,
+  value: string,
+  maxHeight: number = 160
+) => {
+  useEffect(() => {
+    if (textAreaRef) {
+      textAreaRef.style.height = "auto";
+      const scrollHeight = textAreaRef.scrollHeight;
+      textAreaRef.style.height = `${Math.min(scrollHeight, maxHeight)}px`;
+    }
+  }, [textAreaRef, value, maxHeight]);
+};


### PR DESCRIPTION
- Add a `useAutosizeTextArea` custom hook to dynamically adjust textarea height based on input content within configurable limits.
- Replace single-line text inputs with auto-expanding textareas in `KaiChatWidget`, `ChatComponent`, and `ExternalWorkflowChat`.
- Support `Shift+Enter` for line breaks while preserving `Enter` for message submission across all chat interfaces.