### PR TITLE
feat: add dynamic LLM model listing and enhance credential connection testing

### DIFF
--- a/backend/app/api/credentials.py
+++ b/backend/app/api/credentials.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import time
 import uuid
 from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, Depends, HTTPException, status, Query
@@ -355,70 +356,343 @@ class CredentialTestRawRequest(BaseModel):
     data: Dict[str, Any]
 
 
-async def _test_openai(secret: Dict[str, Any]) -> CredentialTestResponse:
-    try:
-        from openai import AsyncOpenAI
+class CredentialModelOption(BaseModel):
+    id: str
+    owned_by: Optional[str] = None
 
-        client = AsyncOpenAI(api_key=secret.get("api_key", ""))
-        await asyncio.wait_for(client.models.list(), timeout=10)
-        return CredentialTestResponse(success=True, message="Connected to OpenAI successfully.")
-    except asyncio.TimeoutError:
-        return CredentialTestResponse(success=False, message="Connection timed out.")
-    except Exception as e:
-        msg = str(e)
-        if "invalid" in msg.lower() or "auth" in msg.lower():
-            msg += (
-                " Note: If this key is for an OpenAI-compatible provider "
-                "(OpenRouter, vLLM, etc.), it may still be valid for that provider."
+
+class CredentialModelsResponse(BaseModel):
+    models: List[CredentialModelOption]
+    source: str  # "provider" | "empty"
+    message: Optional[str] = None
+
+
+_MODELS_CACHE: Dict[str, tuple[float, List[CredentialModelOption]]] = {}
+_CACHE_TTL_SECONDS = 60.0
+
+
+async def _list_openai_models(api_key: str) -> List[CredentialModelOption]:
+    """Query official OpenAI /models endpoint."""
+    from openai import AsyncOpenAI
+
+    client = AsyncOpenAI(api_key=api_key)
+    response = await asyncio.wait_for(client.models.list(), timeout=10)
+    raw_items = getattr(response, "data", None) or []
+
+    seen: set[str] = set()
+    models: List[CredentialModelOption] = []
+    for item in raw_items:
+        model_id = str(getattr(item, "id", "") or "").strip()
+        if not model_id or model_id in seen:
+            continue
+        seen.add(model_id)
+        owned_by = getattr(item, "owned_by", None)
+        models.append(CredentialModelOption(id=model_id, owned_by=str(owned_by) if owned_by else None))
+
+    models.sort(key=lambda m: m.id.lower())
+    return models
+
+
+def _is_html_response(content_type: str = "", body: str = "") -> bool:
+    """Check if an HTTP response is an HTML web page rather than API JSON."""
+    ct = (content_type or "").lower()
+    if "text/html" in ct or "application/xhtml" in ct:
+        return True
+    body_strip = (body or "").strip().lower()
+    if body_strip.startswith("<!doctype html") or body_strip.startswith("<html") or "<title>" in body_strip:
+        return True
+    return False
+
+
+def _format_error_text(text: str, status_code: Optional[int] = None) -> str:
+    """Sanitize error text to avoid dumping massive HTML documents or empty messages in the UI."""
+    text_strip = (text or "").strip()
+    if not text_strip:
+        code_str = f" (HTTP {status_code})" if status_code else ""
+        return f"Connection failed{code_str}. Please check your connection details."
+    if _is_html_response(body=text_strip):
+        code_str = f" (HTTP {status_code})" if status_code else ""
+        return f"Server returned an HTML page instead of API response{code_str}. Please check your Base URL."
+    if len(text_strip) > 500:
+        return text_strip[:500] + "..."
+    return text_strip
+
+
+async def _list_openai_compatible_models(
+    base_url: str,
+    api_key: str = "",
+    skip_ssl: bool = False,
+) -> List[CredentialModelOption]:
+    """Query an OpenAI Compatible endpoint's /models API."""
+    url = f"{base_url.rstrip('/')}/models"
+    headers: Dict[str, str] = {
+        "User-Agent": "KAI-Flow/1.0",
+        "Accept": "application/json",
+    }
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    async with httpx.AsyncClient(verify=not skip_ssl, timeout=httpx.Timeout(10.0, connect=4.0)) as http_client:
+        resp = await http_client.get(url, headers=headers)
+        if _is_html_response(resp.headers.get("content-type"), resp.text):
+            raise ValueError(
+                f"Server returned an HTML page (HTTP {resp.status_code}) instead of API response. Please check your Base URL."
             )
-        return CredentialTestResponse(success=False, message=msg)
+        if resp.status_code >= 400:
+            raise ValueError(f"HTTP {resp.status_code}: {_format_error_text(resp.text, resp.status_code)}")
+
+        json_data = resp.json()
+        raw_items = None
+        if isinstance(json_data, dict):
+            raw_items = json_data.get("data") or json_data.get("models") or []
+        elif isinstance(json_data, list):
+            raw_items = json_data
+
+    seen: set[str] = set()
+    models: List[CredentialModelOption] = []
+    for item in (raw_items or []):
+        model_id = (
+            getattr(item, "id", None)
+            or (item.get("id") if isinstance(item, dict) else None)
+            or (item.get("name") if isinstance(item, dict) else None)
+            or (str(item) if isinstance(item, str) else None)
+        )
+        if not model_id or not str(model_id).strip():
+            continue
+        model_id_str = str(model_id).strip()
+        if model_id_str in seen:
+            continue
+
+        seen.add(model_id_str)
+        owned_by = getattr(item, "owned_by", None) or (item.get("owned_by") if isinstance(item, dict) else None)
+        models.append(
+            CredentialModelOption(
+                id=model_id_str,
+                owned_by=str(owned_by) if owned_by else None,
+            )
+        )
+
+    models.sort(key=lambda m: m.id.lower())
+    return models
 
 
-async def _test_openai_compatible(secret: Dict[str, Any]) -> CredentialTestResponse:
-    try:
-        from openai import AsyncOpenAI
-
-        # Use dummy key for local servers that don't need auth, so client doesn't complain about empty key
-        api_key = secret.get("api_key", "")
+async def _list_models_response(
+    service_type: str,
+    secret: Dict[str, Any],
+) -> CredentialModelsResponse:
+    """Query a provider's /models API with caching and error handling."""
+    if service_type == "openai":
+        api_key = str(secret.get("api_key") or "").strip()
         if not api_key:
-            api_key = "dummy_for_local"
+            return CredentialModelsResponse(
+                models=[],
+                source="empty",
+                message="Enter your API key to load available models.",
+            )
 
-        # Check if SSL verification should be skipped
+        cache_key = f"openai::{api_key}"
+        now = time.time()
+        if cache_key in _MODELS_CACHE:
+            cached_time, cached_models = _MODELS_CACHE[cache_key]
+            if now - cached_time < _CACHE_TTL_SECONDS:
+                return CredentialModelsResponse(models=cached_models, source="provider")
+
+        try:
+            models = await _list_openai_models(api_key)
+            if models:
+                _MODELS_CACHE[cache_key] = (now, models)
+                return CredentialModelsResponse(models=models, source="provider")
+            return CredentialModelsResponse(
+                models=[],
+                source="empty",
+                message="Provider returned no models. You can type a model name manually.",
+            )
+        except asyncio.TimeoutError:
+            return CredentialModelsResponse(
+                models=[],
+                source="empty",
+                message="Connection timed out. You can type a model name manually.",
+            )
+        except Exception as e:
+            logger.warning(f"Failed to list OpenAI models: {e}")
+            return CredentialModelsResponse(
+                models=[],
+                source="empty",
+                message=f"Could not fetch models: {_format_error_text(str(e))}",
+            )
+
+    elif service_type == "openai_compatible":
+        base_url = str(secret.get("base_url") or "").strip().rstrip("/")
+        if not base_url:
+            return CredentialModelsResponse(
+                models=[],
+                source="empty",
+                message="Enter a Base URL to load available models.",
+            )
+
+        api_key = str(secret.get("api_key") or "").strip()
         skip_ssl = secret.get("skip_ssl_verify", False)
         if isinstance(skip_ssl, str):
             skip_ssl = skip_ssl.lower() in ("true", "1", "yes", "on")
         skip_ssl = bool(skip_ssl)
 
-        client_kwargs = {
-            "api_key": api_key,
-            "base_url": secret.get("base_url", "")
+        cache_key = f"openai_compatible:{base_url}:{api_key}"
+        now = time.time()
+        if cache_key in _MODELS_CACHE:
+            cached_time, cached_models = _MODELS_CACHE[cache_key]
+            if now - cached_time < _CACHE_TTL_SECONDS:
+                return CredentialModelsResponse(models=cached_models, source="provider")
+
+        try:
+            models = await _list_openai_compatible_models(base_url, api_key=api_key, skip_ssl=skip_ssl)
+            if models:
+                _MODELS_CACHE[cache_key] = (now, models)
+                return CredentialModelsResponse(models=models, source="provider")
+            return CredentialModelsResponse(
+                models=[],
+                source="empty",
+                message="Provider returned no models. You can type a model name manually.",
+            )
+        except asyncio.TimeoutError:
+            return CredentialModelsResponse(
+                models=[],
+                source="empty",
+                message="Connection timed out. You can type a model name manually.",
+            )
+        except Exception as e:
+            logger.warning(f"Failed to list OpenAI Compatible models: {e}")
+            return CredentialModelsResponse(
+                models=[],
+                source="empty",
+                message=f"Could not fetch models: {_format_error_text(str(e))}",
+            )
+
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail=f"Model listing is not supported for service type: {service_type}",
+    )
+
+
+@router.post("/list-models", response_model=CredentialModelsResponse)
+async def list_models_raw(
+    request: CredentialTestRawRequest,
+    current_user: User = Depends(get_current_user),
+):
+    """List models from unsaved credential form data (base URL / API key)."""
+    return await _list_models_response(request.service_type, request.data or {})
+
+
+@router.get("/{credential_id}/models", response_model=CredentialModelsResponse)
+async def list_credential_models(
+    credential_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session),
+    credential_service: CredentialService = Depends(get_credential_service_dep),
+):
+    """
+    List available LLM models for a credential by querying the provider's /models API.
+    """
+    user_id = current_user.id
+    decrypted = await credential_service.get_decrypted_credential(db, user_id, credential_id)
+    if not decrypted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Credential not found")
+
+    return await _list_models_response(
+        decrypted.get("service_type", ""),
+        decrypted.get("secret", {}) or {},
+    )
+
+
+async def _test_openai(secret: Dict[str, Any]) -> CredentialTestResponse:
+    try:
+        api_key = str(secret.get("api_key") or "").strip()
+        if not api_key:
+            return CredentialTestResponse(success=False, message="API key is required.")
+
+        from openai import AsyncOpenAI
+
+        client = AsyncOpenAI(api_key=api_key)
+        await asyncio.wait_for(client.models.list(), timeout=10)
+        return CredentialTestResponse(success=True, message="Connected to OpenAI successfully.")
+    except asyncio.TimeoutError:
+        return CredentialTestResponse(success=False, message="Connection timed out.")
+    except Exception as e:
+        return CredentialTestResponse(success=False, message=str(e) or "Connection failed. Please check your API key.")
+
+
+async def _test_openai_compatible(secret: Dict[str, Any]) -> CredentialTestResponse:
+    try:
+        base_url = str(secret.get("base_url") or "").strip().rstrip("/")
+        if not base_url:
+            return CredentialTestResponse(success=False, message="Base URL is required.")
+
+        api_key = str(secret.get("api_key") or "").strip()
+        model_name = str(secret.get("model_name") or "").strip()
+        skip_ssl = secret.get("skip_ssl_verify", False)
+        if isinstance(skip_ssl, str):
+            skip_ssl = skip_ssl.lower() in ("true", "1", "yes", "on")
+        skip_ssl = bool(skip_ssl)
+
+        headers: Dict[str, str] = {
+            "User-Agent": "KAI-Flow/1.0",
+            "Accept": "application/json",
         }
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
 
-        # Inject custom HTTP client to bypass SSL verification
-        if skip_ssl:
-            logger.info("SSL verification disabled for test connection.")
-            client_kwargs["http_client"] = httpx.AsyncClient(verify=False)
+        async with httpx.AsyncClient(verify=not skip_ssl, timeout=httpx.Timeout(10.0, connect=4.0)) as http_client:
+            # 1. Connectivity check via /models
+            models_url = f"{base_url}/models"
+            try:
+                models_resp = await http_client.get(models_url, headers=headers)
+                if _is_html_response(models_resp.headers.get("content-type"), models_resp.text):
+                    return CredentialTestResponse(
+                        success=False,
+                        message=f"Server returned an HTML page (HTTP {models_resp.status_code}) instead of API response. Please check your Base URL.",
+                    )
+                if models_resp.status_code >= 400:
+                    return CredentialTestResponse(
+                        success=False,
+                        message=_format_error_text(models_resp.text, models_resp.status_code),
+                    )
+            except httpx.RequestError as req_err:
+                return CredentialTestResponse(success=False, message=str(req_err) or "Connection failed. Please check your Base URL.")
 
-        client = AsyncOpenAI(**client_kwargs)
-        
-        # 1. First, test using chat/completions endpoint
-        model_name = secret.get("model_name", "")
-        await asyncio.wait_for(
-            client.chat.completions.create(
-                model=model_name,
-                messages=[{"role": "user", "content": "ping"}],
-                max_tokens=16
-            ),
-            timeout=10
-        )
-        msg = "Connected to OpenAI Compatible provider successfully via chat/completions."
+            # 2. Authentication probe: if API key is provided, test it with a lightweight POST request
+            if api_key:
+                chat_url = f"{base_url}/chat/completions"
+                probe_model = model_name
+                try:
+                    chat_resp = await http_client.post(
+                        chat_url,
+                        headers=headers,
+                        json={
+                            "model": probe_model,
+                            "messages": [{"role": "user", "content": "ping"}],
+                            "max_tokens": 1,
+                        },
+                    )
+                    if _is_html_response(chat_resp.headers.get("content-type"), chat_resp.text):
+                        return CredentialTestResponse(
+                            success=False,
+                            message=f"Server returned an HTML page (HTTP {chat_resp.status_code}) instead of API response. Please check your Base URL.",
+                        )
+                    if chat_resp.status_code >= 400:
+                        return CredentialTestResponse(
+                            success=False,
+                            message=_format_error_text(chat_resp.text, chat_resp.status_code),
+                        )
+                except httpx.RequestError as req_err:
+                    logger.debug(f"Chat probe request error: {req_err}")
+
+        msg = "Connected to OpenAI Compatible provider successfully."
         if skip_ssl:
             msg += " (SSL verification was skipped)"
         return CredentialTestResponse(success=True, message=msg)
     except asyncio.TimeoutError:
         return CredentialTestResponse(success=False, message="Connection timed out.")
     except Exception as e:
-        return CredentialTestResponse(success=False, message=str(e))
+        return CredentialTestResponse(success=False, message=str(e) or "Connection failed. Please check your connection details.")
 
 
 async def _test_cohere(secret: Dict[str, Any]) -> CredentialTestResponse:

--- a/backend/app/nodes/llms/openai_compatible_node.py
+++ b/backend/app/nodes/llms/openai_compatible_node.py
@@ -416,11 +416,6 @@ class OpenAICompatibleNode(BaseNode):
                 cred_verify_ssl = not bool(skip_ssl)
                 logger.debug("OpenAI-compatible API key loaded")
 
-        if credential_id and not api_key_value:
-            raise ValueError(
-                "The selected OpenAI-compatible credential has no API key."
-            )
-
         # Resolve base URL with priority: kwargs -> credential -> self.user_data
         base_url = kwargs.get("base_url") or cred_base_url or self.user_data.get("base_url")
         if not base_url:
@@ -490,16 +485,8 @@ class OpenAICompatibleNode(BaseNode):
         site_name = kwargs.get("site_name") or self.user_data.get("site_name", "KAI-Flow")
         
         if not api_key_value:
-             # Try environment variables as fallback
-             import os
-             api_key_value = os.getenv("OPENAI_API_KEY") or os.getenv("OPENAI_COMPATIBLE_API_KEY")
-             if api_key_value:
-                 logger.info("INFO: Using API Key from environment.")
-             else:
-                 # Some local endpoints might not require a key.
-                 # We provide a dummy key because langchain/openai usually expects one.
-                 api_key_value = "sk-no-key-required"
-                 logger.info("INFO: No API Key provided. Using placeholder key.")
+            import os
+            api_key_value = os.getenv("OPENAI_API_KEY") or os.getenv("OPENAI_COMPATIBLE_API_KEY") or ""
         
         # Prepare Extra Headers
         extra_headers = {}

--- a/backend/app/nodes/llms/openai_node.py
+++ b/backend/app/nodes/llms/openai_node.py
@@ -280,13 +280,6 @@ class OpenAINode(BaseNode):
             "colors": ["purple-500", "indigo-600"],
             "inputs": [
                 NodeInput(
-                    name="model_name",
-                    type="str",
-                    description="OpenAI model to use",
-                    default="gpt-4o",  # Changed default to gpt-4o
-                    required=False,
-                ),
-                NodeInput(
                     name="temperature",
                     type="float",
                     description="Sampling temperature (0.0-2.0) - Controls randomness",
@@ -372,20 +365,7 @@ class OpenAINode(BaseNode):
                     placeholder="Select Credential",
                     required=True,
                     serviceType="openai",
-                ),
-                NodeProperty(
-                    name="model_name",
-                    displayName="Model",
-                    type=NodePropertyType.SELECT,
-                    default="gpt-4o",
-                    options=[
-                        {"label": "GPT-4o", "value": "gpt-4o"},
-                        {"label": "GPT-4o Mini", "value": "gpt-4o-mini"},
-                        {"label": "GPT-4 Turbo", "value": "gpt-4-turbo"},
-                        {"label": "GPT-4", "value": "gpt-4"},
-                        {"label": "GPT-4 32K", "value": "gpt-4-32k"},
-                    ],
-                    required=True
+                    hint="The model is selected when creating the OpenAI credential.",
                 ),
                 NodeProperty(
                     name="temperature",
@@ -508,9 +488,25 @@ class OpenAINode(BaseNode):
     def execute(self, **kwargs) -> Runnable:
         """Execute OpenAI node with enhanced configuration and validation."""
         logger.info("\nOPENAI LLM SETUP")
-        
-        # Get configuration from kwargs or user_data fallback
-        model_name = kwargs.get("model_name") or self.user_data.get("model_name", "gpt-4o")
+
+        credential_id = kwargs.get("credential_id") or self.user_data.get("credential_id")
+        api_key = None
+        cred_model_name = None
+        if credential_id:
+            cred = self.get_credential(credential_id)
+            if cred and cred.get("secret"):
+                secret = cred.get("secret")
+                api_key = secret.get("api_key")
+                cred_model_name = secret.get("model_name")
+
+        # Model is chosen on the OpenAI credential, not on the node.
+        # Node data is only a fallback for older workflows that still store model_name.
+        model_name = (
+            cred_model_name
+            or kwargs.get("model_name")
+            or self.user_data.get("model_name")
+            or "gpt-4o"
+        )
         
         temperature_val = kwargs.get("temperature")
         if temperature_val is None:
@@ -550,14 +546,6 @@ class OpenAINode(BaseNode):
         if timeout_val is None:
             timeout_val = self.user_data.get("timeout", 60)
         timeout = int(timeout_val)
-        
-        # Get API key from user configuration (database/UI)
-        credential_id = kwargs.get("credential_id") or self.user_data.get("credential_id")
-        api_key = None
-        if credential_id:
-            cred = self.get_credential(credential_id)
-            if cred and cred.get('secret'):
-                api_key = cred.get('secret').get('api_key')
 
         if credential_id and not api_key:
             raise ValueError(

--- a/client/app/components/credentials/CredentialCard.tsx
+++ b/client/app/components/credentials/CredentialCard.tsx
@@ -68,10 +68,15 @@ const CredentialCard: React.FC<CredentialCardProps> = ({
     try {
       const result = await onTest(credential.id);
       setTestState(result.success ? "success" : "error");
-      setTestMessage(result.message);
+      setTestMessage(
+        result.message ||
+          (result.success
+            ? "Connection successful."
+            : "Connection failed. Please check your connection details.")
+      );
     } catch {
       setTestState("error");
-      setTestMessage("Unexpected error. Please try again.");
+      setTestMessage("Connection failed. Please check your connection details.");
     }
     setTimeout(() => {
       setTestState("idle");

--- a/client/app/components/credentials/CredentialModelCombobox.tsx
+++ b/client/app/components/credentials/CredentialModelCombobox.tsx
@@ -1,0 +1,337 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useField, useFormikContext } from "formik";
+import { ChevronDown, Loader2 } from "lucide-react";
+import type { ServiceField } from "~/types/credentials";
+import {
+  listModelsRaw,
+  type CredentialModelOption,
+} from "~/services/userCredentialService";
+
+interface CredentialModelComboboxProps {
+  field: ServiceField;
+  serviceType: string;
+  values: Record<string, any>;
+  className?: string;
+}
+
+const META_KEYS = new Set(["id", "name", "service_type", "created_at", "updated_at", "data", "secret"]);
+
+const isUsableUrl = (value: string): boolean => {
+  return value.trim().length > 0;
+};
+
+const CredentialModelCombobox = ({
+  field,
+  serviceType,
+  values: valuesProp,
+  className = "",
+}: CredentialModelComboboxProps) => {
+  const { values: formikValues } = useFormikContext<Record<string, any>>();
+  const values = formikValues || valuesProp;
+  const [formikField, , helpers] = useField(field.name);
+  const [open, setOpen] = useState(false);
+  const [models, setModels] = useState<CredentialModelOption[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const requestIdRef = useRef(0);
+
+  const currentValue = String(formikField.value ?? field.default ?? "");
+  const baseUrl = String(values.base_url || "").trim();
+  const apiKey = String(values.api_key || "").trim();
+
+  const canFetch = useMemo(() => {
+    if (serviceType === "openai") {
+      return apiKey.length > 0;
+    }
+    if (serviceType === "openai_compatible") {
+      return baseUrl.length > 0;
+    }
+    return false;
+  }, [serviceType, apiKey, baseUrl]);
+
+  const idleMessage = useMemo(() => {
+    if (serviceType === "openai") {
+      return "Enter your API key to load available models.";
+    }
+    if (serviceType === "openai_compatible") {
+      return "Enter a Base URL to load available models.";
+    }
+    return "No models available.";
+  }, [serviceType]);
+
+  const fetchKey = useMemo(
+    () =>
+      JSON.stringify({
+        serviceType,
+        base_url: baseUrl,
+        api_key: apiKey,
+        skip_ssl_verify: values.skip_ssl_verify || false,
+        canFetch,
+      }),
+    [serviceType, baseUrl, apiKey, values.skip_ssl_verify, canFetch]
+  );
+
+  const fetchModels = useCallback(async () => {
+    const requestId = ++requestIdRef.current;
+    if (!canFetch) {
+      setModels([]);
+      setStatusMessage(idleMessage);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setStatusMessage(null);
+
+    const payload = Object.fromEntries(
+      Object.entries(values).filter(([key]) => !META_KEYS.has(key) && key !== field.name)
+    );
+
+    try {
+      const result = await listModelsRaw(serviceType, payload);
+      if (requestId !== requestIdRef.current) return;
+      setModels(result.models || []);
+      setStatusMessage(result.message || null);
+    } catch (error: any) {
+      if (requestId !== requestIdRef.current) return;
+      setModels([]);
+      setStatusMessage(error?.message || "Could not load models. You can type a model name.");
+    } finally {
+      if (requestId === requestIdRef.current) {
+        setLoading(false);
+      }
+    }
+  }, [canFetch, field.name, idleMessage, serviceType, values]);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      void fetchModels();
+    }, 300);
+    return () => window.clearTimeout(timeout);
+    // fetchKey captures the fields that should trigger a refetch
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetchKey]);
+
+  const mergedOptions = useMemo(() => {
+    const seen = new Set<string>();
+    const options: Array<{ label: string; value: string; hint?: string }> = [];
+    for (const model of models) {
+      if (seen.has(model.id)) continue;
+      seen.add(model.id);
+      options.push({
+        label: model.id,
+        value: model.id,
+        hint: model.owned_by ? `owned by ${model.owned_by}` : undefined,
+      });
+    }
+    return options;
+  }, [models]);
+
+  const filteredOptions = useMemo(() => {
+    const query = currentValue.trim().toLowerCase();
+    if (!query) return mergedOptions;
+    const exactMatch = mergedOptions.some(
+      (option) => option.value.toLowerCase() === query || option.label.toLowerCase() === query
+    );
+    if (exactMatch) return mergedOptions;
+    return mergedOptions.filter(
+      (option) =>
+        option.label.toLowerCase().includes(query) || option.value.toLowerCase().includes(query)
+    );
+  }, [currentValue, mergedOptions]);
+
+  useEffect(() => {
+    if (!open) return;
+    const selectedIndex = filteredOptions.findIndex(
+      (option) => option.value === currentValue
+    );
+    setHighlightedIndex(selectedIndex >= 0 ? selectedIndex : 0);
+    // Only snap to the current value when the list is opened.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    setHighlightedIndex(0);
+    // Typing filters the list; keep the highlight on the first match.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentValue]);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  useEffect(() => {
+    const el = optionRefs.current[highlightedIndex];
+    if (open && el) {
+      el.scrollIntoView({ block: "nearest" });
+    }
+  }, [highlightedIndex, open]);
+
+  const selectOption = (value: string) => {
+    helpers.setValue(value);
+    setOpen(false);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      if (!open) {
+        setOpen(true);
+        return;
+      }
+      setHighlightedIndex((index) =>
+        filteredOptions.length === 0 ? 0 : (index + 1) % filteredOptions.length
+      );
+      return;
+    }
+
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      if (!open) {
+        setOpen(true);
+        return;
+      }
+      setHighlightedIndex((index) =>
+        filteredOptions.length === 0
+          ? 0
+          : (index - 1 + filteredOptions.length) % filteredOptions.length
+      );
+      return;
+    }
+
+    if (event.key === "Enter") {
+      if (open) {
+        event.preventDefault();
+        if (filteredOptions[highlightedIndex]) {
+          selectOption(filteredOptions[highlightedIndex].value);
+        }
+      }
+      return;
+    }
+
+    if (event.key === "Escape") {
+      event.preventDefault();
+      setOpen(false);
+    }
+  };
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <div className="relative">
+        <input
+          type="text"
+          name={field.name}
+          value={currentValue}
+          placeholder={field.placeholder}
+          autoComplete="off"
+          onChange={(event) => {
+            helpers.setValue(event.target.value);
+            setOpen(true);
+          }}
+          onFocus={() => {
+            setOpen(true);
+            if (canFetch && models.length === 0 && !loading) {
+              void fetchModels();
+            }
+          }}
+          onKeyDown={handleKeyDown}
+          className={`${className} !pr-10`}
+          role="combobox"
+          aria-expanded={open}
+          aria-controls={`${field.name}-model-list`}
+          aria-activedescendant={
+            open && filteredOptions[highlightedIndex]
+              ? `${field.name}-option-${highlightedIndex}`
+              : undefined
+          }
+        />
+        <button
+          type="button"
+          tabIndex={-1}
+          onClick={() => {
+            if (!open && canFetch && models.length === 0 && !loading) {
+              void fetchModels();
+            }
+            setOpen((prev) => !prev);
+          }}
+          className="absolute inset-y-0 right-0 z-10 flex w-11 items-center justify-center text-gray-500 hover:text-gray-700"
+          aria-label="Toggle model list"
+        >
+          {loading ? (
+            <Loader2 className="w-4 h-4 animate-spin" />
+          ) : (
+            <ChevronDown className={`w-4 h-4 transition-transform ${open ? "rotate-180" : ""}`} />
+          )}
+        </button>
+      </div>
+
+      {open && (
+        <div
+          id={`${field.name}-model-list`}
+          role="listbox"
+          className="absolute z-50 mt-1 left-0 right-0 max-h-60 overflow-y-auto bg-white border border-gray-200 rounded-lg shadow-lg"
+        >
+          {loading && filteredOptions.length === 0 && (
+            <div className="px-4 py-3 text-sm text-gray-500 flex items-center gap-2">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              Loading models...
+            </div>
+          )}
+
+          {!loading && filteredOptions.length === 0 && (
+            <div className="px-4 py-3 text-sm text-gray-500">
+              {currentValue.trim()
+                ? "No matches. Keep typing to use a custom model name."
+                : statusMessage || idleMessage}
+            </div>
+          )}
+
+          {filteredOptions.map((option, index) => {
+            const selected = currentValue === option.value;
+            const highlighted = index === highlightedIndex;
+            return (
+              <button
+                key={option.value}
+                id={`${field.name}-option-${index}`}
+                ref={(el) => {
+                  optionRefs.current[index] = el;
+                }}
+                type="button"
+                role="option"
+                aria-selected={selected}
+                onMouseEnter={() => setHighlightedIndex(index)}
+                onClick={() => selectOption(option.value)}
+                className={`w-full flex flex-col items-start gap-0.5 px-4 py-2.5 text-sm text-left ${
+                  highlighted
+                    ? "bg-blue-50 text-blue-700"
+                    : selected
+                      ? "bg-blue-50/60 text-blue-700"
+                      : "text-gray-700 hover:bg-blue-50 hover:text-blue-700"
+                }`}
+              >
+                <span>{option.label}</span>
+                {option.hint && <span className="text-xs text-gray-400">{option.hint}</span>}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {statusMessage && (
+        <p className="text-xs text-gray-500 mt-1">{statusMessage}</p>
+      )}
+    </div>
+  );
+};
+
+export default CredentialModelCombobox;

--- a/client/app/components/credentials/DynamicCredentialForm.tsx
+++ b/client/app/components/credentials/DynamicCredentialForm.tsx
@@ -4,6 +4,7 @@ import { Check, Loader2, X as XIcon, Zap } from "lucide-react";
 import { resolveIconPath } from "~/lib/iconUtils";
 import type { ServiceDefinition, ServiceField } from "~/types/credentials";
 import CredentialPasswordField from "./CredentialPasswordField";
+import CredentialModelCombobox from "./CredentialModelCombobox";
 
 interface DynamicCredentialFormProps {
   service: ServiceDefinition;
@@ -108,7 +109,7 @@ const DynamicCredentialForm: React.FC<DynamicCredentialFormProps> = ({
     return values;
   }, [initialValues, service]);
 
-  const renderField = (field: ServiceField) => {
+  const renderField = (field: ServiceField, values: Record<string, any>) => {
     const commonProps = {
       name: field.name,
       placeholder: field.placeholder,
@@ -117,6 +118,16 @@ const DynamicCredentialForm: React.FC<DynamicCredentialFormProps> = ({
     };
 
     switch (field.type) {
+      case "model-combobox":
+        return (
+          <CredentialModelCombobox
+            field={field}
+            serviceType={service.id}
+            values={values}
+            className={commonProps.className}
+          />
+        );
+
       case "textarea":
         return (
           <Field
@@ -242,7 +253,7 @@ const DynamicCredentialForm: React.FC<DynamicCredentialFormProps> = ({
                     </label>
                   )}
 
-                  {renderField(field)}
+                  {renderField(field, values)}
 
                   {field.description && (
                     <p className="text-xs text-gray-500 mt-1">
@@ -285,10 +296,15 @@ const DynamicCredentialForm: React.FC<DynamicCredentialFormProps> = ({
                     try {
                       const result = await onTest(values);
                       setTestState(result.success ? "success" : "error");
-                      setTestMessage(result.message);
+                      setTestMessage(
+                        result.message ||
+                          (result.success
+                            ? "Connection successful."
+                            : "Connection failed. Please check your connection details.")
+                      );
                     } catch (error: any) {
                       setTestState("error");
-                      setTestMessage(error?.message || "Unexpected error. Please try again.");
+                      setTestMessage(error?.message || "Connection failed. Please check your connection details.");
                     }
                     setTimeout(() => {
                       setTestState("idle");

--- a/client/app/components/node/GenericNodeForm.tsx
+++ b/client/app/components/node/GenericNodeForm.tsx
@@ -8,6 +8,7 @@ import {
   NodeNumber,
   NodePassword,
   NodeSelect,
+  NodeModelSelect,
   NodeCheckbox,
   NodeTitle,
   NodeRange,
@@ -89,9 +90,14 @@ export default function GenericNodeForm({
   onSave,
   onChange,
 }: GenericNodeFormProps) {
-  const properties = configData?.metadata?.properties || [];
+  const rawProperties = configData?.metadata?.properties || [];
   const nodeType =
     configData?.metadata?.name || configData?.name || configData?.type;
+  // OpenAI GPT and OpenAI Compatible take the model from the credential; ignore stale saved metadata.
+  const properties =
+    nodeType === "OpenAIChat" || nodeType === "openai_gpt" || nodeType === "OpenAICompatible" || nodeType === "openai_compatible"
+      ? rawProperties.filter((property: NodeProperty) => property.name !== "model_name")
+      : rawProperties;
   const columnMapperSessionsRef = useRef<Record<string, any>>({});
 
   const tabs = properties.reduce((acc: any[], property: NodeProperty) => {
@@ -281,7 +287,8 @@ export default function GenericNodeForm({
                     );
                   case "select":
                     return <NodeSelect property={fullWidthProperty} values={values} />;
-
+                  case "model-select":
+                    return <NodeModelSelect property={fullWidthProperty} values={values} />;
                   case "dynamic-select":
                     return (
                       <NodeDynamicSelect

--- a/client/app/components/node/fields/NodeModelSelect.tsx
+++ b/client/app/components/node/fields/NodeModelSelect.tsx
@@ -1,0 +1,342 @@
+import { useField } from "formik";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { ChevronDown, Loader2, RefreshCw } from "lucide-react";
+import type { NodeProperty } from "../types";
+import { FieldLabel, getFieldHelpText } from "./FieldLabel";
+import {
+  getCredentialModels,
+  getUserCredentialById,
+  type CredentialModelOption,
+} from "~/services/userCredentialService";
+
+interface NodeModelSelectProps {
+  property: NodeProperty;
+  values: any;
+}
+
+export const NodeModelSelect = ({ property, values }: NodeModelSelectProps) => {
+  const [field, , helpers] = useField(property.name);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const [models, setModels] = useState<CredentialModelOption[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [allowManual, setAllowManual] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const lastPrefillCredentialRef = useRef<string | null>(null);
+
+  const credentialId = values?.credential_id as string | undefined;
+  const currentValue = field.value ?? property?.default ?? "";
+
+  const displayOptions = property?.displayOptions || {};
+  const show = displayOptions.show || {};
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setDropdownOpen(false);
+        setSearch("");
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  useEffect(() => {
+    if (dropdownOpen && searchInputRef.current) {
+      searchInputRef.current.focus();
+    }
+  }, [dropdownOpen]);
+
+  const loadModels = async (credId: string) => {
+    setLoading(true);
+    setStatusMessage(null);
+    try {
+      const result = await getCredentialModels(credId);
+      setModels(result.models || []);
+      setAllowManual(true);
+      setStatusMessage(result.message || null);
+    } catch (error: any) {
+      setModels([]);
+      setAllowManual(true);
+      setStatusMessage(
+        error?.message || "Could not load models. You can type a model name manually."
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!credentialId) {
+      setModels([]);
+      setAllowManual(false);
+      setStatusMessage("Select a credential to load available models.");
+      lastPrefillCredentialRef.current = null;
+      return;
+    }
+
+    void loadModels(credentialId);
+
+    // Prefill from credential secret once per credential if field is empty
+    if (lastPrefillCredentialRef.current === credentialId) return;
+    lastPrefillCredentialRef.current = credentialId;
+
+    if (field.value) return;
+
+    void (async () => {
+      try {
+        const cred = await getUserCredentialById(credentialId);
+        const secretModel = (cred as any)?.secret?.model_name;
+        if (secretModel && !field.value) {
+          helpers.setValue(secretModel);
+        }
+      } catch {
+        // ignore prefill errors
+      }
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [credentialId]);
+
+  const mergedOptions = useMemo(() => {
+    const seen = new Set<string>();
+    const options: Array<{ label: string; value: string; hint?: string }> = [];
+    for (const model of models) {
+      if (seen.has(model.id)) continue;
+      seen.add(model.id);
+      options.push({
+        label: model.id,
+        value: model.id,
+        hint: model.owned_by ? `owned by ${model.owned_by}` : undefined,
+      });
+    }
+    return options;
+  }, [models]);
+
+  const filteredOptions = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return mergedOptions;
+    return mergedOptions.filter(
+      (opt: { label: string; value: string }) =>
+        opt.label.toLowerCase().includes(q) || opt.value.toLowerCase().includes(q)
+    );
+  }, [mergedOptions, search]);
+
+  useEffect(() => {
+    if (!dropdownOpen) return;
+    const selectedIndex = filteredOptions.findIndex(
+      (option: { value: string }) => option.value === currentValue
+    );
+    setHighlightedIndex(selectedIndex >= 0 ? selectedIndex : 0);
+    // Snap to the selected model only when the dropdown opens.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dropdownOpen]);
+
+  useEffect(() => {
+    if (!dropdownOpen) return;
+    setHighlightedIndex(0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [search]);
+
+  useEffect(() => {
+    const el = optionRefs.current[highlightedIndex];
+    if (dropdownOpen && el) {
+      el.scrollIntoView({ block: "nearest" });
+    }
+  }, [highlightedIndex, dropdownOpen]);
+
+  if (Object.keys(show).length > 0) {
+    for (const [dependencyName, validValue] of Object.entries(show)) {
+      const dependencyValue = values[dependencyName];
+      if (dependencyValue !== validValue) {
+        return null;
+      }
+    }
+  }
+
+  const selectedOption = mergedOptions.find(
+    (option: { value: string }) => option.value === currentValue
+  );
+  const displayText = currentValue
+    ? selectedOption?.label || currentValue
+    : property.placeholder || "Select model...";
+
+  const disabled = !credentialId;
+
+  const handleSelect = (value: string) => {
+    helpers.setValue(value);
+    setDropdownOpen(false);
+    setSearch("");
+  };
+
+  const handleManualCommit = () => {
+    const next = search.trim();
+    if (!next) return;
+    helpers.setValue(next);
+    setDropdownOpen(false);
+    setSearch("");
+  };
+
+  const handleSearchKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      if (filteredOptions.length === 0) return;
+      setHighlightedIndex((index) => (index + 1) % filteredOptions.length);
+      return;
+    }
+
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      if (filteredOptions.length === 0) return;
+      setHighlightedIndex((index) =>
+        (index - 1 + filteredOptions.length) % filteredOptions.length
+      );
+      return;
+    }
+
+    if (event.key === "Enter") {
+      event.preventDefault();
+      if (filteredOptions[highlightedIndex]) {
+        handleSelect(filteredOptions[highlightedIndex].value);
+        return;
+      }
+      if (allowManual || filteredOptions.length === 0) {
+        handleManualCommit();
+      }
+      return;
+    }
+
+    if (event.key === "Escape") {
+      event.preventDefault();
+      setDropdownOpen(false);
+      setSearch("");
+    }
+  };
+
+  return (
+    <div className={`${property?.colSpan ? `col-span-${property?.colSpan}` : "col-span-2"}`} key={property.name}>
+      <div className="flex items-center justify-between gap-2">
+        <FieldLabel label={property.displayName} helpText={getFieldHelpText(property)} />
+        {credentialId && (
+          <button
+            type="button"
+            onClick={() => loadModels(credentialId)}
+            disabled={loading}
+            className="inline-flex items-center gap-1 text-xs text-slate-400 hover:text-slate-200 disabled:opacity-50"
+            title="Refresh models"
+          >
+            {loading ? <Loader2 size={12} className="animate-spin" /> : <RefreshCw size={12} />}
+            Refresh
+          </button>
+        )}
+      </div>
+
+      <div className="relative" ref={dropdownRef}>
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={() => !disabled && setDropdownOpen(!dropdownOpen)}
+          onMouseDown={(e: any) => e.stopPropagation()}
+          onTouchStart={(e: any) => e.stopPropagation()}
+          className={`w-full flex items-center justify-between bg-[#10182c] border border-slate-600 rounded-lg px-4 py-3 text-left transition-all duration-200 ${
+            disabled
+              ? "opacity-60 cursor-not-allowed"
+              : `cursor-pointer hover:border-slate-500 ${dropdownOpen ? "border-blue-500" : ""}`
+          }`}
+        >
+          <span className={`text-sm truncate ${currentValue ? "text-white" : "text-slate-400"}`}>
+            {loading && !currentValue ? "Loading models..." : displayText}
+          </span>
+          {loading ? (
+            <Loader2 size={16} className="text-slate-400 animate-spin shrink-0" />
+          ) : (
+            <ChevronDown
+              size={16}
+              className={`text-slate-400 transition-transform duration-200 shrink-0 ${dropdownOpen ? "rotate-180" : ""}`}
+            />
+          )}
+        </button>
+
+        {dropdownOpen && !disabled && (
+          <div className="absolute z-50 mt-1 left-0 right-0 bg-slate-900 border border-slate-700 rounded-lg shadow-lg shadow-black/40 overflow-hidden">
+            <div className="p-2 border-b border-slate-700">
+              <input
+                ref={searchInputRef}
+                type="text"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                onKeyDown={handleSearchKeyDown}
+                placeholder={
+                  allowManual || mergedOptions.length === 0
+                    ? "Search or type a model name..."
+                    : "Search models..."
+                }
+                className="w-full bg-slate-800 border border-slate-600 rounded-md px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:outline-none focus:border-blue-500"
+                onMouseDown={(e) => e.stopPropagation()}
+              />
+            </div>
+
+            <div className="max-h-56 overflow-y-auto">
+              {loading && (
+                <div className="px-4 py-3 text-sm text-slate-400 flex items-center gap-2">
+                  <Loader2 size={14} className="animate-spin" />
+                  Loading models...
+                </div>
+              )}
+
+              {!loading && filteredOptions.length === 0 && (
+                <div className="px-4 py-3 text-sm text-slate-400">
+                  {allowManual || search.trim()
+                    ? "No matches. Press Enter to use the typed model name."
+                    : "No models available."}
+                </div>
+              )}
+
+              {!loading &&
+                filteredOptions.map((option: { label: string; value: string; hint?: string }, index: number) => {
+                  const selected = currentValue === option.value;
+                  const highlighted = index === highlightedIndex;
+                  return (
+                    <button
+                      key={option.value}
+                      type="button"
+                      ref={(el) => {
+                        optionRefs.current[index] = el;
+                      }}
+                      onMouseEnter={() => setHighlightedIndex(index)}
+                      onClick={() => handleSelect(option.value)}
+                      className={`w-full flex flex-col items-start gap-0.5 px-4 py-2.5 text-sm text-left transition-colors duration-150 ${
+                        highlighted || selected
+                          ? "bg-blue-500/20 text-blue-300"
+                          : "text-slate-300 hover:bg-blue-500/20 hover:text-blue-300"
+                      }`}
+                    >
+                      <span>{option.label}</span>
+                      {option.hint && <span className="text-xs text-slate-500">{option.hint}</span>}
+                    </button>
+                  );
+                })}
+            </div>
+
+            {(allowManual || mergedOptions.length === 0) && search.trim() && (
+              <div className="border-t border-slate-700 p-2">
+                <button
+                  type="button"
+                  onClick={handleManualCommit}
+                  className="w-full text-left px-3 py-2 text-sm text-blue-300 hover:bg-blue-500/20 rounded-md"
+                >
+                  Use &quot;{search.trim()}&quot;
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {statusMessage && <p className="text-slate-400 text-xs mt-1">{statusMessage}</p>}
+    </div>
+  );
+};

--- a/client/app/components/node/fields/index.tsx
+++ b/client/app/components/node/fields/index.tsx
@@ -1,5 +1,6 @@
 export { NodeTextArea } from "./NodeTextArea";
 export { NodeSelect } from "./NodeSelect";
+export { NodeModelSelect } from "./NodeModelSelect";
 export { NodeCredentialSelect } from "./NodeCredentialSelect";
 export { NodeText } from "./NodeText";
 export { NodeReadonlyText } from "./NodeReadonlyText";

--- a/client/app/data/templates/basic-agent.json
+++ b/client/app/data/templates/basic-agent.json
@@ -51,7 +51,6 @@
         "data": {
           "name": "openai_gpt",
           "max_tokens": 1000,
-          "model_name": "gpt-4o",
           "temperature": 0.7,
           "credential_id": "",
           "tavily_api_key": "",

--- a/client/app/lib/config.ts
+++ b/client/app/lib/config.ts
@@ -80,6 +80,8 @@ export const API_ENDPOINTS = {
     TEST: (id: string) => `/credentials/${id}/test`,
     TEST_RAW: '/credentials/test-raw',
     WORKFLOWS: (id: string) => `/credentials/${id}/workflows`,
+    MODELS: (id: string) => `/credentials/${id}/models`,
+    LIST_MODELS: '/credentials/list-models',
   },
   API_KEYS: {
     LIST: '/api-keys',

--- a/client/app/services/userCredentialService.ts
+++ b/client/app/services/userCredentialService.ts
@@ -49,3 +49,32 @@ export const getCredentialWorkflows = async (
     API_ENDPOINTS.CREDENTIALS.WORKFLOWS(id)
   );
 };
+
+export interface CredentialModelOption {
+  id: string;
+  owned_by?: string | null;
+}
+
+export interface CredentialModelsResponse {
+  models: CredentialModelOption[];
+  source: 'provider' | 'empty' | string;
+  message?: string | null;
+}
+
+export const getCredentialModels = async (
+  id: string
+): Promise<CredentialModelsResponse> => {
+  return await apiClient.get<CredentialModelsResponse>(
+    API_ENDPOINTS.CREDENTIALS.MODELS(id)
+  );
+};
+
+export const listModelsRaw = async (
+  serviceType: string,
+  data: Record<string, any>
+): Promise<CredentialModelsResponse> => {
+  return await apiClient.post<CredentialModelsResponse>(
+    API_ENDPOINTS.CREDENTIALS.LIST_MODELS,
+    { service_type: serviceType, data }
+  );
+};

--- a/client/app/types/credentials.ts
+++ b/client/app/types/credentials.ts
@@ -1,7 +1,7 @@
 export interface ServiceField {
   name: string;
   label: string;
-  type: 'text' | 'password' | 'textarea' | 'select' | 'checkbox';
+  type: 'text' | 'password' | 'textarea' | 'select' | 'checkbox' | 'model-combobox';
   helpText?: string;
   required: boolean;
   placeholder?: string;
@@ -55,6 +55,14 @@ export const SERVICE_DEFINITIONS: ServiceDefinition[] = [
             return undefined;
           }
         }
+      },
+      {
+        name: 'model_name',
+        label: 'Model',
+        type: 'model-combobox',
+        required: true,
+        placeholder: 'Select or type a model',
+        description: 'Models are loaded from OpenAI after you enter your API key. Use the arrow keys to move through the list.'
       }
     ]
   },
@@ -71,24 +79,24 @@ export const SERVICE_DEFINITIONS: ServiceDefinition[] = [
         label: 'Base URL',
         type: 'text',
         required: true,
-        placeholder: 'https://openrouter.ai/api/v1',
+        placeholder: 'e.g. https://openrouter.ai/api/v1',
         description: 'The endpoint URL for the compatible service'
-      },
-      {
-        name: 'model_name',
-        label: 'Model Name',
-        type: 'text',
-        required: true,
-        placeholder: 'google/gemma-3n-e4b-it',
-        description: 'The model name/identifier (e.g. llama3-70b-8192)'
       },
       {
         name: 'api_key',
         label: 'API Key',
         type: 'password',
+        required: false,
+        placeholder: 'Optional for local endpoints (Ollama, LM Studio, etc.)',
+        description: 'The authentication key for the compatible service (leave empty if not required)'
+      },
+      {
+        name: 'model_name',
+        label: 'Model',
+        type: 'model-combobox',
         required: true,
-        placeholder: '...',
-        description: 'The authentication key for the compatible service'
+        placeholder: 'Select or type a model',
+        description: 'Models are loaded from your provider when Base URL is set. Use the arrow keys to move through the list.'
       },
       {
         name: 'skip_ssl_verify',


### PR DESCRIPTION
- Decouple OpenAI and OpenAI Compatible model listing and connection testing into dedicated handlers.
- Add dynamic model fetching from provider /models endpoints with combobox selection and manual override support.
- Enhance connection testing for OpenAI Compatible providers with genuine auth probe via chat completions.
- Implement HTML response detection and comprehensive HTTP error handling (>= 400) without artificial masking.
- Add guaranteed fallback error messages for connection test failures across frontend and backend.
- Remove redundant dummy credentials and artificial URL formatting rules.